### PR TITLE
Enable loading (rather than generating) data at startup

### DIFF
--- a/main.js
+++ b/main.js
@@ -101,9 +101,11 @@ oceanLayers.append("rect").attr("id", "oceanBase").attr("x", graphWidth * -.2).a
 equatorOutput.min = equatorInput.min = graphHeight * -1;
 equatorOutput.max = equatorInput.max = graphHeight * 2;
 
+const queryStringParams = new URLSearchParams(window.location.search)
+
 applyDefaultNamesData(); // apply default namesbase on load
 applyDefaultStyle(); // apply style on load
-generate(); // generate map on load
+if (!queryStringParams.has('doNotGenerate')) generate(); // generate map on load
 focusOn(); // based on searchParams focus on point, cell or burg from MFCG
 addDragToUpload(); // allow map loading by drag and drop
 
@@ -115,7 +117,7 @@ function showWelcomeMessage() {
     const link = 'https://www.reddit.com/r/FantasyMapGenerator/comments/bfskpi/update_stable_version_is_released_v_08b/?utm_source=share&utm_medium=web2x'; // announcement on Reddit
     alertMessage.innerHTML = `The Fantasy Map Generator is updated up to version <b>${version}</b>.
 
-      This version is <b>not compatible</b> with older <i>.map</i> files. 
+      This version is <b>not compatible</b> with older <i>.map</i> files.
       Please use an <a href='https://github.com/Azgaar/Fantasy-Map-Generator/wiki/Changelog' target='_blank'>archived version</a> to open the file.
 
       <ul><a href=${link} target='_blank'>Main changes:</a>
@@ -132,8 +134,8 @@ function showWelcomeMessage() {
         <li>Reworked <a href='https://github.com/Azgaar/Fantasy-Map-Generator/wiki/Hotkeys' target='_blank'>hotkeys</a></li>
       </ul>
 
-      <p>Join our <a href='https://www.reddit.com/r/FantasyMapGenerator' target='_blank'>Reddit community</a> and 
-      <a href='https://discordapp.com/invite/X7E84HU' target='_blank'>Discord server</a> 
+      <p>Join our <a href='https://www.reddit.com/r/FantasyMapGenerator' target='_blank'>Reddit community</a> and
+      <a href='https://discordapp.com/invite/X7E84HU' target='_blank'>Discord server</a>
       to share created maps, discuss the Generator, report bugs, ask questions and propose new features.</p>
 
       <p>Thanks for all supporters on <a href='https://www.patreon.com/azgaar' target='_blank'>Patreon</a>!</i></p>`;
@@ -221,7 +223,7 @@ function applyDefaultNamesData() {
     ["Abim","Adjumani","Alebtong","Amolatar","Amuria","Amuru","Apac","Arua","Arusha","Babati","Baragoi","Bombo","Budaka","Bugembe","Bugiri","Buikwe","Bukedea","Bukoba","Bukomansimbi","Bukungu","Buliisa","Bundibugyo","Bungoma","Busembatya","Bushenyi","Busia","Busia","Busolwe","Butaleja","Butambala","Butere","Buwenge","Buyende","Dadaab","Dodoma","Dokolo","Eldoret","Elegu","Emali","Embu","Entebbe","Garissa","Gede","Gulu","Handeni","Hima","Hoima","Hola","Ibanda","Iganga","Iringa","Isingiro","Isiolo","Jinja","Kaabong","Kabale","Kaberamaido","Kabuyanda","Kabwohe","Kagadi","Kahama","Kajiado","Kakamega","Kakinga","Kakira","Kakiri","Kakuma","Kalangala","Kaliro","Kalisizo","Kalongo","Kalungu","Kampala","Kamuli","Kamwenge","Kanoni","Kanungu","Kapchorwa","Kapenguria","Kasese","Kasulu","Katakwi","Kayunga","Kericho","Keroka","Kiambu","Kibaale","Kibaha","Kibingo","Kiboga","Kibwezi","Kigoma","Kihiihi","Kilifi","Kira","Kiruhura","Kiryandongo","Kisii","Kisoro","Kisumu","Kitale","Kitgum","Kitui","Koboko","Korogwe","Kotido","Kumi","Kyazanga","Kyegegwa","Kyenjojo","Kyotera","Lamu","Langata","Lindi","Lodwar","Lokichoggio","Londiani","Loyangalani","Lugazi","Lukaya","Luweero","Lwakhakha","Lwengo","Lyantonde","Machakos","Mafinga","Makambako","Makindu","Malaba","Malindi","Manafwa","Mandera","Maralal","Marsabit","Masaka","Masindi","MasindiPort","Masulita","Matugga","Mayuge","Mbale","Mbarara","Mbeya","Meru","Mitooma","Mityana","Mombasa","Morogoro","Moroto","Moshi","Moyale","Moyo","Mpanda","Mpigi","Mpondwe","Mtwara","Mubende","Mukono","Mumias","Muranga","Musoma","Mutomo","Mutukula","Mwanza","Nagongera","Nairobi","Naivasha","Nakapiripirit","Nakaseke","Nakasongola","Nakuru","Namanga","Namayingo","Namutumba","Nansana","Nanyuki","Narok","Naromoru","Nebbi","Ngora","Njeru","Njombe","Nkokonjeru","Ntungamo","Nyahururu","Nyeri","Oyam","Pader","Paidha","Pakwach","Pallisa","Rakai","Ruiru","Rukungiri","Rwimi","Sanga","Sembabule","Shimoni","Shinyanga","Singida","Sironko","Songea","Soroti","Ssabagabo","Sumbawanga","Tabora","Takaungu","Tanga","Thika","Tororo","Tunduma","Vihiga","Voi","Wajir","Wakiso","Watamu","Webuye","Wobulenzi","Wote","Wundanyi","Yumbe","Zanzibar"],
     ["An Khe","An Nhon","Ayun Pa","Ba Don","Ba Ria","Bac Giang","Bac Kan","Bac Lieu","Bac Ninh","Bao Loc","Ben Cat","Ben Tre","Bien Hoa","Bim Son","Binh Long","Binh Minh","Buon Ho","Buon Ma Thuot","Ca Mau","Cai Lay","Cam Pha","Cam Ranh","Can Tho","Cao Bang","Cao Lanh","Chau Doc","Chi Linh","Cua Lo","Da Lat","Da Nang","Di An","Dien Ban","Dien Bien Phu","Dong Ha","Dong Hoi","Dong Trieu","Duyen Hai","Gia Nghia","Gia Rai","Go Cong","Ha Giang","Ha Long","Ha Noi","Ha Tinh","Hai Duong","Hai Phong","Hoa Binh","Hoang Mai","Hoi An","Hong Linh","Hong Ngu","Hue","Hung Yen","Huong Thuy","Huong Tra","Kien Tuong","Kon Tum","Ky Anh","La Gi","Lai Chau","Lang Son","Lao Cai","Long Khanh","Long My","Long Xuyen","Mong Cai","Muong Lay","My Hao","My Tho","Nam Dinh","Nga Bay","Nga Nam","Nghia Lo","Nha Trang","Ninh Binh","Ninh Hoa","Phan Rang Thap Cham","Phan Thiet","Pho Yen","Phu Ly","Phu My","Phu Tho","Phuoc Long","Pleiku","Quang Ngai","Quang Tri","Quang Yen","Quy Nhon","Rach Gia","Sa Dec","Sam Son","Soc Trang","Son La","Son Tay","Song Cau","Song Cong","Tam Diep","Tam Ky","Tan An","Tan Chau","Tan Uyen","Tay Ninh","Thai Binh","Thai Hoa","Thai Nguyen","Thanh Hoa","Thu Dau Mot","Thuan An","Tra Vinh","Tu Son","Tuy Hoa","Tuyen Quang","Uong Bi","Vi Thanh","Viet Tri","Vinh","Vinh Chau","Vinh Long","Vinh Yen","Vung Tau","Yen Bai"],
     ["Chaiwan", "Chekham", "Cheungshawan", "Chingchung", "Chinghoi", "Chingsen", "Chingshing", "Chiunam", "Chiuon", "Chiuyeung", "Chiyuen", "Choihung", "Chuehoi", "Chuiman", "Chungfa", "Chungfu", "Chungsan", "Chunguktsuen", "Dakhing", "Daopo", "Daumun", "Dingwu", "Dinpak", "Donggun", "Dongyuen", "Duenchau", "Fachau", "Fado", "Fanling", "Fatgong", "Fatshan", "Fotan", "Fuktien", "Fumun", "Funggong", "Funghoi", "Fungshun", "Fungtei", "Gamtin", "Gochau", "Goming", "Gonghoi", "Gongshing", "Goyiu", "Hanghau", "Hangmei", "Hashan", "Hengfachuen", "Hengon", "Heungchau", "Heunggong", "Heungkiu", "Hingning", "Hohfuktong", "Hoichue", "Hoifung", "Hoiping", "Hokong", "Hokshan", "Homantin", "Hotin", "Hoyuen", "Hunghom", "Hungshuikiu", "Jiuling", "Kamping", "Kamsheung", "Kamwan", "Kaulongtong", "Keilun", "Kinon", "Kinsang", "Kityeung", "Kongmun", "Kukgong", "Kwaifong", "Kwaihing", "Kwongchau", "Kwongling", "Kwongming", "Kwuntong", "Laichikok", "Laiking", "Laiwan", "Lamtei", "Lamtin", "Leitung", "Leungking", "Limkong", "Linchau", "Linnam", "Linping", "Linshan", "Loding", "Lokcheong", "Lokfu", "Lokmachau", "Longchuen", "Longgong", "Longmun", "Longping", "Longwa", "Longwu", "Lowu", "Luichau", "Lukfung", "Lukho", "Lungmun", "Macheung", "Maliushui", "Maonshan", "Mauming", "Maunam", "Meifoo", "Mingkum", "Mogong", "Mongkok", "Muichau", "Muigong", "Muiyuen", "Naiwai", "Namcheong", "Namhoi", "Namhong", "Namo", "Namsha", "Namshan", "Nganwai", "Ngchuen", "Ngoumun", "Ngwa", "Nngautaukok", "Onting", "Pakwun", "Paotoishan", "Pingshan", "Pingyuen", "Poklo", "Polam", "Pongon", "Poning", "Potau", "Puito", "Punyue", "Saiwanho", "Saiyingpun", "Samshing", "Samshui", "Samtsen", "Samyuenlei", "Sanfung", "Sanhing", "Sanhui", "Sanwai", "Sanwui", "Seiwui", "Shamshuipo", "Shanmei", "Shantau", "Shatin", "Shatinwai", "Shaukeiwan", "Shauking", "Shekkipmei", "Shekmun", "Shekpai", "Sheungshui", "Shingkui", "Shiuhing", "Shundak", "Shunyi", "Shupinwai", "Simshing", "Siuhei", "Siuhong", "Siukwan", "Siulun", "Suikai", "Taihing", "Taikoo", "Taipo", "Taishuihang", "Taiwai", "Taiwo", "Taiwohau", "Tinhau", "Tinho", "Tinking", "Tinshuiwai", "Tiukengleng", "Toishan", "Tongfong", "Tonglowan", "Tsakyoochung", "Tsamgong", "Tsangshing", "Tseungkwano", "Tsihing", "Tsimshatsui", "Tsinggong", "Tsingshantsuen", "Tsingwun", "Tsingyi", "Tsingyuen", "Tsiuchau", "Tsuenshekshan", "Tsuenwan", "Tuenmun", "Tungchung", "Waichap", "Waichau", "Waidong", "Wailoi", "Waishing", "Waiyeung", "Wanchai", "Wanfau", "Wanon", "Wanshing", "Wingon", "Wongchukhang", "Wongpo", "Wongtaisin", "Woping", "Wukaisha", "Yano", "Yaumatei", "Yauoi", "Yautong", "Yenfa", "Yeungchun", "Yeungdong", "Yeunggong", "Yeungsai", "Yeungshan", "Yimtin", "Yingdak", "Yiuping", "Yongshing", "Yongyuen", "Yuenlong", "Yuenshing", "Yuetsau", "Yuknam", "Yunping", "Yuyuen"],
-    ["Adaatsag", "Airag", "Alag Erdene", "Altai", "Altanshiree", "Altantsogts", "Arbulag", "Baatsagaan", "Batnorov", "Batshireet", "Battsengel", "Bayan Adarga", "Bayan Agt", "Bayanbulag", "Bayandalai", "Bayandun", "Bayangovi", "Bayanjargalan", "Bayankhongor", "Bayankhutag", "Bayanlig", "Bayanmonkh", "Bayannuur", "Bayan Ondor", "Bayan Ovoo", "Bayantal", "Bayantsagaan", "Bayantumen", "Bayan Uul", "Bayanzurkh", "Berkh", "Biger", "Binder", "Bogd", "Bombogor", "Bor Ondor", "Bugat", "Bulgan", "Buregkhangai", "Burentogtokh", "Buutsagaan", "Buyant", "Chandmani", "Chandmani Ondor", "Choibalsan", "Chuluunkhoroot", "Chuluut", "Dadal", "Dalanjargalan", "Dalanzadgad", "Darkhan", "Darvi", "Dashbalbar", "Dashinchilen", "Delger", "Delgerekh", "Delgerkhaan", "Delgerkhangai", "Delgertsogt", "Deluun", "Deren", "Dorgon", "Duut", "Erdene", "Erdenebulgan", "Erdeneburen", "Erdenedalai", "Erdenemandal", "Erdenetsogt", "Galshar", "Galt", "Galuut", "Govi Ugtaal", "Gurvan", "Gurvanbulag", "Gurvansaikhan", "Gurvanzagal", "Ikhkhet", "Ikh Tamir", "Ikh Uul", "Jargalan", "Jargalant", "Jargaltkhaan", "Jinst", "Khairkhan", "Khalhgol", "Khaliun", "Khanbogd", "Khangai", "Khangal", "Khankh", "Khankhongor", "Khashaat", "Khatanbulag", "Khatgal", "Kherlen", "Khishig Ondor", "Khokh", "Kholonbuir", "Khongor", "Khotont", "Khovd", "Khovsgol", "Khuld", "Khureemaral", "Khurmen", "Khutag Ondor", "Luus", "Mandakh", "Mandal Ovoo", "Mankhan", "Manlai", "Matad", "Mogod", "Monkhkhairkhan", "Moron", "Most", "Myangad", "Nogoonnuur", "Nomgon", "Norovlin", "Noyon", "Ogii", "Olgii", "Olziit", "Omnodelger", "Ondorkhaan", "Ondorshil", "Ondor Ulaan", "Orgon", "Orkhon", "Rashaant", "Renchinlkhumbe", "Sagsai", "Saikhan", "Saikhandulaan", "Saikhan Ovoo", "Sainshand", "Saintsagaan", "Selenge", "Sergelen", "Sevrei", "Sharga", "Sharyngol", "Shine Ider", "Shinejinst", "Shiveegovi", "Sumber", "Taishir", "Tarialan", "Tariat", "Teshig", "Togrog", "Tolbo", "Tomorbulag", "Tonkhil", "Tosontsengel", "Tsagaandelger", "Tsagaannuur", "Tsagaan Ovoo", "Tsagaan Uur", "Tsakhir", "Tseel", "Tsengel", "Tsenkher", "Tsenkhermandal", "Tsetseg", "Tsetserleg", "Tsogt", "Tsogt Ovoo", "Tsogttsetsii", "Tunel", "Tuvshruulekh", "Ulaanbadrakh", "Ulaankhus", "Ulaan Uul", "Uyench", "Yesonbulag", "Zag", "Zamyn Uud", "Zereg"]    
+    ["Adaatsag", "Airag", "Alag Erdene", "Altai", "Altanshiree", "Altantsogts", "Arbulag", "Baatsagaan", "Batnorov", "Batshireet", "Battsengel", "Bayan Adarga", "Bayan Agt", "Bayanbulag", "Bayandalai", "Bayandun", "Bayangovi", "Bayanjargalan", "Bayankhongor", "Bayankhutag", "Bayanlig", "Bayanmonkh", "Bayannuur", "Bayan Ondor", "Bayan Ovoo", "Bayantal", "Bayantsagaan", "Bayantumen", "Bayan Uul", "Bayanzurkh", "Berkh", "Biger", "Binder", "Bogd", "Bombogor", "Bor Ondor", "Bugat", "Bulgan", "Buregkhangai", "Burentogtokh", "Buutsagaan", "Buyant", "Chandmani", "Chandmani Ondor", "Choibalsan", "Chuluunkhoroot", "Chuluut", "Dadal", "Dalanjargalan", "Dalanzadgad", "Darkhan", "Darvi", "Dashbalbar", "Dashinchilen", "Delger", "Delgerekh", "Delgerkhaan", "Delgerkhangai", "Delgertsogt", "Deluun", "Deren", "Dorgon", "Duut", "Erdene", "Erdenebulgan", "Erdeneburen", "Erdenedalai", "Erdenemandal", "Erdenetsogt", "Galshar", "Galt", "Galuut", "Govi Ugtaal", "Gurvan", "Gurvanbulag", "Gurvansaikhan", "Gurvanzagal", "Ikhkhet", "Ikh Tamir", "Ikh Uul", "Jargalan", "Jargalant", "Jargaltkhaan", "Jinst", "Khairkhan", "Khalhgol", "Khaliun", "Khanbogd", "Khangai", "Khangal", "Khankh", "Khankhongor", "Khashaat", "Khatanbulag", "Khatgal", "Kherlen", "Khishig Ondor", "Khokh", "Kholonbuir", "Khongor", "Khotont", "Khovd", "Khovsgol", "Khuld", "Khureemaral", "Khurmen", "Khutag Ondor", "Luus", "Mandakh", "Mandal Ovoo", "Mankhan", "Manlai", "Matad", "Mogod", "Monkhkhairkhan", "Moron", "Most", "Myangad", "Nogoonnuur", "Nomgon", "Norovlin", "Noyon", "Ogii", "Olgii", "Olziit", "Omnodelger", "Ondorkhaan", "Ondorshil", "Ondor Ulaan", "Orgon", "Orkhon", "Rashaant", "Renchinlkhumbe", "Sagsai", "Saikhan", "Saikhandulaan", "Saikhan Ovoo", "Sainshand", "Saintsagaan", "Selenge", "Sergelen", "Sevrei", "Sharga", "Sharyngol", "Shine Ider", "Shinejinst", "Shiveegovi", "Sumber", "Taishir", "Tarialan", "Tariat", "Teshig", "Togrog", "Tolbo", "Tomorbulag", "Tonkhil", "Tosontsengel", "Tsagaandelger", "Tsagaannuur", "Tsagaan Ovoo", "Tsagaan Uur", "Tsakhir", "Tseel", "Tsengel", "Tsenkher", "Tsenkhermandal", "Tsetseg", "Tsetserleg", "Tsogt", "Tsogt Ovoo", "Tsogttsetsii", "Tunel", "Tuvshruulekh", "Ulaanbadrakh", "Ulaankhus", "Ulaan Uul", "Uyench", "Yesonbulag", "Zag", "Zamyn Uud", "Zereg"]
   ];
 }
 
@@ -230,7 +232,7 @@ function applyDefaultBiomesSystem() {
   const name = ["Marine","Hot desert","Cold desert","Savanna","Grassland","Tropical seasonal forest","Temperate deciduous forest","Tropical rain forest","Temperate rain forest","Taiga","Tundra","Glacier"];
   //const color = ["#53679f","#fbfaae","#e1df9b","#eef586","#bdde82","#b6d95d","#29bc56","#7dcb35","#45b348","#567c2c","#d5d59d","#e6f5fa"];
   const color = ["#53679f","#fbe79f","#b5b887","#d2d082","#c8d68f","#b6d95d","#29bc56","#7dcb35","#45b348","#4b6b32","#96784b","#d5e7eb"];
-  
+
   const i = new Uint8Array(d3.range(0, name.length));
   const habitability = new Uint16Array([0,2,5,15,25,50,100,80,90,10,2,0]);
   const iconsDensity = new Uint8Array([0,3,2,120,120,120,120,150,150,100,5,0]);
@@ -287,7 +289,7 @@ function applyDefaultStyle() {
   roads.attr("opacity", .9).attr("stroke", "#d06324").attr("stroke-width", .45).attr("stroke-dasharray", "1.5").attr("stroke-linecap", "butt").attr("filter", null);
   ruler.attr("opacity", null).attr("filter", null);
   searoutes.attr("opacity", .8).attr("stroke", "#ffffff").attr("stroke-width", .45).attr("stroke-dasharray", "1 2").attr("stroke-linecap", "round").attr("filter", null);
-  
+
   regions.attr("opacity", .4).attr("filter", null);
   temperature.attr("opacity", null).attr("fill", "#000000").attr("stroke-width", 1.8).attr("fill-opacity", .3).attr("font-size", "8px").attr("stroke-dasharray", null).attr("filter", null).attr("mask", null);
   texture.attr("opacity", null).attr("filter", null).attr("mask", "url(#land)");
@@ -309,10 +311,10 @@ function applyDefaultStyle() {
 
   // heightmap style
   terrs.attr("opacity", null).attr("filter", null).attr("mask", "url(#land)").attr("stroke", "none");
-  const changed = styleHeightmapSchemeInput.value !== "bright" || 
-                  styleHeightmapTerracingInput.value != 0 || 
-                  styleHeightmapSkipInput.value != 5 || 
-                  styleHeightmapSimplificationInput.value != 0 || 
+  const changed = styleHeightmapSchemeInput.value !== "bright" ||
+                  styleHeightmapTerracingInput.value != 0 ||
+                  styleHeightmapSkipInput.value != 5 ||
+                  styleHeightmapSimplificationInput.value != 0 ||
                   styleHeightmapCurveInput.value != 0;
   styleHeightmapSchemeInput.value = "bright";
   styleHeightmapTerracingInput.value = styleHeightmapTerracingOutput.value = 0;
@@ -347,7 +349,7 @@ function focusOn() {
       params.set("burg", params.get("seed").slice(-4));
     } else {
       // select burg for MFCG
-      findBurgForMFCG(params); 
+      findBurgForMFCG(params);
       return;
     }
   }
@@ -397,7 +399,7 @@ function findBurgForMFCG(params) {
 
   // select a burg with closest population from selection
   const selected = d3.scan(selection, (a, b) => Math.abs(a.population - size) - Math.abs(b.population - size));
-  const b = selection[selected].i;  
+  const b = selection[selected].i;
   if (!b) {console.error("Cannot select a burg for MFCG"); return;}
   if (size) burgs[b].population = size;
 
@@ -610,7 +612,7 @@ function calculateVoronoi(graph, points) {
   const allPoints = points.concat(grid.boundary);
   const delaunay = Delaunator.from(allPoints);
   console.timeEnd("calculateDelaunay");
-  
+
   console.time("calculateVoronoi");
   const voronoi = Voronoi(delaunay, allPoints, n);
   graph.cells = voronoi.cells;
@@ -762,7 +764,7 @@ function generatePrecipitation() {
   // x1 = 70-90 latitude: dry all year (sinking zone)
   }
   const lalitudeModifier = [4,2,2,2,1,1,2,2,2,2,3,3,2,2,1,1,1,0.5]; // by 5d step
- 
+
   // difine wind directions based on cells latitude and prevailing winds there
   d3.range(0, cells.i.length, cellsX).forEach(function(c, i) {
     const lat = mapCoordinates.latN - i / cellsY * mapCoordinates.latT;
@@ -774,7 +776,7 @@ function generatePrecipitation() {
     if (winds[tier] > 100 && winds[tier] < 260) northerly++;
     else if (winds[tier] > 280 || winds[tier] < 80) southerly++;
   });
-  
+
   // distribute winds by direction
   if (westerly.length) passWind(westerly, 120 * modifier, 1, cellsX);
   if (easterly.length) passWind(easterly, 120 * modifier, -1, cellsX);
@@ -799,7 +801,7 @@ function generatePrecipitation() {
       let humidity = maxPrec - cells.h[first]; // initial water amount
       if (humidity <= 0) continue; // if first cell in row is too elevated cosdired wind dry
       for (let s = 0, current = first; s < steps; s++, current += next) {
-        // no flux on permafrost 
+        // no flux on permafrost
         if (cells.temp[current] < -5) continue;
         // water cell
         if (cells.h[current] < 20) {
@@ -915,7 +917,7 @@ function drawCoastline() {
   const used = new Uint8Array(features.length); // store conneted features
   const largestLand = d3.scan(features.map(f => f.land ? f.cells : 0), (a, b) => b - a);
   const landMask = defs.select("#land");
-  const waterMask = defs.select("#water");  
+  const waterMask = defs.select("#water");
   lineGen.curve(d3.curveBasisClosed);
 
   for (const i of cells.i) {
@@ -1012,7 +1014,7 @@ function reMarkFeatures() {
           cellNumber++;
         }
         if (land && !eLand) {
-          cells.t[q] = 1; 
+          cells.t[q] = 1;
           cells.t[e] = -1;
           cells.harbor[q]++;
           if (!cells.haven[q]) cells.haven[q] = e;

--- a/main.js
+++ b/main.js
@@ -110,7 +110,7 @@ focusOn(); // based on searchParams focus on point, cell or burg from MFCG
 addDragToUpload(); // allow map loading by drag and drop
 
 // show message on load if required
-setTimeout(showWelcomeMessage, 8000);
+// setTimeout(showWelcomeMessage, 8000);
 function showWelcomeMessage() {
   // Changelog dialog window
   if (localStorage.getItem("version") != version) {

--- a/main.js
+++ b/main.js
@@ -238,7 +238,7 @@ function applyDefaultBiomesSystem() {
   const iconsDensity = new Uint8Array([0,3,2,120,120,120,120,150,150,100,5,0]);
   const icons = [{},{dune:1},{dune:1},{acacia:1, grass:9},{grass:1},{acacia:1, palm:1},{deciduous:1},{acacia:7, palm:2, deciduous:1},{deciduous:7, swamp:3},{conifer:1},{grass:1},{}];
   const cost = new Uint8Array([10,200,150,60,50,70,70,80,90,80,100,255]); // biome movement cost
-  const biomesMartix = [
+  const biomesMatrix = [
     new Uint8Array([1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2]),
     new Uint8Array([3,3,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,9,9,9,9,9,10,10]),
     new Uint8Array([5,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,9,9,9,9,9,10,10,10]),
@@ -255,7 +255,7 @@ function applyDefaultBiomesSystem() {
     icons[i] = parsed;
   }
 
-  return {i, name, color, biomesMartix, habitability, iconsDensity, icons, cost};
+  return {i, name, color, biomesMatrix, habitability, iconsDensity, icons, cost};
 }
 
 // restore initial style
@@ -1098,7 +1098,7 @@ function defineBiomes() {
     if (temperature < -5) return 11; // permafrost biome
     const m = Math.min((moisture + 4) / 5 | 0, 4); // moisture band from 0 to 4
     const t = Math.min(Math.max(20 - temperature, 0), 25); // temparature band from 0 to 25
-    return biomesData.biomesMartix[m][t];
+    return biomesData.biomesMatrix[m][t];
   }
 
   console.timeEnd("defineBiomes");

--- a/modules/save-and-load.js
+++ b/modules/save-and-load.js
@@ -276,54 +276,8 @@ function displayMapData(data) {
     biomesData.name = name;
   }()
 
-  void function replaceSVG() {
-    svg.remove();
-    document.body.insertAdjacentHTML("afterbegin", data[5]);
-  }()
-
-  void function redefineElements() {
-    svg = d3.select("#map");
-    defs = svg.select("#deftemp");
-    viewbox = svg.select("#viewbox");
-    scaleBar = svg.select("#scaleBar");
-    ocean = viewbox.select("#ocean");
-    oceanLayers = ocean.select("#oceanLayers");
-    oceanPattern = ocean.select("#oceanPattern");
-    lakes = viewbox.select("#lakes");
-    landmass = viewbox.select("#landmass");
-    texture = viewbox.select("#texture");
-    terrs = viewbox.select("#terrs");
-    biomes = viewbox.select("#biomes");
-    cells = viewbox.select("#cells");
-    gridOverlay = viewbox.select("#gridOverlay");
-    coordinates = viewbox.select("#coordinates");
-    compass = viewbox.select("#compass");
-    rivers = viewbox.select("#rivers");
-    terrain = viewbox.select("#terrain");
-    cults = viewbox.select("#cults");
-    regions = viewbox.select("#regions");
-    statesBody = regions.select("#statesBody");
-    statesHalo = regions.select("#statesHalo");
-    borders = viewbox.select("#borders");
-    routes = viewbox.select("#routes");
-    roads = routes.select("#roads");
-    trails = routes.select("#trails");
-    searoutes = routes.select("#searoutes");
-    temperature = viewbox.select("#temperature");
-    coastline = viewbox.select("#coastline");
-    prec = viewbox.select("#prec");
-    population = viewbox.select("#population");
-    labels = viewbox.select("#labels");
-    icons = viewbox.select("#icons");
-    burgIcons = icons.select("#burgIcons");
-    anchors = icons.select("#anchors");
-    markers = viewbox.select("#markers");
-    ruler = viewbox.select("#ruler");
-    debug = viewbox.select("#debug");
-    freshwater = lakes.select("#freshwater");
-    salt = lakes.select("#salt");
-    burgLabels = labels.select("#burgLabels");
-  }()
+  replaceSVG(data[5])
+  redefineElements()
 
   void function parseGridData() {
     grid = JSON.parse(data[6]);
@@ -356,43 +310,281 @@ function displayMapData(data) {
     pack.cells.state = Uint8Array.from(data[25].split(","));
   }()
 
-  void function restoreLayersState() {
-    if (texture.style("display") !== "none" && texture.select("image").size()) turnButtonOn("toggleTexture"); else turnButtonOff("toggleTexture");
-    if (terrs.selectAll("*").size()) turnButtonOn("toggleHeight"); else turnButtonOff("toggleHeight");
-    if (biomes.selectAll("*").size()) turnButtonOn("toggleBiomes"); else turnButtonOff("toggleBiomes");
-    if (cells.selectAll("*").size()) turnButtonOn("toggleCells"); else turnButtonOff("toggleCells");
-    if (gridOverlay.selectAll("*").size()) turnButtonOn("toggleGrid"); else turnButtonOff("toggleGrid");
-    if (coordinates.selectAll("*").size()) turnButtonOn("toggleCoordinates"); else turnButtonOff("toggleCoordinates");
-    if (compass.style("display") !== "none" && compass.select("use").size()) turnButtonOn("toggleCompass"); else turnButtonOff("toggleCompass");
-    if (rivers.style("display") !== "none") turnButtonOn("toggleRivers"); else turnButtonOff("toggleRivers");
-    if (terrain.style("display") !== "none" && terrain.selectAll("*").size()) turnButtonOn("toggleRelief"); else turnButtonOff("toggleRelief");
-    if (cults.selectAll("*").size()) turnButtonOn("toggleCultures"); else turnButtonOff("toggleCultures");
-    if (statesBody.selectAll("*").size()) turnButtonOn("toggleStates"); else turnButtonOff("toggleStates");
-    if (borders.style("display") !== "none" && borders.selectAll("*").size()) turnButtonOn("toggleBorders"); else turnButtonOff("toggleBorders");
-    if (routes.style("display") !== "none" && routes.selectAll("path").size()) turnButtonOn("toggleRoutes"); else turnButtonOff("toggleRoutes");
-    if (temperature.selectAll("*").size()) turnButtonOn("toggleTemp"); else turnButtonOff("toggleTemp");
-    if (population.select("#rural").selectAll("*").size()) turnButtonOn("togglePopulation"); else turnButtonOff("togglePopulation");
-    if (prec.selectAll("circle").size()) turnButtonOn("togglePrec"); else turnButtonOff("togglePrec");
-    if (labels.style("display") !== "none") turnButtonOn("toggleLabels"); else turnButtonOff("toggleLabels");
-    if (icons.style("display") !== "none") turnButtonOn("toggleIcons"); else turnButtonOff("toggleIcons");
-    if (markers.style("display") !== "none") turnButtonOn("toggleMarkers"); else turnButtonOff("toggleMarkers");
-    if (ruler.style("display") !== "none") turnButtonOn("toggleRulers"); else turnButtonOff("toggleRulers");
-    if (scaleBar.style("display") !== "none") turnButtonOn("toggleScaleBar"); else turnButtonOff("toggleScaleBar");
-  }()
-
-  void function establishHistory() {
-    mapHistory.push({
-      created: Date.now(),
-      height: graphHeight,
-      seed,
-      template: templateInput.value,
-      width: graphWidth,
-    });
-  }()
+  restoreLayersState()
+  establishHistory()
 
   changeMapSize();
   restoreDefaultEvents();
   invokeActiveZooming();
   tip("Map is loaded");
   console.timeEnd("loadMap");
+}
+
+function packageJsonData() {
+  if (customization) {
+    tip("Map cannot be saved when is in edit mode, please exit the mode and re-try", false, "error");
+    return;
+  }
+
+  console.time("packageJsonData");
+  const now = new Date();
+  // set transform values to default
+  svg.attr("width", graphWidth).attr("height", graphHeight);
+  const transform = d3.zoomTransform(svg.node());
+  viewbox.attr("transform", null);
+
+  const json = {
+    coordinates: mapCoordinates,
+    biomes: {
+      color: biomesData.color,
+      habitability: biomesData.habitability,
+      name: biomesData.name
+    },
+    burgs: pack.burgs,
+    cells: {
+      grid: {
+        f: Array.from(grid.cells.f),
+        h: Array.from(grid.cells.h),
+        prec: Array.from(grid.cells.prec),
+        t: Array.from(grid.cells.t),
+        temp: Array.from(grid.cells.temp),
+      },
+      pack: {
+        biome: Array.from(pack.cells.biome),
+        burg: Array.from(pack.cells.burg),
+        conf: Array.from(pack.cells.conf),
+        culture: Array.from(pack.cells.culture),
+        fl: Array.from(pack.cells.fl),
+        pop: Array.from(pack.cells.pop),
+        r: Array.from(pack.cells.r),
+        road: Array.from(pack.cells.road),
+        s: Array.from(pack.cells.s),
+        state: Array.from(pack.cells.state),
+      },
+    },
+    cultures: pack.cultures,
+    features: pack.features,
+    grid: {
+      boundary: grid.boundary,
+      cellsX: grid.cellsX,
+      cellsY: grid.cellsY,
+      features: grid.features,
+      points: grid.points,
+      spacing: grid.spacing,
+    },
+    meta: {
+      dateString: now.getFullYear() + "-" + (now.getMonth() + 1) + "-" + now.getDate(),
+      graphHeight,
+      graphWidth,
+      license: 'File can be loaded in azgaar.github.io/Fantasy-Map-Generator',
+      seed,
+      version,
+    },
+    notes,
+    options: {
+      areaUnit: areaUnit.value,
+      barBackColor: barBackColor.value,
+      barBackOpacity: barBackOpacity.value,
+      barLabel: barLabel.value,
+      barPosX: barPosX.value,
+      barPosY: barPosY.value,
+      barSize: barSize.value,
+      distanceScale: distanceScale.value,
+      distanceUnit: distanceUnit.value,
+      equatorOutput: equatorOutput.value,
+      equidistanceOutput: equidistanceOutput.value,
+      heightExponent: heightExponent.value,
+      heightUnit: heightUnit.value,
+      populationRate: populationRate.value,
+      precOutput: precOutput.value,
+      temperatureEquatorOutput: temperatureEquatorOutput.value,
+      temperaturePoleOutput: temperaturePoleOutput.value,
+      temperatureScale: temperatureScale.value,
+      urbanization: urbanization.value,
+      winds: JSON.stringify(winds),
+    },
+    states: pack.states,
+    svg: (new XMLSerializer()).serializeToString(svg.node()),
+  }
+
+  // restore initial values
+  svg.attr("width", svgWidth).attr("height", svgHeight);
+  zoom.transform(svg, transform);
+
+  return json;
+}
+
+function displayJsonData(json) {
+  console.time("loadMap");
+  closeDialogs();
+
+  void function parseMeta() {
+    const meta = json.meta
+    if (meta.seed) { optionsSeed.value = seed = meta.seed; }
+    if (meta.graphWidth) graphWidth = meta.graphWidth;
+    if (meta.graphHeight) graphHeight = meta.graphHeight;
+  }()
+
+  void function parseOptions() {
+    const options = json.options;
+    if (options.distanceUnit) distanceUnit.value = distanceUnitOutput.innerHTML = options.distanceUnit;
+    if (options.distanceScale) distanceScale.value = distanceScaleSlider.value = options.distanceScale;
+    if (options.areaUnit) areaUnit.value = options.areaUnit;
+    if (options.heightUnit) heightUnit.value= options.heightUnit;
+    if (options.heightExponent) heightExponent.value = heightExponentSlider.value = options.heightExponent;
+    if (options.temperatureScale) temperatureScale.value = options.temperatureScale;
+    if (options.barSize) barSize.value = barSizeSlider.value = options.barSize;
+    if (options.barLabel !== undefined) barLabel.value = options.barLabel;
+    if (options.barBackOpacity !== undefined) barBackOpacity.value = options.barBackOpacity;
+    if (options.barBackColor) barBackColor.value = options.barBackColor;
+    if (options.barPosX) barPosX.value = options.barPosX;
+    if (options.barPosY) barPosY.value = options.barPosY;
+    if (options.populationRate) populationRate.value = populationRateSlider.value = options.populationRate;
+    if (options.urbanization) urbanization.value = urbanizationSlider.value = options.urbanization;
+    if (options.equatorInput) equatorInput.value = equatorOutput.value = options.equatorInput;
+    if (options.equidistanceInput) equidistanceInput.value = equidistanceOutput.value = options.equidistanceInput;
+    if (options.temperatureEquatorInput) temperatureEquatorInput.value = temperatureEquatorOutput.value = options.temperatureEquatorInput;
+    if (options.temperaturePoleInput) temperaturePoleInput.value = temperaturePoleOutput.value = options.temperaturePoleInput;
+    if (options.precInput) precInput.value = precOutput.value = options.precInput;
+    if (options.winds) winds = JSON.parse(options.winds);
+  }()
+
+  void function parseConfiguration() {
+    if (json.coordinates) mapCoordinates = json.coordinates;
+    if (json.notes) notes = json.notes;
+
+    if (json.biomes.name.length !== biomesData.name.length) {
+      console.error("Biomes data is not correct and will not be loaded");
+      return;
+    }
+    biomesData.color = json.biomes.color
+    biomesData.habitability = json.biomes.habitability
+    biomesData.name = json.biomes.name
+  }()
+
+  replaceSVG(json.svg)
+  redefineElements()
+
+  void function parseGridData() {
+    grid = json.grid;
+    calculateVoronoi(grid, grid.points);
+    grid.cells.h = Uint8Array.from(json.cells.grid.h);
+    grid.cells.prec = Uint8Array.from(json.cells.grid.prec);
+    grid.cells.f = Uint16Array.from(json.cells.grid.f);
+    grid.cells.t = Int8Array.from(json.cells.grid.t);
+    grid.cells.temp = Int8Array.from(json.cells.grid.temp);
+  }()
+
+  void function parsePackData() {
+    pack = {};
+    reGraph();
+    reMarkFeatures();
+    pack.features = json.features;
+    pack.cultures = json.cultures;
+    pack.states = json.states;
+    pack.burgs = json.burgs;
+
+    pack.cells.biome = Uint8Array.from(json.cells.pack.biome);
+    pack.cells.burg = Uint16Array.from(json.cells.pack.burg);
+    pack.cells.conf = Uint8Array.from(json.cells.pack.conf);
+    pack.cells.culture = Uint8Array.from(json.cells.pack.culture);
+    pack.cells.fl = Uint16Array.from(json.cells.pack.fl);
+    pack.cells.pop = Uint16Array.from(json.cells.pack.pop);
+    pack.cells.r = Uint16Array.from(json.cells.pack.r);
+    pack.cells.road = Uint16Array.from(json.cells.pack.road);
+    pack.cells.s = Uint16Array.from(json.cells.pack.s);
+    pack.cells.state = Uint8Array.from(json.cells.pack.state);
+  }()
+
+  restoreLayersState()
+  establishHistory()
+
+  changeMapSize();
+  restoreDefaultEvents();
+  invokeActiveZooming();
+  tip("Map is loaded");
+  console.timeEnd("loadMap");
+}
+
+function replaceSVG(svgMarkup) {
+  svg.remove();
+  document.body.insertAdjacentHTML("afterbegin", svgMarkup);
+}
+
+function redefineElements() {
+  svg = d3.select("#map");
+  defs = svg.select("#deftemp");
+  viewbox = svg.select("#viewbox");
+  scaleBar = svg.select("#scaleBar");
+  ocean = viewbox.select("#ocean");
+  oceanLayers = ocean.select("#oceanLayers");
+  oceanPattern = ocean.select("#oceanPattern");
+  lakes = viewbox.select("#lakes");
+  landmass = viewbox.select("#landmass");
+  texture = viewbox.select("#texture");
+  terrs = viewbox.select("#terrs");
+  biomes = viewbox.select("#biomes");
+  cells = viewbox.select("#cells");
+  gridOverlay = viewbox.select("#gridOverlay");
+  coordinates = viewbox.select("#coordinates");
+  compass = viewbox.select("#compass");
+  rivers = viewbox.select("#rivers");
+  terrain = viewbox.select("#terrain");
+  cults = viewbox.select("#cults");
+  regions = viewbox.select("#regions");
+  statesBody = regions.select("#statesBody");
+  statesHalo = regions.select("#statesHalo");
+  borders = viewbox.select("#borders");
+  routes = viewbox.select("#routes");
+  roads = routes.select("#roads");
+  trails = routes.select("#trails");
+  searoutes = routes.select("#searoutes");
+  temperature = viewbox.select("#temperature");
+  coastline = viewbox.select("#coastline");
+  prec = viewbox.select("#prec");
+  population = viewbox.select("#population");
+  labels = viewbox.select("#labels");
+  icons = viewbox.select("#icons");
+  burgIcons = icons.select("#burgIcons");
+  anchors = icons.select("#anchors");
+  markers = viewbox.select("#markers");
+  ruler = viewbox.select("#ruler");
+  debug = viewbox.select("#debug");
+  freshwater = lakes.select("#freshwater");
+  salt = lakes.select("#salt");
+  burgLabels = labels.select("#burgLabels");
+}
+
+function restoreLayersState() {
+  if (texture.style("display") !== "none" && texture.select("image").size()) turnButtonOn("toggleTexture"); else turnButtonOff("toggleTexture");
+  if (terrs.selectAll("*").size()) turnButtonOn("toggleHeight"); else turnButtonOff("toggleHeight");
+  if (biomes.selectAll("*").size()) turnButtonOn("toggleBiomes"); else turnButtonOff("toggleBiomes");
+  if (cells.selectAll("*").size()) turnButtonOn("toggleCells"); else turnButtonOff("toggleCells");
+  if (gridOverlay.selectAll("*").size()) turnButtonOn("toggleGrid"); else turnButtonOff("toggleGrid");
+  if (coordinates.selectAll("*").size()) turnButtonOn("toggleCoordinates"); else turnButtonOff("toggleCoordinates");
+  if (compass.style("display") !== "none" && compass.select("use").size()) turnButtonOn("toggleCompass"); else turnButtonOff("toggleCompass");
+  if (rivers.style("display") !== "none") turnButtonOn("toggleRivers"); else turnButtonOff("toggleRivers");
+  if (terrain.style("display") !== "none" && terrain.selectAll("*").size()) turnButtonOn("toggleRelief"); else turnButtonOff("toggleRelief");
+  if (cults.selectAll("*").size()) turnButtonOn("toggleCultures"); else turnButtonOff("toggleCultures");
+  if (statesBody.selectAll("*").size()) turnButtonOn("toggleStates"); else turnButtonOff("toggleStates");
+  if (borders.style("display") !== "none" && borders.selectAll("*").size()) turnButtonOn("toggleBorders"); else turnButtonOff("toggleBorders");
+  if (routes.style("display") !== "none" && routes.selectAll("path").size()) turnButtonOn("toggleRoutes"); else turnButtonOff("toggleRoutes");
+  if (temperature.selectAll("*").size()) turnButtonOn("toggleTemp"); else turnButtonOff("toggleTemp");
+  if (population.select("#rural").selectAll("*").size()) turnButtonOn("togglePopulation"); else turnButtonOff("togglePopulation");
+  if (prec.selectAll("circle").size()) turnButtonOn("togglePrec"); else turnButtonOff("togglePrec");
+  if (labels.style("display") !== "none") turnButtonOn("toggleLabels"); else turnButtonOff("toggleLabels");
+  if (icons.style("display") !== "none") turnButtonOn("toggleIcons"); else turnButtonOff("toggleIcons");
+  if (markers.style("display") !== "none") turnButtonOn("toggleMarkers"); else turnButtonOff("toggleMarkers");
+  if (ruler.style("display") !== "none") turnButtonOn("toggleRulers"); else turnButtonOff("toggleRulers");
+  if (scaleBar.style("display") !== "none") turnButtonOn("toggleScaleBar"); else turnButtonOff("toggleScaleBar");
+}
+
+function establishHistory() {
+  mapHistory.push({
+    created: Date.now(),
+    height: graphHeight,
+    seed,
+    template: templateInput.value,
+    width: graphWidth,
+  });
 }

--- a/modules/ui/layers.js
+++ b/modules/ui/layers.js
@@ -1,7 +1,7 @@
 // UI module stub to control map layers
 "use strict";
 
-// on map regeneration restore layers if they was turned on 
+// on map regeneration restore layers if they was turned on
 function restoreLayers() {
   if (layerIsOn("toggleHeight")) drawHeightmap();
   if (layerIsOn("toggleCells")) drawCells();
@@ -73,13 +73,13 @@ function drawHeightmap() {
   }
 
   let currentLayer = 20;
-  const heights = cells.i.sort((a, b) => cells.h[a] - cells.h[b]); 
+  const heights = cells.i.sort((a, b) => cells.h[a] - cells.h[b]);
   for (const i of heights) {
     const h = cells.h[i];
     if (h > currentLayer) currentLayer += skip;
     if (currentLayer > 100) break; // no layers possible with height > 100
     if (h < currentLayer) continue;
-    if (used[i]) continue; // already marked    
+    if (used[i]) continue; // already marked
     const onborder = cells.c[i].some(n => cells.h[n] < h);
     if (!onborder) continue;
     const vertex = cells.v[i].find(v => vertices.c[v].some(i => cells.h[i] < h));
@@ -122,7 +122,7 @@ function drawHeightmap() {
     const n = simplification + 1; // filter each nth element
     return chain.filter((d, i) => i % n === 0);
   }
-  
+
   console.timeEnd("drawHeightmap");
 }
 
@@ -159,7 +159,7 @@ function drawTemp() {
   const used = new Uint8Array(n); // to detect already passed cells
   const min = d3.min(cells.temp), max = d3.max(cells.temp);
   const step = Math.max(Math.round(Math.abs(min - max) / 5), 1);
-  const isolines = d3.range(min+step, max, step); 
+  const isolines = d3.range(min+step, max, step);
   const chains = [], labels = []; // store label coordinates
 
   for (const i of cells.i) {
@@ -255,7 +255,7 @@ function drawBiomes() {
   const cells = pack.cells, vertices = pack.vertices, n = cells.i.length;
   const used = new Uint8Array(cells.i.length);
   const paths = new Array(biomesData.i.length).fill("");
-  
+
   for (const i of cells.i) {
     if (!cells.biome[i]) continue; // no need to mark water
     if (used[i]) continue; // already marked
@@ -319,7 +319,7 @@ function drawPrec() {
   const data = cells.i.filter(i => cells.h[i] >= 20 && cells.prec[i]);
   prec.selectAll("circle").data(data).enter().append("circle")
     .attr("cx", d => p[d][0]).attr("cy", d => p[d][1]).attr("r", 0)
-    .transition(show).attr("r", d => rn(Math.max(Math.sqrt(cells.prec[d] * .5), .8),2)); 
+    .transition(show).attr("r", d => rn(Math.max(Math.sqrt(cells.prec[d] * .5), .8),2));
 }
 
 function togglePopulation() {
@@ -383,7 +383,7 @@ function toggleCultures() {
 
 function drawCultures() {
   console.time("drawCultures");
-  
+
   cults.selectAll("path").remove();
   const cells = pack.cells, vertices = pack.vertices, cultures = pack.cultures, n = cells.i.length;
   const used = new Uint8Array(cells.i.length);
@@ -444,6 +444,8 @@ function drawStatesWithBorders() {
   regions.selectAll("path").remove();
   borders.selectAll("path").remove();
 
+  if (!pack.cells || !pack.cells.i) return;
+
   const cells = pack.cells, vertices = pack.vertices, states = pack.states, n = cells.i.length;
   const used = new Uint8Array(cells.i.length);
   const body = new Array(states.length).fill(""); // store path around each state
@@ -489,7 +491,7 @@ function drawStatesWithBorders() {
     const chain = []; // vertices chain to form a path
     let land = vertices.c[start].some(c => cells.h[c] >= 20 && cells.state[c] !== t);
     function check(i) {state = cells.state[i]; land = cells.h[i] >= 20;}
-    
+
     for (let i=0, current = start; i === 0 || current !== start && i < 20000; i++) {
       const prev = chain[chain.length - 1] ? chain[chain.length - 1][0] : -1; // previous vertex in chain
       chain.push([current, state, land]); // add current vertex to sequence
@@ -517,7 +519,7 @@ function toggleBorders() {
   } else {
     turnButtonOff("toggleBorders");
     $('#borders').fadeOut();
-  }  
+  }
 }
 
 function toggleGrid() {
@@ -574,7 +576,7 @@ function drawGrid() {
       x0 = x1, y0 = y1;
       return [rn(dx, 2), rn(dy, 2)];
     });
-  }  
+  }
 
   console.timeEnd("drawGrid");
 }
@@ -736,7 +738,7 @@ function toggleIcons() {
   } else {
     turnButtonOff("toggleIcons");
     $('#icons').fadeOut();
-  }  
+  }
 }
 
 function toggleRulers() {

--- a/modules/ui/options.js
+++ b/modules/ui/options.js
@@ -4,7 +4,7 @@
 $("#optionsContainer").draggable({handle: ".drag-trigger", snap: "svg", snapMode: "both"});
 $("#mapLayers").disableSelection();
 
-// show control elements and remove loading screen on map load 
+// show control elements and remove loading screen on map load
 d3.select("#loading").transition().duration(5000).style("opacity", 0).remove();
 d3.select("#initial").transition().duration(5000).attr("opacity", 0).remove();
 d3.select("#optionsContainer").transition().duration(5000).style("opacity", 1);
@@ -14,6 +14,10 @@ d3.select("#tooltip").transition().duration(5000).style("opacity", 1);
 if (localStorage.getItem("disable_click_arrow_tooltip")) {
   clearMainTip();
   optionsTrigger.classList.remove("glow");
+}
+
+function hideLoadingMessage() {
+  d3.select("#loading").remove()
 }
 
 // Show options pane on trigger click
@@ -27,7 +31,7 @@ function showOptions(event) {
   regenerate.style.display = "none";
   options.style.display = "block";
   optionsTrigger.style.display = "none";
-  
+
   if (event) event.stopPropagation();
 }
 
@@ -55,20 +59,20 @@ collapsible.addEventListener("mouseleave", function() {
 });
 
 // Activate options tab on click
-options.querySelector("div.tab").addEventListener("click", function(event) { 
+options.querySelector("div.tab").addEventListener("click", function(event) {
   if (event.target.tagName !== "BUTTON") return;
   const id = event.target.id;
   const active = options.querySelector(".tab > button.active");
   if (active && id === active.id) return; // already active tab is clicked
 
   if (active) active.classList.remove("active");
-  document.getElementById(id).classList.add("active");  
+  document.getElementById(id).classList.add("active");
   options.querySelectorAll(".tabcontent").forEach(e => e.style.display = "none");
 
-  if (id === "styleTab") styleContent.style.display = "block"; else 
-  if (id === "optionsTab") optionsContent.style.display = "block"; else 
-  if (id === "toolsTab" && !customization) toolsContent.style.display = "block"; else 
-  if (id === "toolsTab" && customization) customizationMenu.style.display = "block"; else   
+  if (id === "styleTab") styleContent.style.display = "block"; else
+  if (id === "optionsTab") optionsContent.style.display = "block"; else
+  if (id === "toolsTab" && !customization) toolsContent.style.display = "block"; else
+  if (id === "toolsTab" && customization) customizationMenu.style.display = "block"; else
   if (id === "aboutTab") aboutContent.style.display = "block";
 });
 
@@ -92,7 +96,7 @@ function selectStyleElement() {
   const sel = styleElementSelect.value;
   let el = viewbox.select("#"+sel);
 
-  styleElements.querySelectorAll("tbody").forEach(e => e.style.display = "none"); // hide all sections 
+  styleElements.querySelectorAll("tbody").forEach(e => e.style.display = "none"); // hide all sections
   const off = el.style("display") === "none" || !el.selectAll("*").size(); // check if layer is off
   if (off) {
     styleIsOff.style.display = "block";
@@ -104,7 +108,7 @@ function selectStyleElement() {
   if (sel == "ocean") el = oceanLayers.select("rect");
   else if (sel == "routes" || sel == "labels" || sel == "lakes" || sel == "anchors" || sel == "burgIcons") {
     el = d3.select("#"+sel).select("g#"+group).size()
-      ? d3.select("#"+sel).select("g#"+group) 
+      ? d3.select("#"+sel).select("g#"+group)
       : d3.select("#"+sel).select("g");
   }
 
@@ -161,7 +165,7 @@ function selectStyleElement() {
     styleCompassShiftY.value = tr[1];
     styleCompassSizeInput.value = styleCompassSizeOutput.value = tr[2];
   }
-  
+
   // show specific sections
   if (sel === "terrs") styleHeightmap.style.display = "block";
   if (sel === "gridOverlay") styleGrid.style.display = "block";
@@ -169,15 +173,15 @@ function selectStyleElement() {
   if (sel === "texture") styleTexture.style.display = "block";
   if (sel === "routes" || sel === "labels" || sel == "anchors" || sel == "burgIcons" || sel === "lakes") styleGroup.style.display = "block";
   if (sel === "markers") styleMarkers.style.display = "block";
- 
+
   if (sel === "population") {
     stylePopulation.style.display = "block";
     stylePopulationRuralStrokeInput.value = stylePopulationRuralStrokeOutput.value = population.select("#rural").attr("stroke");
     stylePopulationUrbanStrokeInput.value = stylePopulationUrbanStrokeOutput.value = population.select("#urban").attr("stroke");
     styleStrokeWidth.style.display = "block";
-    styleStrokeWidthInput.value = styleStrokeWidthOutput.value = el.attr("stroke-width") || "";      
+    styleStrokeWidthInput.value = styleStrokeWidthOutput.value = el.attr("stroke-width") || "";
   }
-  
+
   if (sel === "labels") {
     styleFill.style.display = "block";
     styleStroke.style.display = "block";
@@ -234,7 +238,7 @@ function selectStyleElement() {
   if (sel === "temperature") {
     styleStrokeWidth.style.display = "block";
     styleTemperature.style.display = "block";
-    styleStrokeWidthInput.value = styleStrokeWidthOutput.value = el.attr("stroke-width") || ""; 
+    styleStrokeWidthInput.value = styleStrokeWidthOutput.value = el.attr("stroke-width") || "";
     styleTemperatureFillOpacityInput.value = styleTemperatureFillOpacityOutput.value = el.attr("fill-opacity") || .1;
     styleTemperatureFillInput.value = styleTemperatureFillOutput.value = el.attr("fill") || "#000";
     styleTemperatureFontSizeInput.value = styleTemperatureFontSizeOutput.value = el.attr("font-size") || "8px";;
@@ -339,7 +343,7 @@ styleShiftY.addEventListener("input", shiftElement);
 function shiftElement() {
   const x = styleShiftX.value || 0;
   const y = styleShiftY.value || 0;
-  getEl().attr("transform", `translate(${x},${y})`);  
+  getEl().attr("transform", `translate(${x},${y})`);
 }
 
 styleOceanBack.addEventListener("input", function() {
@@ -417,7 +421,7 @@ styleCompassShiftY.addEventListener("input", shiftCompass);
 
 function shiftCompass() {
   const tr = `translate(${styleCompassShiftX.value} ${styleCompassShiftY.value}) scale(${styleCompassSizeInput.value})`;
-  d3.select("#rose").attr("transform", tr); 
+  d3.select("#rose").attr("transform", tr);
 }
 
 styleSelectFont.addEventListener("change", changeFont);
@@ -562,7 +566,7 @@ function textureProvideURL() {
 }
 
 function fetchTextureURL(url) {
-  console.log("Provided URL is", url);  
+  console.log("Provided URL is", url);
   const img = new Image();
   img.onload = function () {
     const canvas = document.getElementById("preview");
@@ -663,7 +667,7 @@ function toggleFullscreen() {
 
 function generateMapWithSeed() {
   if (optionsSeed.value == seed) {
-    tip("The current map already has this seed", false, "error"); 
+    tip("The current map already has this seed", false, "error");
     return;
   }
   regeneratePrompt();
@@ -685,7 +689,7 @@ function showSeedHistoryDialog() {
 // generate map with historycal seed
 function restoreSeed(id) {
   if (mapHistory[id].seed == seed) {
-    tip("The current map is already generated with this seed", null, "error"); 
+    tip("The current map is already generated with this seed", null, "error");
     return;
   }
   optionsSeed.value = mapHistory[id].seed;
@@ -722,7 +726,7 @@ function changeBurgsNumberSlider(value) {
 function changeUIsize(value) {
   uiSizeInput.value = uiSizeOutput.value = value;
   document.getElementsByTagName("body")[0].style.fontSize = value * 11 + "px";
-  document.getElementById("options").style.width = (value - 1) * 300 / 2 + 300 + "px"; 
+  document.getElementById("options").style.width = (value - 1) * 300 / 2 + 300 + "px";
 }
 
 function changeTooltipSize(value) {
@@ -772,7 +776,7 @@ function applyStoredOptions() {
   }
 
   if (localStorage.getItem("winds")) winds = localStorage.getItem("winds").split(",").map(w => +w);
-  
+
   changeDialogsTransparency(localStorage.getItem("transparency") || 30);
   if (localStorage.getItem("uiSize")) changeUIsize(localStorage.getItem("uiSize"));
   if (localStorage.getItem("tooltipSize")) changeTooltipSize(localStorage.getItem("tooltipSize"));
@@ -919,7 +923,7 @@ document.getElementById("sticked").addEventListener("click", function(event) {
 });
 
 function regeneratePrompt() {
-  if (customization) {tip("Please exit the customization mode first", false, "warning"); return;} 
+  if (customization) {tip("Please exit the customization mode first", false, "warning"); return;}
   const workingTime = (Date.now() - last(mapHistory).created) / 60000; // minutes
   if (workingTime < 15) {regenerateMap(); return;}
 
@@ -939,7 +943,7 @@ function toggleSavePane() {
 
   // ask users to allow popups
   if (!localStorage.getItem("dns_allow_popup_message")) {
-    alertMessage.innerHTML = `Generator uses pop-up window to download files. 
+    alertMessage.innerHTML = `Generator uses pop-up window to download files.
     <br>Please ensure your browser does not block popups.
     <br>Please check browser settings and turn off adBlocker if it is enabled`;
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "fantasy-map-generator",
+  "version": "0.8.19",
+  "description": "Fantasy Map Generator and Editor based on Voronoi diagram",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Azgaar/Fantasy-Map-Generator.git"
+  },
+  "keywords": [
+    "procedural-generation",
+    "map-generation",
+    "javascript",
+    "fantasy-map",
+    "gamedev-tool",
+    "mapmaker",
+    "demo"
+  ],
+  "author": "Azgaar",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Azgaar/Fantasy-Map-Generator/issues"
+  },
+  "homepage": "https://github.com/Azgaar/Fantasy-Map-Generator#readme"
+}


### PR DESCRIPTION
 - Adds a queryString param called `doNotGenerate`, which disables generation of a new map at startup
 - Adds a small convenience method to hide the `Loading...` message immediately (useful when loading a pre-generated map)
 - Splits `displayMapData` out from `uploadFile`, to allow programmatic loading of `.map` data format
 - Adds a `package.json` file, to support using this package as an `npm` dependency in other projects
