### PR TITLE
Fix for a few event handling errors on Firefox/forks

### DIFF
--- a/modules/ui/burg-editor.js
+++ b/modules/ui/burg-editor.js
@@ -9,7 +9,7 @@ function editBurg() {
   elSelected = burgLabels.select("[data-id='" + id + "']");
   burgLabels.selectAll("text").call(d3.drag().on("start", dragBurgLabel)).classed("draggable", true);
 
-  selectBurgGroup(event.target);
+  selectBurgGroup(d3.event.target);
   document.getElementById("burgNameInput").value = elSelected.text();
   const my = elSelected.attr("id") == d3.event.target.id ? "center bottom" : "center top+10";
   const at = elSelected.attr("id") == d3.event.target.id ? "top" : "bottom";

--- a/modules/ui/options.js
+++ b/modules/ui/options.js
@@ -575,7 +575,7 @@ function fetchTextureURL(url) {
 
 // Style map filters handler
 mapFilters.addEventListener("click", applyMapFilter);
-function applyMapFilter() {
+function applyMapFilter(event) {
   if (event.target.tagName !== "BUTTON") return;
   const button = event.target;
   svg.attr("filter", null);

--- a/modules/ui/tools.js
+++ b/modules/ui/tools.js
@@ -1,7 +1,7 @@
 // module to control the Tools options (click to edit, to re-geenerate, tp add)
 "use strict";
 
-toolsContent.addEventListener("click", function() {
+toolsContent.addEventListener("click", function(event) {
   if (customization) {tip("Please exit the customization mode first", false, "warning"); return;}
   if (event.target.tagName !== "BUTTON") return;
   const button = event.target.id;


### PR DESCRIPTION
I noticed some `event.target is not defined` errors when I went to try out the new version, and I tracked them down. In 2 cases (Map Filters and Tools), it looks like you forgot to pass an argument to the event handler. I'm not sure if the Burg Editor case is a typo or intentional, but changing it this way makes it work on Firefox and forks.

This is my first PR, so I'm sorry if I did anything wrong.