### PR TITLE
#320 Export Urban and Rural populations

### DIFF
--- a/modules/ui/provinces-editor.js
+++ b/modules/ui/provinces-editor.js
@@ -761,9 +761,10 @@ function editProvinces() {
 
   function downloadProvincesData() {
     const unit = areaUnit.value === "square" ? distanceUnitInput.value + "2" : areaUnit.value;
-    let data = "Id,Province,Form,State,Color,Capital,Area "+unit+",Population\n"; // headers
+    let data = "Id,Province,Form,State,Color,Capital,Area "+unit+",Population,Rural Population,Urban Population\n"; // headers
 
     body.querySelectorAll(":scope > div").forEach(function(el) {
+      let key = parseInt(el.dataset.id)
       data += el.dataset.id + ",";
       data += el.dataset.name + ",";
       data += el.dataset.form + ",";
@@ -771,7 +772,9 @@ function editProvinces() {
       data += el.dataset.color + ",";
       data += el.dataset.capital + ",";
       data += el.dataset.area + ",";
-      data += el.dataset.population + "\n";
+      data += el.dataset.population + ",";
+      data += `${Math.floor(pack.provinces[key].rural*populationRate.value)},`
+      data += `${Math.floor(pack.provinces[key].urban*populationRate.value)}\n`
     });
 
     const dataBlob = new Blob([data], {type: "text/plain"});

--- a/modules/ui/provinces-editor.js
+++ b/modules/ui/provinces-editor.js
@@ -761,7 +761,7 @@ function editProvinces() {
 
   function downloadProvincesData() {
     const unit = areaUnit.value === "square" ? distanceUnitInput.value + "2" : areaUnit.value;
-    let data = "Id,Province,Form,State,Color,Capital,Area "+unit+",Population,Rural Population,Urban Population\n"; // headers
+    let data = "Id,Province,Form,State,Color,Capital,Area "+unit+",Total Population,Rural Population,Urban Population\n"; // headers
 
     body.querySelectorAll(":scope > div").forEach(function(el) {
       let key = parseInt(el.dataset.id)
@@ -774,7 +774,7 @@ function editProvinces() {
       data += el.dataset.area + ",";
       data += el.dataset.population + ",";
       data += `${Math.round(pack.provinces[key].rural*populationRate.value)},`
-      data += `${Math.round(pack.provinces[key].urban*populationRate.value)}\n`
+      data += `${Math.round(pack.provinces[key].urban*populationRate.value * urbanization.value)}\n`
     });
 
     const dataBlob = new Blob([data], {type: "text/plain"});

--- a/modules/ui/provinces-editor.js
+++ b/modules/ui/provinces-editor.js
@@ -773,8 +773,8 @@ function editProvinces() {
       data += el.dataset.capital + ",";
       data += el.dataset.area + ",";
       data += el.dataset.population + ",";
-      data += `${Math.floor(pack.provinces[key].rural*populationRate.value)},`
-      data += `${Math.floor(pack.provinces[key].urban*populationRate.value)}\n`
+      data += `${Math.round(pack.provinces[key].rural*populationRate.value)},`
+      data += `${Math.round(pack.provinces[key].urban*populationRate.value)}\n`
     });
 
     const dataBlob = new Blob([data], {type: "text/plain"});

--- a/modules/ui/states-editor.js
+++ b/modules/ui/states-editor.js
@@ -869,7 +869,7 @@ function editStates() {
   
   function downloadStatesData() {
     const unit = areaUnit.value === "square" ? distanceUnitInput.value + "2" : areaUnit.value;
-    let data = "Id,State,Color,Capital,Culture,Type,Expansionism,Cells,Burgs,Area "+unit+",Population\n"; // headers
+    let data = "Id,State,Color,Capital,Culture,Type,Expansionism,Cells,Burgs,Area "+unit+",Population,Rural Population,Urban Population\n"; // headers
 
     body.querySelectorAll(":scope > div").forEach(function(el) {
       data += el.dataset.id + ",";
@@ -882,7 +882,9 @@ function editStates() {
       data += el.dataset.cells + ",";
       data += el.dataset.burgs + ",";
       data += el.dataset.area + ",";
-      data += el.dataset.population + "\n";
+      data += el.dataset.population + ",";
+      data += `${Math.floor(pack.states[key].rural*populationRate.value)},`;
+      data += `${Math.floor(pack.states[key].urban*populationRate.value)}\n`;
     });
 
     const dataBlob = new Blob([data], {type: "text/plain"});

--- a/modules/ui/states-editor.js
+++ b/modules/ui/states-editor.js
@@ -869,7 +869,7 @@ function editStates() {
   
   function downloadStatesData() {
     const unit = areaUnit.value === "square" ? distanceUnitInput.value + "2" : areaUnit.value;
-    let data = "Id,State,Color,Capital,Culture,Type,Expansionism,Cells,Burgs,Area "+unit+",Population,Rural Population,Urban Population\n"; // headers
+    let data = "Id,State,Color,Capital,Culture,Type,Expansionism,Cells,Burgs,Area "+unit+",Total Population,Rural Population,Urban Population\n"; // headers
 
     body.querySelectorAll(":scope > div").forEach(function(el) {
       let key = parseInt(el.dataset.id)
@@ -885,7 +885,7 @@ function editStates() {
       data += el.dataset.area + ",";
       data += el.dataset.population + ",";
       data += `${Math.round(pack.states[key].rural*populationRate.value)},`;
-      data += `${Math.round(pack.states[key].urban*populationRate.value)}\n`;
+      data += `${Math.round(pack.states[key].urban*populationRate.value * urbanization.value)}\n`;
     });
 
     const dataBlob = new Blob([data], {type: "text/plain"});

--- a/modules/ui/states-editor.js
+++ b/modules/ui/states-editor.js
@@ -872,6 +872,7 @@ function editStates() {
     let data = "Id,State,Color,Capital,Culture,Type,Expansionism,Cells,Burgs,Area "+unit+",Population,Rural Population,Urban Population\n"; // headers
 
     body.querySelectorAll(":scope > div").forEach(function(el) {
+      let key = parseInt(el.dataset.id)
       data += el.dataset.id + ",";
       data += el.dataset.name + ",";
       data += el.dataset.color + ",";
@@ -883,8 +884,8 @@ function editStates() {
       data += el.dataset.burgs + ",";
       data += el.dataset.area + ",";
       data += el.dataset.population + ",";
-      data += `${Math.floor(pack.states[key].rural*populationRate.value)},`;
-      data += `${Math.floor(pack.states[key].urban*populationRate.value)}\n`;
+      data += `${Math.round(pack.states[key].rural*populationRate.value)},`;
+      data += `${Math.round(pack.states[key].urban*populationRate.value)}\n`;
     });
 
     const dataBlob = new Blob([data], {type: "text/plain"});


### PR DESCRIPTION
Easier than expected. Adds Urban and Rural population numbers to the CSV export for provinces and states. Also exports the full "Title" of  States. This may be useful later if syntactic variations are implemented. (Not sure if they are now. But think "Kurmen Confederation"/"Kurmen Confederacy" /"Confederation of Kurmen", or Greece vs "Hellenic Republic")
Closes #320 