### PR TITLE
fix: 🐛 Allow also cmd key for all ctrl actions on mac

### DIFF
--- a/modules/ui/burg-editor.js
+++ b/modules/ui/burg-editor.js
@@ -282,8 +282,7 @@ function editBurg(id) {
     const id = elSelected.attr("data-id");
     const burg = pack.burgs[id];
     const defSeed = seed + id.padStart(4, 0);
-
-    if (event.ctrlKey) {
+    if (isCtrlClick(event)) {
       const newSeed = prompt(`Please provide a Medieval Fantasy City Generator seed. `+
         `Seed should be a number. Default seed is FMG map seed + burg id padded to 4 chars with zeros (${defSeed}). `+
         `Please note that if seed is custom, "Overworld" button from MFCG will open a different map`, burg.MFCG || defSeed);
@@ -314,7 +313,7 @@ function editBurg(id) {
     const burg = pack.burgs[id];
     const defSeed = `${seed}-b${id}`;
 
-    if (event.ctrlKey) {
+    if (isCtrlClick(event)) {
       const newSeed = prompt(`Please provide an Iron Arachne Heraldry Generator seed. `+
         `Default seed is a combination of FMG map seed and burg id (${defSeed})`, burg.IAHG || defSeed);
       if (newSeed) burg.IAHG = newSeed; else return;

--- a/modules/ui/cultures-editor.js
+++ b/modules/ui/cultures-editor.js
@@ -426,7 +426,7 @@ function editCultures() {
     });
 
     function dragToReorigin(d) {
-      if (d3.event.sourceEvent.ctrlKey) {changeCode(d); return;}
+      if (isCtrlClick(d3.event.sourceEvent)) {changeCode(d); return;}
 
       const originLine = graph.append("path")
         .attr("class", "dragLine").attr("d", `M${d.x},${d.y}L${d.x},${d.y}`);

--- a/modules/ui/layers.js
+++ b/modules/ui/layers.js
@@ -119,9 +119,9 @@ function toggleHeight(event) {
   if (!terrs.selectAll("*").size()) {
     turnButtonOn("toggleHeight");
     drawHeightmap();
-    if (event && event.ctrlKey) editStyle("terrs");
+    if (event && isCtrlClick(event)) editStyle("terrs");
   } else {
-    if (event && event.ctrlKey) {editStyle("terrs"); return;}
+    if (event && isCtrlClick(event)) {editStyle("terrs"); return;}
     if (customization === 1) {tip("You cannot turn off the layer when heightmap is in edit mode", false, "error"); return;}
     turnButtonOff("toggleHeight");
     terrs.selectAll("*").remove();
@@ -217,9 +217,9 @@ function toggleTemp(event) {
   if (!temperature.selectAll("*").size()) {
     turnButtonOn("toggleTemp");
     drawTemp();
-    if (event && event.ctrlKey) editStyle("temperature");
+    if (event && isCtrlClick(event)) editStyle("temperature");
   } else {
-    if (event && event.ctrlKey) {editStyle("temperature"); return;}
+    if (event && isCtrlClick(event)) {editStyle("temperature"); return;}
     turnButtonOff("toggleTemp");
     temperature.selectAll("*").remove();
   }
@@ -321,9 +321,9 @@ function toggleBiomes(event) {
   if (!biomes.selectAll("path").size()) {
     turnButtonOn("toggleBiomes");
     drawBiomes();
-    if (event && event.ctrlKey) editStyle("biomes");
+    if (event && isCtrlClick(event)) editStyle("biomes");
   } else {
-    if (event && event.ctrlKey) {editStyle("biomes"); return;}
+    if (event && isCtrlClick(event)) {editStyle("biomes"); return;}
     biomes.selectAll("path").remove();
     turnButtonOff("toggleBiomes");
   }
@@ -378,9 +378,9 @@ function togglePrec(event) {
   if (!prec.selectAll("circle").size()) {
     turnButtonOn("togglePrec");
     drawPrec();
-    if (event && event.ctrlKey) editStyle("prec");
+    if (event && isCtrlClick(event)) editStyle("prec");
   } else {
-    if (event && event.ctrlKey) {editStyle("prec"); return;}
+    if (event && isCtrlClick(event)) {editStyle("prec"); return;}
     turnButtonOff("togglePrec");
     const hide = d3.transition().duration(1000).ease(d3.easeSinIn);
     prec.selectAll("text").attr("opacity", 1).transition(hide).attr("opacity", 0);
@@ -406,9 +406,9 @@ function togglePopulation(event) {
   if (!population.selectAll("line").size()) {
     turnButtonOn("togglePopulation");
     drawPopulation();
-    if (event && event.ctrlKey) editStyle("population");
+    if (event && isCtrlClick(event)) editStyle("population");
   } else {
-    if (event && event.ctrlKey) {editStyle("population"); return;}
+    if (event && isCtrlClick(event)) {editStyle("population"); return;}
     turnButtonOff("togglePopulation");
     const hide = d3.transition().duration(1000).ease(d3.easeSinIn);
     population.select("#rural").selectAll("line").transition(hide).attr("y2", d => d[1]).remove();
@@ -438,9 +438,9 @@ function toggleCells(event) {
   if (!cells.selectAll("path").size()) {
     turnButtonOn("toggleCells");
     drawCells();
-    if (event && event.ctrlKey) editStyle("cells");
+    if (event && isCtrlClick(event)) editStyle("cells");
   } else {
-    if (event && event.ctrlKey) {editStyle("cells"); return;}
+    if (event && isCtrlClick(event)) {editStyle("cells"); return;}
     cells.selectAll("path").remove();
     turnButtonOff("toggleCells");
   }
@@ -461,9 +461,9 @@ function toggleCultures(event) {
   if (empty && cultures.length) {
     turnButtonOn("toggleCultures");
     drawCultures();
-    if (event && event.ctrlKey) editStyle("cults");
+    if (event && isCtrlClick(event)) editStyle("cults");
   } else {
-    if (event && event.ctrlKey) {editStyle("cults"); return;}
+    if (event && isCtrlClick(event)) {editStyle("cults"); return;}
     cults.selectAll("path").remove();
     turnButtonOff("toggleCultures");
   }
@@ -521,9 +521,9 @@ function toggleReligions(event) {
   if (!relig.selectAll("path").size() && religions.length) {
     turnButtonOn("toggleReligions");
     drawReligions();
-    if (event && event.ctrlKey) editStyle("relig");
+    if (event && isCtrlClick(event)) editStyle("relig");
   } else {
-    if (event && event.ctrlKey) {editStyle("relig"); return;}
+    if (event && isCtrlClick(event)) {editStyle("relig"); return;}
     relig.selectAll("path").remove();
     turnButtonOff("toggleReligions");
   }
@@ -593,9 +593,9 @@ function toggleStates(event) {
     turnButtonOn("toggleStates");
     regions.style("display", null);
     drawStates();
-    if (event && event.ctrlKey) editStyle("regions");
+    if (event && isCtrlClick(event)) editStyle("regions");
   } else {
-    if (event && event.ctrlKey) {editStyle("regions"); return;}
+    if (event && isCtrlClick(event)) {editStyle("regions"); return;}
     regions.style("display", "none").selectAll("path").remove();
     turnButtonOff("toggleStates");
   }
@@ -775,9 +775,9 @@ function toggleBorders(event) {
   if (!layerIsOn("toggleBorders")) {
     turnButtonOn("toggleBorders");
     $('#borders').fadeIn();
-    if (event && event.ctrlKey) editStyle("borders");
+    if (event && isCtrlClick(event)) editStyle("borders");
   } else {
-    if (event && event.ctrlKey) {editStyle("borders"); return;}
+    if (event && isCtrlClick(event)) {editStyle("borders"); return;}
     turnButtonOff("toggleBorders");
     $('#borders').fadeOut();
   }  
@@ -787,9 +787,9 @@ function toggleProvinces(event) {
   if (!layerIsOn("toggleProvinces")) {
     turnButtonOn("toggleProvinces");
     drawProvinces();
-    if (event && event.ctrlKey) editStyle("provs");
+    if (event && isCtrlClick(event)) editStyle("provs");
   } else {
-    if (event && event.ctrlKey) {editStyle("provs"); return;}
+    if (event && isCtrlClick(event)) {editStyle("provs"); return;}
     provs.selectAll("*").remove();
     turnButtonOff("toggleProvinces");
   }
@@ -873,9 +873,9 @@ function toggleGrid(event) {
     turnButtonOn("toggleGrid");
     drawGrid();
     calculateFriendlyGridSize();
-    if (event && event.ctrlKey) editStyle("gridOverlay");
+    if (event && isCtrlClick(event)) editStyle("gridOverlay");
   } else {
-    if (event && event.ctrlKey) {editStyle("gridOverlay"); return;}
+    if (event && isCtrlClick(event)) {editStyle("gridOverlay"); return;}
     turnButtonOff("toggleGrid");
     gridOverlay.selectAll("*").remove();
   }
@@ -933,9 +933,9 @@ function toggleCoordinates(event) {
   if (!coordinates.selectAll("*").size()) {
     turnButtonOn("toggleCoordinates");
     drawCoordinates();
-    if (event && event.ctrlKey) editStyle("coordinates");
+    if (event && isCtrlClick(event)) editStyle("coordinates");
   } else {
-    if (event && event.ctrlKey) {editStyle("coordinates"); return;}
+    if (event && isCtrlClick(event)) {editStyle("coordinates"); return;}
     turnButtonOff("toggleCoordinates");
     coordinates.selectAll("*").remove();
   }
@@ -992,9 +992,9 @@ function toggleCompass(event) {
       svg.select("g#rose > g#sL > line#sL2").attr("x1", -19000).attr("x2", 19000);
       shiftCompass();
     }
-    if (event && event.ctrlKey) editStyle("compass");
+    if (event && isCtrlClick(event)) editStyle("compass");
   } else {
-    if (event && event.ctrlKey) {editStyle("compass"); return;}
+    if (event && isCtrlClick(event)) {editStyle("compass"); return;}
     $('#compass').fadeOut();
     turnButtonOff("toggleCompass");
   }
@@ -1005,9 +1005,9 @@ function toggleRelief(event) {
     turnButtonOn("toggleRelief");
     if (!terrain.selectAll("*").size()) ReliefIcons();
     $('#terrain').fadeIn();
-    if (event && event.ctrlKey) editStyle("terrain");
+    if (event && isCtrlClick(event)) editStyle("terrain");
   } else {
-    if (event && event.ctrlKey) {editStyle("terrain"); return;}
+    if (event && isCtrlClick(event)) {editStyle("terrain"); return;}
     $('#terrain').fadeOut();
     turnButtonOff("toggleRelief");
   }
@@ -1026,9 +1026,9 @@ function toggleTexture(event) {
     }
     $('#texture').fadeIn();
     zoom.scaleBy(svg, 1.00001); // enforce browser re-draw
-    if (event && event.ctrlKey) editStyle("texture");
+    if (event && isCtrlClick(event)) editStyle("texture");
   } else {
-    if (event && event.ctrlKey) {editStyle("texture"); return;}
+    if (event && isCtrlClick(event)) {editStyle("texture"); return;}
     $('#texture').fadeOut();
     turnButtonOff("toggleTexture");
   }
@@ -1038,9 +1038,9 @@ function toggleRivers(event) {
   if (!layerIsOn("toggleRivers")) {
     turnButtonOn("toggleRivers");
     $('#rivers').fadeIn();
-    if (event && event.ctrlKey) editStyle("rivers");
+    if (event && isCtrlClick(event)) editStyle("rivers");
   } else {
-    if (event && event.ctrlKey) {editStyle("rivers"); return;}
+    if (event && isCtrlClick(event)) {editStyle("rivers"); return;}
     $('#rivers').fadeOut();
     turnButtonOff("toggleRivers");
   }
@@ -1050,9 +1050,9 @@ function toggleRoutes(event) {
   if (!layerIsOn("toggleRoutes")) {
     turnButtonOn("toggleRoutes");
     $('#routes').fadeIn();
-    if (event && event.ctrlKey) editStyle("routes");
+    if (event && isCtrlClick(event)) editStyle("routes");
   } else {
-    if (event && event.ctrlKey) {editStyle("routes"); return;}
+    if (event && isCtrlClick(event)) {editStyle("routes"); return;}
     $('#routes').fadeOut();
     turnButtonOff("toggleRoutes");
   }
@@ -1062,9 +1062,9 @@ function toggleMarkers(event) {
   if (!layerIsOn("toggleMarkers")) {
     turnButtonOn("toggleMarkers");
     $('#markers').fadeIn();
-    if (event && event.ctrlKey) editStyle("markers");
+    if (event && isCtrlClick(event)) editStyle("markers");
   } else {
-    if (event && event.ctrlKey) {editStyle("markers"); return;}
+    if (event && isCtrlClick(event)) {editStyle("markers"); return;}
     $('#markers').fadeOut();
     turnButtonOff("toggleMarkers");
   }
@@ -1075,9 +1075,9 @@ function toggleLabels(event) {
     turnButtonOn("toggleLabels");
     labels.style("display", null)
     invokeActiveZooming();
-    if (event && event.ctrlKey) editStyle("labels");
+    if (event && isCtrlClick(event)) editStyle("labels");
   } else {
-    if (event && event.ctrlKey) {editStyle("labels"); return;}
+    if (event && isCtrlClick(event)) {editStyle("labels"); return;}
     turnButtonOff("toggleLabels");
     labels.style("display", "none");
   }
@@ -1087,9 +1087,9 @@ function toggleIcons(event) {
   if (!layerIsOn("toggleIcons")) {
     turnButtonOn("toggleIcons");
     $('#icons').fadeIn();
-    if (event && event.ctrlKey) editStyle("burgIcons");
+    if (event && isCtrlClick(event)) editStyle("burgIcons");
   } else {
-    if (event && event.ctrlKey) {editStyle("burgIcons"); return;}
+    if (event && isCtrlClick(event)) {editStyle("burgIcons"); return;}
     turnButtonOff("toggleIcons");
     $('#icons').fadeOut();
   }  
@@ -1099,9 +1099,9 @@ function toggleRulers(event) {
   if (!layerIsOn("toggleRulers")) {
     turnButtonOn("toggleRulers");
     $('#ruler').fadeIn();
-    if (event && event.ctrlKey) editStyle("ruler");
+    if (event && isCtrlClick(event)) editStyle("ruler");
   } else {
-    if (event && event.ctrlKey) {editStyle("ruler"); return;}
+    if (event && isCtrlClick(event)) {editStyle("ruler"); return;}
     $('#ruler').fadeOut();
     turnButtonOff("toggleRulers");
   }
@@ -1111,9 +1111,9 @@ function toggleScaleBar(event) {
   if (!layerIsOn("toggleScaleBar")) {
     turnButtonOn("toggleScaleBar");
     $('#scaleBar').fadeIn();
-    if (event && event.ctrlKey) editUnits();
+    if (event && isCtrlClick(event)) editUnits();
   } else {
-    if (event && event.ctrlKey) {editUnits(); return;}
+    if (event && isCtrlClick(event)) {editUnits(); return;}
     $('#scaleBar').fadeOut();
     turnButtonOff("toggleScaleBar");
   }
@@ -1123,9 +1123,9 @@ function toggleZones(event) {
   if (!layerIsOn("toggleZones")) {
     turnButtonOn("toggleZones");
     $('#zones').fadeIn();
-    if (event && event.ctrlKey) editStyle("zones");
+    if (event && isCtrlClick(event)) editStyle("zones");
   } else {
-    if (event && event.ctrlKey) {editStyle("zones"); return;}
+    if (event && isCtrlClick(event)) {editStyle("zones"); return;}
     turnButtonOff("toggleZones");
     $('#zones').fadeOut();
   }  

--- a/modules/ui/provinces-editor.js
+++ b/modules/ui/provinces-editor.js
@@ -194,7 +194,7 @@ function editProvinces() {
   function provinceOpenCOA(event, p) {
     const defSeed = `${seed}-p${p}`;
 
-    if (event.ctrlKey) {
+    if (isCtrlClick(event)) {
       const newSeed = prompt(`Please provide an Iron Arachne Heraldry Generator seed. `+ 
         `Default seed is a combination of FMG map seed and province id (${defSeed})`, pack.provinces[p].IAHG || defSeed);
       if (newSeed && newSeed != defSeed) pack.provinces[p].IAHG = newSeed; else return;

--- a/modules/ui/religions-editor.js
+++ b/modules/ui/religions-editor.js
@@ -414,7 +414,7 @@ function editReligions() {
     });
 
     function dragToReorigin(d) {
-      if (d3.event.sourceEvent.ctrlKey) {changeCode(d); return;}
+      if (isCtrlClick(d3.event.sourceEvent)) {changeCode(d); return;}
 
       const originLine = graph.append("path")
         .attr("class", "dragLine").attr("d", `M${d.x},${d.y}L${d.x},${d.y}`);

--- a/modules/ui/rivers-overview.js
+++ b/modules/ui/rivers-overview.js
@@ -81,7 +81,7 @@ function overviewRivers() {
   }
 
   function regenerateRiverName(event) {
-    if (!event.ctrlKey) return;
+    if (!isCtrlClick(event)) return;
     const river = +this.parentNode.dataset.id;
     const r = pack.rivers.find(r => r.i === river);
     r.name = this.value = this.parentNode.dataset.name = Rivers.getName(r.mouth);

--- a/modules/ui/states-editor.js
+++ b/modules/ui/states-editor.js
@@ -308,7 +308,7 @@ function editStates() {
   function stateOpenCOA(event, state) {
     const defSeed = `${seed}-s${state}`;
 
-    if (event.ctrlKey) {
+    if (isCtrlClick(event)) {
       const newSeed = prompt(`Please provide an Iron Arachne Heraldry Generator seed. `+ 
         `Default seed is a combination of FMG map seed and province id (${defSeed})`, pack.states[state].IAHG || defSeed);
       if (newSeed && newSeed != defSeed) pack.states[state].IAHG = newSeed; else return;

--- a/modules/ui/tools.js
+++ b/modules/ui/tools.js
@@ -241,7 +241,7 @@ function regenerateReligions() {
 function regenerateMarkers(event) {
   let number = gauss(1, .5, .3, 5, 2);
 
-  if (event.ctrlKey) {
+  if (isCtrlClick(event)) {
     const numberManual = prompt("Please provide markers number multiplier", 1);
     if (numberManual === null || numberManual === "" || isNaN(+numberManual)) {
       tip("The number provided is invalid, please try again and provide a valid number", false, "error", 4000);
@@ -263,7 +263,7 @@ function regenerateMarkers(event) {
 function regenerateZones(event) {
   let number = gauss(1, .5, .6, 5, 2);
 
-  if (event.ctrlKey) {
+  if (isCtrlClick(event)) {
     const numberManual = prompt("Please provide zones number multiplier", 1);
     if (numberManual === null || numberManual === "" || isNaN(+numberManual)) {
       tip("The number provided is invalid, please try again and provide a valid number", false, "error", 4000);

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -591,5 +591,10 @@ function link(URL, description) {
   return `<a href="${URL}" rel="noopener" target="_blank">${description}</a>`
 }
 
+function isCtrlClick(event) {
+  // meta key is cmd key on MacOs
+  return event.ctrlKey || event.metaKey;
+}
+
 // localStorageDB
 !function(){function e(t,o){return n?void(n.transaction("s").objectStore("s").get(t).onsuccess=function(e){var t=e.target.result&&e.target.result.v||null;o(t)}):void setTimeout(function(){e(t,o)},100)}var t=window.indexedDB||window.mozIndexedDB||window.webkitIndexedDB||window.msIndexedDB;if(!t)return void console.error("indexDB not supported");var n,o={k:"",v:""},r=t.open("d2",1);r.onsuccess=function(e){n=this.result},r.onerror=function(e){console.error("indexedDB request error"),console.log(e)},r.onupgradeneeded=function(e){n=null;var t=e.target.result.createObjectStore("s",{keyPath:"k"});t.transaction.oncomplete=function(e){n=e.target.db}},window.ldb={get:e,set:function(e,t){o.k=e,o.v=t,n.transaction("s","readwrite").objectStore("s").put(o)}}}();


### PR DESCRIPTION
I had the problem not being able to use the ctrl key on mac, as it will do a right click instead.