### PR TITLE
Fixed note-editor bug

### DIFF
--- a/modules/ui/notes-editor.js
+++ b/modules/ui/notes-editor.js
@@ -6,7 +6,7 @@ function editNotes(id, name) {
   for (const note of notes) {select.options.add(new Option(note.id, note.id));}
 
   // select an object
-  if (notes.length) {
+  if (notes.length || id) {
     if (!id) id = notes[0].id;
     let note = notes.find(note => note.id === id);
     if (note === undefined) {
@@ -19,10 +19,9 @@ function editNotes(id, name) {
     notesName.value = note.name;
     notesText.value = note.legend;
   } else {
-    if (!notes.length) {
-      const value = "There are no added notes. Click on element (e.g. label) and add a free text note";
-      document.getElementById("notesText").value = value;
-    }
+    const value = "There are no added notes. Click on element (e.g. label) and add a free text note";
+    document.getElementById("notesText").value = value;
+    document.getElementById("notesName").value = "";
   }
 
   // open a dialog

--- a/modules/ui/notes-editor.js
+++ b/modules/ui/notes-editor.js
@@ -53,12 +53,14 @@ function editNotes(id, name) {
   function changeName() {
     const id = document.getElementById("notesSelect").value;
     const note = notes.find(note => note.id === id);
+    if (!note) return;
     note.name = this.value;
   }
 
   function changeText() {
     const id = document.getElementById("notesSelect").value;
     const note = notes.find(note => note.id === id);
+    if (!note) return;
     note.legend = this.value;
   }
 


### PR DESCRIPTION
Based on the bug described in trello card (Bug: Deleting all markers removes Marker Elements) I found that an error would be raised when trying to add a new note for any element (not just markers) when there are no other notes present.
While normally the note-editor would register a new note element when adding a note to an object, this would not be the case when notes array is empty (see changed  line 9).
Because no note element would be registered, function changeText (and others) would try to reference non-existent note (see added checks), throw error and in result not register the note.