### PR TITLE
use map canvas size to save as PNG/JPG image

### DIFF
--- a/index.html
+++ b/index.html
@@ -3346,12 +3346,13 @@
     <div id="saveMapData" style="display: none" class="dialog">
       <div style="margin-bottom: .3em">Please select a saving variant:</div>
       <div>
-        <button onclick="saveMap()" data-tip="Download the map as fully-functional .map file to your machine">.map</button>
+        <!--<button onclick="saveMap()" data-tip="Download the map as fully-functional .map file to your machine">.map</button>
         <button onclick="saveSVG()" data-tip="Download the map as vector image (open in browser or Inkscape)">.svg</button>
         <button onclick="savePNG()" data-tip="Download visible part of the map as .png (lossless compressed)">.png</button>
         <button onclick="saveJPEG()" data-tip="Download visible part of the map as .jpeg (lossy compressed) image">.jpeg</button>
         <button onclick="saveGeoJSON()" data-tip="Download map data in GeoJSON format">.json</button>
-        <button onclick="quickSave()" data-tip="Save fully-functional map to browser storage. Shortcut: F6">storage</button>
+        <button onclick="quickSave()" data-tip="Save fully-functional map to browser storage. Shortcut: F6">storage</button>-->
+        <button onclick="customExport()" data-tip="Export to map to our game engine">export</button>
       </div>
       <p style="font-style: italic">Generator uses pop-up window to download files. Please ensure your browser does not block popups</p>
     </div>

--- a/modules/save-and-load.js
+++ b/modules/save-and-load.js
@@ -23,8 +23,9 @@ async function savePNG() {
   const link = document.createElement("a");
   const canvas = document.createElement("canvas");
   const ctx = canvas.getContext("2d");
-  canvas.width = svgWidth * pngResolutionInput.value;
-  canvas.height = svgHeight * pngResolutionInput.value;
+
+  canvas.width = mapWidthInput.value * pngResolutionInput.value;
+  canvas.height = mapHeightInput.value * pngResolutionInput.value;
   const img = new Image();
   img.src = url;
 
@@ -52,8 +53,8 @@ async function saveJPEG() {
   const url = await getMapURL("png");
 
   const canvas = document.createElement("canvas");
-  canvas.width = svgWidth * pngResolutionInput.value;
-  canvas.height = svgHeight * pngResolutionInput.value;
+  canvas.width = mapWidthInput.value * pngResolutionInput.value;
+  canvas.height = mapHeightInput.value * pngResolutionInput.value;
   const img = new Image();
   img.src = url;
 
@@ -75,10 +76,11 @@ async function saveJPEG() {
 
 // parse map svg to object url
 async function getMapURL(type, subtype) {
-  const cloneEl = document.getElementById("map").cloneNode(true); // clone svg
+  const cloneEl = document.getElementById("map").cloneNode(true); // clone svg  
   cloneEl.id = "fantasyMap";
   document.body.appendChild(cloneEl);
   const clone = d3.select(cloneEl);
+  clone.attr("width", mapWidthInput.value).attr("height", mapHeightInput.value);
   clone.select("#debug").remove();
 
   const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -598,3 +598,20 @@ function isCtrlClick(event) {
 
 // localStorageDB
 !function(){function e(t,o){return n?void(n.transaction("s").objectStore("s").get(t).onsuccess=function(e){var t=e.target.result&&e.target.result.v||null;o(t)}):void setTimeout(function(){e(t,o)},100)}var t=window.indexedDB||window.mozIndexedDB||window.webkitIndexedDB||window.msIndexedDB;if(!t)return void console.error("indexDB not supported");var n,o={k:"",v:""},r=t.open("d2",1);r.onsuccess=function(e){n=this.result},r.onerror=function(e){console.error("indexedDB request error"),console.log(e)},r.onupgradeneeded=function(e){n=null;var t=e.target.result.createObjectStore("s",{keyPath:"k"});t.transaction.oncomplete=function(e){n=e.target.db}},window.ldb={get:e,set:function(e,t){o.k=e,o.v=t,n.transaction("s","readwrite").objectStore("s").put(o)}}}();
+
+
+function copyStylesInline(destinationNode, sourceNode) {
+  var containerElements = ["svg", "g"];
+  for (var cd = 0; cd < destinationNode.childNodes.length; cd++) {
+    var child = destinationNode.childNodes[cd];
+    if (containerElements.indexOf(child.tagName) != -1) {
+      copyStylesInline(child, sourceNode.childNodes[cd]);
+      continue;
+    }
+    var style = sourceNode.childNodes[cd].style && (sourceNode.childNodes[cd].currentStyle || window.getComputedStyle(sourceNode.childNodes[cd]));
+    if (style == "undefined" || style == null) continue;
+    for (var st = 0; st < style.length; st++) {
+      child.style.setProperty(style[st], style.getPropertyValue(style[st]));
+    }
+  }
+}


### PR DESCRIPTION
The function to save as PNG/JPG image is using window's size which might not be useful for most situations. I suggest using the map canvas size (which users type in the Options UI) instead.

This PR resize the cloned SVG node and save the image file using the map canvas size.