### PR TITLE
Dev

### DIFF
--- a/modules/ui/rivers-editor.js
+++ b/modules/ui/rivers-editor.js
@@ -55,7 +55,7 @@ function editRiver(id) {
 
   function drawControlPoints(node) {
     const l = node.getTotalLength() / 2;
-    const segments = Math.ceil(l / 8);
+    const segments = Math.ceil(l / 4);
     const increment = rn(l / segments * 1e5);
     for (let i=increment*segments, c=i; i >= 0; i -= increment, c += increment) {
       const p1 = node.getPointAtLength(i / 1e5);
@@ -183,7 +183,7 @@ function editRiver(id) {
 
   function showElevationProfile() {
     modules.elevation = true;
-    showEPForRiver(node);
+    showEPForRiver(elSelected.node());
   }
 
   function showRiverWidth() {

--- a/modules/ui/routes-editor.js
+++ b/modules/ui/routes-editor.js
@@ -47,7 +47,7 @@ function editRoute(onClick) {
 
   function drawControlPoints(node) {
     const l = node.getTotalLength();
-    const increment = l / Math.ceil(l / 8);
+    const increment = l / Math.ceil(l / 4);
     for (let i=0; i <= l; i += increment) {addControlPoint(node.getPointAtLength(i));}
     routeLength.innerHTML = rn(l * distanceScaleInput.value) + " " + distanceUnitInput.value;
   }
@@ -110,7 +110,7 @@ function editRoute(onClick) {
 
   function showElevationProfile() {
     modules.elevation = true;
-    showEPForRoute(node);
+    showEPForRoute(elSelected.node());
   }
 
   function showGroupSection() {


### PR DESCRIPTION
I've added back the closeElevationProfile() function - I believe it's necessary to avoid the elevation profile popping up uncalled-for when editing route/river control points if you have already previously used the elevation profile.

I've doubled the number of control points on rivers and routes - I believe this is required to avoid missing a cell at higher point values.  Missing a cell means potentially missing a burg.

I've added the fixes for the node context in showElevationProfile() - it now uses elSelected.node().