### PR TITLE
added missing square brackets in json export

### DIFF
--- a/modules/save-and-load.js
+++ b/modules/save-and-load.js
@@ -352,7 +352,7 @@ function saveGeoJSON_Cells() {
     data += "      \"province\": \""+cells.province[i]+"\",\n";
     data += "      \"culture\": \""+cells.culture[i]+"\",\n";
     data += "      \"religion\": \""+cells.religion[i]+"\",\n";
-    data += "      \"neighbors\": "+cells.c[i]+"\n";
+    data += "      \"neighbors\": ["+cells.c[i]+"]\n";
     data +="   }\n},\n";
   });
 


### PR DESCRIPTION
I am very sorry, I accidentally broke the json export with my last pull request #464. The "neighbors" key was missing the square brackets around the values and so the generated json was actually invalid.