### PR TITLE
Add the ability to regenerate cultures

### DIFF
--- a/index.html
+++ b/index.html
@@ -1861,6 +1861,7 @@
           <button id="regenerateStates" data-tip="Click to select new capitals and regenerate states. Military forces will be regenerated as well, burgs will remain as they are">States</button>
           <button id="regenerateProvinces" data-tip="Click to regenerate provinces. States will remain as they are">Provinces</button>
           <button id="regenerateReligions" data-tip="Click to regenerate religions">Religions</button>
+          <button id="regenerateCultures" data-tip="Click to regenerate cultures">Cultures</button>
           <button id="regenerateMilitary" data-tip="Click to recalculate military forces based on current military options">Military</button>
           <button id="regenerateIce" data-tip="Click to icebergs and glaciers">Ice</button>
           <button id="regenerateMarkers" data-tip="Click to regenerate markers. Hold Ctrl and click to set markers number multiplier">Markers</button>
@@ -3456,7 +3457,7 @@
           <div data-tip="Military personnel rate (% of state population). Depends on war alert. Click to sort" style="width: 3.7em" class="sortable" data-sortby="rate">Rate&nbsp;</div>
           <div data-tip="War Alert. Modifier to military forces number, depends of political situation. Click to sort" class="sortable" data-sortby="alert">War Alert&nbsp;</div>
         </div>
-  
+
         <div id="militaryBody" data-type="absolute"></div>
       </div>
 
@@ -3486,7 +3487,7 @@
           <div data-tip="Regiment emblem and name. Click to sort by name" style="width: 12em" class="sortable alphabetically" data-sortby="name">Name&nbsp;</div>
           <div data-tip="Total military personnel (not considering crew). Click to sort" style="margin-left: .8em" id="regimentsTotal" class="sortable icon-sort-number-down" data-sortby="total">Total&nbsp;</div>
         </div>
-  
+
         <div id="regimentsBody" data-type="absolute"></div>
       </div>
 

--- a/modules/burgs-and-states.js
+++ b/modules/burgs-and-states.js
@@ -353,6 +353,31 @@
     console.timeEnd("normalizeStates");
   }
 
+  // Resets the cultures of all burgs and states to their
+  // cell or center cell's (respectively) culture.
+  const resetCultures = function () {
+    console.time('resetCulturesForBurgsAndStates');
+    // Pull out index 0 nodes so iterators don't touch them.
+    const burgTreeNode = pack.burgs.shift();
+    const neutralsStateNode = pack.states.shift();
+
+    // Assign the culture associated with the burgs cell.
+    pack.burgs = pack.burgs.map( (burg) => {
+      return {...burg, culture: pack.cells.culture[burg.cell]};
+    });
+
+    // Assign the culture associated with the states' center cell.
+    pack.states = pack.states.map( (state) => {
+      return {...state, culture: pack.cells.culture[state.center]};
+    });
+
+    // Prepend the index 0 nodes back onto the packgroups.
+    pack.burgs.unshift(burgTreeNode);
+    pack.states.unshift(neutralsStateNode);
+
+    console.timeEnd('resetCulturesForBurgsAndStates');
+  }
+
   // calculate and draw curved state labels for a list of states
   const drawStateLabels = function(list) {
     console.time("drawStateLabels");
@@ -1029,6 +1054,6 @@
 
   return {generate, expandStates, normalizeStates, assignColors,
     drawBurgs, specifyBurgs, defineBurgFeatures, drawStateLabels, collectStatistics,
-    generateCampaigns, generateDiplomacy, defineStateForms, getFullName, generateProvinces};
+    generateCampaigns, generateDiplomacy, defineStateForms, getFullName, generateProvinces, resetCultures};
 
 })));

--- a/modules/burgs-and-states.js
+++ b/modules/burgs-and-states.js
@@ -357,23 +357,24 @@
   // cell or center cell's (respectively) culture.
   const resetCultures = function () {
     console.time('resetCulturesForBurgsAndStates');
-    // Pull out index 0 nodes so iterators don't touch them.
-    const burgTreeNode = pack.burgs.shift();
-    const neutralsStateNode = pack.states.shift();
 
     // Assign the culture associated with the burgs cell.
-    pack.burgs = pack.burgs.map( (burg) => {
+    pack.burgs = pack.burgs.map( (burg, index) => {
+      // Ignore metadata burg
+      if(index === 0) {
+        return burg;
+      }
       return {...burg, culture: pack.cells.culture[burg.cell]};
     });
 
     // Assign the culture associated with the states' center cell.
-    pack.states = pack.states.map( (state) => {
+    pack.states = pack.states.map( (state, index) => {
+      // Ignore neutrals state
+      if(index === 0) {
+        return state;
+      }
       return {...state, culture: pack.cells.culture[state.center]};
     });
-
-    // Prepend the index 0 nodes back onto the packgroups.
-    pack.burgs.unshift(burgTreeNode);
-    pack.states.unshift(neutralsStateNode);
 
     console.timeEnd('resetCulturesForBurgsAndStates');
   }

--- a/modules/burgs-and-states.js
+++ b/modules/burgs-and-states.js
@@ -355,8 +355,8 @@
 
   // Resets the cultures of all burgs and states to their
   // cell or center cell's (respectively) culture.
-  const resetCultures = function () {
-    console.time('resetCulturesForBurgsAndStates');
+  const updateCultures = function () {
+    console.time('updateCulturesForBurgsAndStates');
 
     // Assign the culture associated with the burgs cell.
     pack.burgs = pack.burgs.map( (burg, index) => {
@@ -376,7 +376,7 @@
       return {...state, culture: pack.cells.culture[state.center]};
     });
 
-    console.timeEnd('resetCulturesForBurgsAndStates');
+    console.timeEnd('updateCulturesForBurgsAndStates');
   }
 
   // calculate and draw curved state labels for a list of states
@@ -1055,6 +1055,6 @@
 
   return {generate, expandStates, normalizeStates, assignColors,
     drawBurgs, specifyBurgs, defineBurgFeatures, drawStateLabels, collectStatistics,
-    generateCampaigns, generateDiplomacy, defineStateForms, getFullName, generateProvinces, resetCultures};
+    generateCampaigns, generateDiplomacy, defineStateForms, getFullName, generateProvinces, updateCultures};
 
 })));

--- a/modules/religions-generator.js
+++ b/modules/religions-generator.js
@@ -279,6 +279,17 @@
     });
   }
 
+  function updateCultures() {
+    console.time('updateCulturesForReligions');
+    pack.religions = pack.religions.map( (religion, index) => {
+      if(index === 0) {
+        return religion;
+      }
+      return {...religion, culture: pack.cells.culture[religion.center]};
+    });
+    console.timeEnd('updateCulturesForReligions');
+  }
+
   // assign a unique two-letters code (abbreviation)
   function getCode(rawName) {
     const name = rawName.replace("Old ", ""); // remove Old prefix
@@ -350,6 +361,6 @@
     return type() + " of the " + generateMeaning();
   };
 
-  return {generate, add, getDeityName, expandReligions};
+  return {generate, add, getDeityName, expandReligions, updateCultures};
 
 })));

--- a/modules/ui/cultures-editor.js
+++ b/modules/ui/cultures-editor.js
@@ -38,6 +38,7 @@ function editCultures() {
   function refreshCulturesEditor() {
     culturesCollectStatistics();
     culturesEditorAddLines();
+    drawCultureCenters();
   }
 
   function culturesCollectStatistics() {

--- a/modules/ui/editors.js
+++ b/modules/ui/editors.js
@@ -631,3 +631,16 @@ function selectIcon(initial, callback) {
     Close: function() {callback(initial); $(this).dialog("close")}}
   });
 }
+
+// Calls the refresh functionality on all editors currently open.
+function refreshAllEditors() {
+  console.time('refreshAllEditors');
+  if (document.getElementById('culturesEditorRefresh').offsetParent) culturesEditorRefresh.click();
+  if (document.getElementById('biomesEditorRefresh').offsetParent) biomesEditorRefresh.click();
+  if (document.getElementById('diplomacyEditorRefresh').offsetParent) diplomacyEditorRefresh.click();
+  if (document.getElementById('provincesEditorRefresh').offsetParent) provincesEditorRefresh.click();
+  if (document.getElementById('religionsEditorRefresh').offsetParent) religionsEditorRefresh.click();
+  if (document.getElementById('statesEditorRefresh').offsetParent) statesEditorRefresh.click();
+  if (document.getElementById('zonesEditorRefresh').offsetParent) zonesEditorRefresh.click();
+  console.timeEnd('refreshAllEditors');
+}

--- a/modules/ui/tools.js
+++ b/modules/ui/tools.js
@@ -248,8 +248,9 @@ function regenerateReligions() {
 function regenerateCultures() {
   Cultures.generate();
   Cultures.expand();
+  BurgsAndStates.resetCultures();
   if (!layerIsOn("toggleCultures")) toggleCultures(); else drawCultures();
-  if (document.getElementById("culturesEditorRefresh").offsetParent) culturesEditorRefresh.click();
+  refreshAllEditors();
 }
 
 function regenerateMilitary() {

--- a/modules/ui/tools.js
+++ b/modules/ui/tools.js
@@ -248,7 +248,8 @@ function regenerateReligions() {
 function regenerateCultures() {
   Cultures.generate();
   Cultures.expand();
-  BurgsAndStates.resetCultures();
+  BurgsAndStates.updateCultures();
+  Religions.updateCultures();
   if (!layerIsOn("toggleCultures")) toggleCultures(); else drawCultures();
   refreshAllEditors();
 }

--- a/modules/ui/tools.js
+++ b/modules/ui/tools.js
@@ -249,6 +249,7 @@ function regenerateCultures() {
   Cultures.generate();
   Cultures.expand();
   if (!layerIsOn("toggleCultures")) toggleCultures(); else drawCultures();
+  if (document.getElementById("culturesEditorRefresh").offsetParent) culturesEditorRefresh.click();
 }
 
 function regenerateMilitary() {

--- a/modules/ui/tools.js
+++ b/modules/ui/tools.js
@@ -55,15 +55,16 @@ toolsContent.addEventListener("click", function(event) {
 });
 
 function processFeatureRegeneration(event, button) {
-  if (button === "regenerateStateLabels") {BurgsAndStates.drawStateLabels(); if (!layerIsOn("toggleLabels")) toggleLabels();} else 
-  if (button === "regenerateReliefIcons") {ReliefIcons(); if (!layerIsOn("toggleRelief")) toggleRelief();} else 
-  if (button === "regenerateRoutes") {Routes.regenerate(); if (!layerIsOn("toggleRoutes")) toggleRoutes();} else 
+  if (button === "regenerateStateLabels") {BurgsAndStates.drawStateLabels(); if (!layerIsOn("toggleLabels")) toggleLabels();} else
+  if (button === "regenerateReliefIcons") {ReliefIcons(); if (!layerIsOn("toggleRelief")) toggleRelief();} else
+  if (button === "regenerateRoutes") {Routes.regenerate(); if (!layerIsOn("toggleRoutes")) toggleRoutes();} else
   if (button === "regenerateRivers") regenerateRivers(); else
   if (button === "regeneratePopulation") recalculatePopulation(); else
   if (button === "regenerateBurgs") regenerateBurgs(); else
   if (button === "regenerateStates") regenerateStates(); else
   if (button === "regenerateProvinces") regenerateProvinces(); else
   if (button === "regenerateReligions") regenerateReligions(); else
+  if (button === "regenerateCultures") regenerateCultures(); else
   if (button === "regenerateMilitary") regenerateMilitary(); else
   if (button === "regenerateIce") regenerateIce(); else
   if (button === "regenerateMarkers") regenerateMarkers(event); else
@@ -242,6 +243,12 @@ function regenerateProvinces() {
 function regenerateReligions() {
   Religions.generate();
   if (!layerIsOn("toggleReligions")) toggleReligions(); else drawReligions();
+}
+
+function regenerateCultures() {
+  Cultures.generate();
+  Cultures.expand();
+  if (!layerIsOn("toggleCultures")) toggleCultures(); else drawCultures();
 }
 
 function regenerateMilitary() {


### PR DESCRIPTION
- Addresses request #491
- Added a button to the tools menu for culture regeneration.
- Regeneration button will handle initial generation of new cultures and expansion afterwards.
- Pressing regenerate will warn the user.
- Culture regeneration will generate new cultural centers and redraw them.
- Burgs will adopt the new culture of the cell it occupies.
- States will adopt the culture of the cell where it's "center" is located.
- Religions will adopt the culture of the religious center.
- Regenerating cultures will refresh all open editors.