### PR TITLE
Change filename format of saved files

### DIFF
--- a/modules/ui/editors.js
+++ b/modules/ui/editors.js
@@ -546,12 +546,8 @@ function unfog(id) {
 function getFileName(dataType) {
   const name = mapName.value;
   const type = dataType ? dataType + " " : "";
-  const date = new Date();
-  const datFormatter = new Intl.DateTimeFormat("en", {month: "short", day: "numeric"});
-  const timeFormatter = new Intl.DateTimeFormat("ru", {hour: "numeric", minute: "numeric"});
-  const day = datFormatter.format(date).replace(" ", "");
-  const time = timeFormatter.format(date).replace(":", "-");
-  return name + " " + type + day + " " + time;
+  const dateString = new Date().toISOString().replace(/:[0-9]+\..*/, "").replaceAll(/[T:]/g, "-");
+  return name + " " + type + dateString;
 }
 
 function downloadFile(data, name, type = "text/plain") {


### PR DESCRIPTION
The following commit changes the default name of files saved by the
user. Originally, any saved file was named
`<map name> <capitalized three letter english month>D HH-mm.<ext>`
Now filenames follow more closely ISO 8601 and are named by default
`<map name> YYYY-MM-DD-HH-mm.<ext>`.

The function also became much smaller and easier to read.

This fixes #503 