### PR TITLE
Added RouteOpisometer and related changes.

### DIFF
--- a/icons.css
+++ b/icons.css
@@ -204,6 +204,7 @@
 .icon-chess-pawn:before {content:'\f443';} /* '' */
 .icon-chess-queen:before {content:'\f445';} /* '' */
 .icon-chess-rook:before {content:'\f447';} /* '' */
+/*.icon-route:before {content:'\f4d7';} /* '' */
 .icon-sign:before {content:'\f4d9';} /* '' */
 .icon-user-friends:before {content:'\f500';} /* '' */
 .icon-user-shield:before {content:'\f505';} /* '' */

--- a/icons.css
+++ b/icons.css
@@ -204,7 +204,6 @@
 .icon-chess-pawn:before {content:'\f443';} /* '' */
 .icon-chess-queen:before {content:'\f445';} /* '' */
 .icon-chess-rook:before {content:'\f447';} /* '' */
-/*.icon-route:before {content:'\f4d7';} /* '' */
 .icon-sign:before {content:'\f4d9';} /* '' */
 .icon-user-friends:before {content:'\f500';} /* '' */
 .icon-user-shield:before {content:'\f505';} /* '' */

--- a/index.html
+++ b/index.html
@@ -3099,6 +3099,11 @@
       <div id="unitsBottom">
         <button id="addLinearRuler" data-tip="Click to place a linear measurer (ruler)" class="icon-ruler"></button>
         <button id="addOpisometer" data-tip="Drag to measure a curve length (opisometer)" class="icon-drafting-compass"></button>
+        <button id="addRouteOpisometer" data-tip="Drag to measure a curve length that sticks to routes (route opisometer)" class="icon-route">
+          <svg width="1em" height="1em">
+            <use xlink:href="#icon-route" />
+          </svg>
+        </button>
         <button id="addPlanimeter" data-tip="Drag to measure a polygon area (planimeter)" class="icon-draw-polygon"></button>
         <button id="removeRulers" data-tip="Remove all rulers from the map. Click on ruler label to remove a ruler separately" class="icon-trash"></button>
         <button id="unitsRestore" data-tip="Restore default units settings" class="icon-ccw"></button>
@@ -3436,6 +3441,10 @@
       <symbol id="icon-anchor" viewBox="0 0 30 28">
         <title>Port</title>
         <path d="M15 4c0-0.547-0.453-1-1-1s-1 0.453-1 1 0.453 1 1 1 1-0.453 1-1zM28 18.5v5.5c0 0.203-0.125 0.391-0.313 0.469-0.063 0.016-0.125 0.031-0.187 0.031-0.125 0-0.25-0.047-0.359-0.141l-1.453-1.453c-2.453 2.953-6.859 4.844-11.688 4.844s-9.234-1.891-11.688-4.844l-1.453 1.453c-0.094 0.094-0.234 0.141-0.359 0.141-0.063 0-0.125-0.016-0.187-0.031-0.187-0.078-0.313-0.266-0.313-0.469v-5.5c0-0.281 0.219-0.5 0.5-0.5h5.5c0.203 0 0.391 0.125 0.469 0.313s0.031 0.391-0.109 0.547l-1.563 1.563c1.406 1.891 4.109 3.266 7.203 3.687v-10.109h-3c-0.547 0-1-0.453-1-1v-2c0-0.547 0.453-1 1-1h3v-2.547c-1.188-0.688-2-1.969-2-3.453 0-2.203 1.797-4 4-4s4 1.797 4 4c0 1.484-0.812 2.766-2 3.453v2.547h3c0.547 0 1 0.453 1 1v2c0 0.547-0.453 1-1 1h-3v10.109c3.094-0.422 5.797-1.797 7.203-3.687l-1.563-1.563c-0.141-0.156-0.187-0.359-0.109-0.547s0.266-0.313 0.469-0.313h5.5c0.281 0 0.5 0.219 0.5 0.5z"></path>
+      </symbol>
+
+      <symbol id="icon-route" viewBox="0 0 512 512">
+        <path d="M416 320h-96c-17.6 0-32-14.4-32-32s14.4-32 32-32h96s96-107 96-160-43-96-96-96-96 43-96 96c0 25.5 22.2 63.4 45.3 96H320c-52.9 0-96 43.1-96 96s43.1 96 96 96h96c17.6 0 32 14.4 32 32s-14.4 32-32 32H185.5c-16 24.8-33.8 47.7-47.3 64H416c52.9 0 96-43.1 96-96s-43.1-96-96-96zm0-256c17.7 0 32 14.3 32 32s-14.3 32-32 32-32-14.3-32-32 14.3-32 32-32zM96 256c-53 0-96 43-96 96s96 160 96 160 96-107 96-160-43-96-96-96zm0 128c-17.7 0-32-14.3-32-32s14.3-32 32-32 32 14.3 32 32-14.3 32-32 32z"></path>
       </symbol>
 
       <g id="defs-relief">

--- a/index.html
+++ b/index.html
@@ -1938,7 +1938,7 @@
 
           <div data-tip="Burg mean annual temperature and real-world city for comparison">
             <div class="label">Temperature:</div>
-            <span id="burgTemperature"></span>, like in
+            <span id="burgTemperature"></span>, like in 
             <span id="burgTemperatureLikeIn"></span>
           </div>
 

--- a/index.html
+++ b/index.html
@@ -1938,7 +1938,7 @@
 
           <div data-tip="Burg mean annual temperature and real-world city for comparison">
             <div class="label">Temperature:</div>
-            <span id="burgTemperature"></span>, like in 
+            <span id="burgTemperature"></span>, like in
             <span id="burgTemperatureLikeIn"></span>
           </div>
 
@@ -3099,8 +3099,8 @@
       <div id="unitsBottom">
         <button id="addLinearRuler" data-tip="Click to place a linear measurer (ruler)" class="icon-ruler"></button>
         <button id="addOpisometer" data-tip="Drag to measure a curve length (opisometer)" class="icon-drafting-compass"></button>
-        <button id="addRouteOpisometer" data-tip="Drag to measure a curve length that sticks to routes (route opisometer)" class="icon-route">
-          <svg width="1em" height="1em">
+        <button id="addRouteOpisometer" data-tip="Drag to measure a curve length that sticks to routes (route opisometer)">
+          <svg width="0.88em" height="0.88em">
             <use xlink:href="#icon-route" />
           </svg>
         </button>

--- a/modules/ui/measurers.js
+++ b/modules/ui/measurers.js
@@ -20,7 +20,7 @@ class Rulers {
     for (const rulerString of rulers) {
       const [type, pointsString] = rulerString.split(": ");
       const points = pointsString.split(" ").map(el => el.split(",").map(n => +n));
-      const Type = type === "Ruler" ? Ruler : 
+      const Type = type === "Ruler" ? Ruler :
                    type === "Opisometer" ? Opisometer :
                    type === "RouteOpisometer" ? RouteOpisometer :
                    type === "Planimeter" ? Planimeter : null;
@@ -326,12 +326,13 @@ class RouteOpisometer extends Measurer {
   trackCell(cell, rigth) {
     this.checkCellStops();
     const cellStops = this.cellStops;
+    const foundIndex = cellStops.indexOf(cell);
     if (rigth) {
       if (last(cellStops) === cell) {
         return;
-      } else if (cellStops.length > 1 && cellStops[cellStops.length - 2] === cell) {
-        cellStops.pop();
-        this.points.pop();
+      } else if (cellStops.length > 1 && foundIndex != -1) {
+        cellStops.splice(foundIndex + 1);
+        this.points.splice(foundIndex + 1);
         this.updateCurve();
         this.updateLabel();
        } else {
@@ -340,13 +341,12 @@ class RouteOpisometer extends Measurer {
         this.updateCurve();
         this.updateLabel();
       }
-    }
-    else {
+    } else {
       if (cellStops[0] === cell) {
         return;
-      } else if (cellStops.length > 1 && cellStops[1] === cell) {
-        cellStops.shift();
-        this.points.shift();
+      } else if (cellStops.length > 1 && foundIndex != -1) {
+        cellStops.splice(0, foundIndex);
+        this.points.splice(0, foundIndex);
         this.updateCurve();
         this.updateLabel();
        } else {
@@ -361,14 +361,10 @@ class RouteOpisometer extends Measurer {
   getCellRouteCoord(c) {
     const cells = pack.cells;
     const burgs = pack.burgs;
-    if (cells.road[c]) {
-      const b = cells.burg[c];
-      const x = b ? burgs[b].x : cells.p[c][0];
-      const y = b ? burgs[b].y : cells.p[c][1];
-      return [x, y];
-    } else {
-      return null;
-    }
+    const b = cells.burg[c];
+    const x = b ? burgs[b].x : cells.p[c][0];
+    const y = b ? burgs[b].y : cells.p[c][1];
+    return [x, y];
   }
 
   draw() {
@@ -377,7 +373,7 @@ class RouteOpisometer extends Measurer {
     const dash = this.getDash();
     const context = this;
 
-    const el = this.el = ruler.append("g").attr("class", "opisometer")/*.call(d3.drag().on("start", this.drag))*/.attr("font-size", 10 * size);
+    const el = this.el = ruler.append("g").attr("class", "opisometer").attr("font-size", 10 * size);
     el.append("path").attr("class", "white").attr("stroke-width", size);
     el.append("path").attr("class", "gray").attr("stroke-width", size).attr("stroke-dasharray", dash);
     const rulerPoints = el.append("g").attr("class", "rulerPoints").attr("stroke-width", .5 * size).attr("font-size", 2 * size);
@@ -414,7 +410,7 @@ class RouteOpisometer extends Measurer {
       const cells = pack.cells;
 
       const c = findCell(mousePoint[0], mousePoint[1]);
-      if (!cells.road[c]) {
+      if (!cells.road[c] && !d3.event.sourceEvent.shiftKey) {
         return;
       }
 

--- a/modules/ui/measurers.js
+++ b/modules/ui/measurers.js
@@ -333,13 +333,9 @@ class RouteOpisometer extends Measurer {
       } else if (cellStops.length > 1 && foundIndex != -1) {
         cellStops.splice(foundIndex + 1);
         this.points.splice(foundIndex + 1);
-        this.updateCurve();
-        this.updateLabel();
-       } else {
+      } else {
         cellStops.push(cell);
         this.points.push(this.getCellRouteCoord(cell));
-        this.updateCurve();
-        this.updateLabel();
       }
     } else {
       if (cellStops[0] === cell) {
@@ -347,15 +343,13 @@ class RouteOpisometer extends Measurer {
       } else if (cellStops.length > 1 && foundIndex != -1) {
         cellStops.splice(0, foundIndex);
         this.points.splice(0, foundIndex);
-        this.updateCurve();
-        this.updateLabel();
-       } else {
+      } else {
         cellStops.unshift(cell);
         this.points.unshift(this.getCellRouteCoord(cell));
-        this.updateCurve();
-        this.updateLabel();
       }
     }
+    this.updateCurve();
+    this.updateLabel();
   }
 
   getCellRouteCoord(c) {

--- a/modules/ui/units-editor.js
+++ b/modules/ui/units-editor.js
@@ -178,7 +178,7 @@ function editUnits() {
     heightExponentInput.value = heightExponentOutput.value = 1.8;
     localStorage.removeItem("heightExponent");
     calculateTemperatures();
-    
+
     // scale bar
     barSizeOutput.value = barSize.value = 2;
     barLabel.value = "";
@@ -250,7 +250,7 @@ function editUnits() {
       this.classList.remove("pressed");
     } else {
       if (!layerIsOn("toggleRulers")) toggleRulers();
-      tip("Draw a curve along routes to measure length", true);
+      tip("Draw a curve along routes to measure length. Hold Shift to measure away from roads.", true);
       unitsBottom.querySelectorAll(".pressed").forEach(button => button.classList.remove("pressed"));
       this.classList.add("pressed");
       viewbox.style("cursor", "crosshair").call(d3.drag().on("start", function() {
@@ -258,7 +258,7 @@ function editUnits() {
         const burgs = pack.burgs;
         const point = d3.mouse(this);
         const c = findCell(point[0], point[1]);
-        if (cells.road[c]) {
+        if (cells.road[c] || d3.event.sourceEvent.shiftKey) {
           const b = cells.burg[c];
           const x = b ? burgs[b].x : cells.p[c][0];
           const y = b ? burgs[b].y : cells.p[c][1];
@@ -267,11 +267,7 @@ function editUnits() {
           d3.event.on("drag", function () {
             const point = d3.mouse(this);
             const c = findCell(point[0], point[1]);
-            if (cells.road[c]) {
-              /*const b = cells.burg[c];
-              const x = b ? burgs[b].x : cells.p[c][0];
-              const y = b ? burgs[b].y : cells.p[c][1];
-              routeOpisometer.addPoint([x, y]);*/
+            if (cells.road[c] || d3.event.sourceEvent.shiftKey) {
               routeOpisometer.trackCell(c, true);
             }
           });


### PR DESCRIPTION
This new tool lets you draw an opisometer that always sticks to cells that have routes and you can drag it backward to "undo" that part of the route. It works on main roads, trails, and sea routes.

Changes:
===
Adds RouteOpisometer class based on Opisometer

Adds button to Units dialog to draw new route opisometer
Adds SVG symbol "icon-route" for the button

Adds commented out CSS icon entry for if FontAwesome is updated in the future

I am not very familiar with web development and I strongly dislike JavaScript but I did my best to match your existing code style. 

Closes #605