### PR TITLE
Added a lock function to burgs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1972,6 +1972,7 @@
         <button id="burgEditEmblem" data-tip="Edit emblem" class="icon-shield-alt"></button>
         <button id="burgRelocate" data-tip="Relocate burg" class="icon-target"></button>
         <button id="burglLegend" data-tip="Edit free text notes (legend) for this burg" class="icon-edit"></button>
+        <button id="burgLock" data-tip="Lock or Unlock this burg" class="icon-lock-open"></button>
         <button id="burgRemove" data-tip="Remove non-capital burg. Shortcut: Delete" class="icon-trash fastDelete"></button>
       </div>
     </div>
@@ -3358,7 +3359,7 @@
       <div id="options3dBottom" style="margin-top: .2em">
         <button id="options3dUpdate" data-tip="Update the scene" class="icon-cw"></button>
         <button data-tip="Configure world and map size and climate settings" onclick="editWorld()" class="icon-globe"></button>
-        <button id="options3dSave" data-tip="Save screenshot of the 3d scene" class="icon-button-screenshot"></button>
+		<button id="options3dSave" data-tip="Save screenshot of the 3d scene" class="icon-button-screenshot"></button>
         <button id="options3dOBJSave" data-tip="Save OBJ file of the 3d scene" class="icon-download"></button>
       </div>
     </div>
@@ -4133,4 +4134,3 @@
   <script defer src="libs/pell.min.js"></script>
 </body>
 </html>
-

--- a/index.html
+++ b/index.html
@@ -1313,7 +1313,7 @@
           <button id="regeneratePopulation" data-tip="Click to recalculate rural and urban population">Population</button>
           <button id="regenerateStates" data-tip="Click to select new capitals and regenerate states. Emblems and military forces will be regenerated as well, burgs will remain as they are">States</button>
           <button id="regenerateProvinces" data-tip="Click to regenerate provinces. States will remain as they are">Provinces</button>
-          <button id="regenerateBurgs" data-tip="Click to regenerate all burgs and routes. States will remain as they are">Burgs</button>
+          <button id="regenerateBurgs" data-tip="Click to regenerate all unlocked burgs and routes. States will remain as they are">Burgs</button>
           <button id="regenerateEmblems" data-tip="Click to regenerate all emblems">Emblems</button>
           <button id="regenerateReligions" data-tip="Click to regenerate religions">Religions</button>
           <button id="regenerateCultures" data-tip="Click to regenerate cultures">Cultures</button>
@@ -1972,7 +1972,7 @@
         <button id="burgEditEmblem" data-tip="Edit emblem" class="icon-shield-alt"></button>
         <button id="burgRelocate" data-tip="Relocate burg" class="icon-target"></button>
         <button id="burglLegend" data-tip="Edit free text notes (legend) for this burg" class="icon-edit"></button>
-        <button id="burgLock" data-tip="Lock or Unlock this burg" class="icon-lock-open"></button>
+        <button id="burgLock" class="icon-lock-open"></button>
         <button id="burgRemove" data-tip="Remove non-capital burg. Shortcut: Delete" class="icon-trash fastDelete"></button>
       </div>
     </div>
@@ -3143,7 +3143,7 @@
         <button id="addNewBurg" data-tip="Add a new burg. Hold Shift to add multiple" class="icon-plus"></button>
         <button id="burgsExport" data-tip="Save burgs-related data as a text file (.csv)" class="icon-download"></button>
         <button id="burgNamesImport" data-tip="Rename burgs in bulk" class="icon-upload"></button>
-        <button id="burgsRemoveAll" data-tip="Remove all burgs except for capitals. To remove a capital remove its state first" class="icon-trash"></button>
+        <button id="burgsRemoveAll" data-tip="Remove all unlocked burgs except for capitals. To remove a capital remove its state first" class="icon-trash"></button>
       </div>
     </div>
 

--- a/modules/burgs-and-states.js
+++ b/modules/burgs-and-states.js
@@ -145,7 +145,7 @@
     const cells = pack.cells, vertices = pack.vertices, features = pack.features, temp = grid.cells.temp;
 
     for (const b of pack.burgs) {
-      if (!b.i) continue;
+      if (!b.i || b.lock) continue;
       const i = b.cell;
 
       // asign port status to some coastline burgs with temp > 0 °C

--- a/modules/ui/burg-editor.js
+++ b/modules/ui/burg-editor.js
@@ -48,6 +48,7 @@ function editBurg(id) {
   document.getElementById("burgEditEmblem").addEventListener("click", openEmblemEdit);
   document.getElementById("burgRelocate").addEventListener("click", toggleRelocateBurg);
   document.getElementById("burglLegend").addEventListener("click", editBurgLegend);
+  document.getElementById("burgLock").addEventListener("click", toggleBurgLockButton);
   document.getElementById("burgRemove").addEventListener("click", removeSelectedBurg);
 
   function updateBurgValues() {
@@ -89,6 +90,9 @@ function editBurg(id) {
     else document.getElementById("burgTemple").classList.add("inactive");
     if (b.shanty) document.getElementById("burgShanty").classList.remove("inactive");
     else document.getElementById("burgShanty").classList.add("inactive");
+
+    //toggle lock
+    updateBurgLockIcon();
 
     // select group
     const group = elSelected.node().parentNode.id;
@@ -297,6 +301,20 @@ function editBurg(id) {
 
     if (b.port) document.getElementById("burgEditAnchorStyle").style.display = "inline-block";
     else document.getElementById("burgEditAnchorStyle").style.display = "none";
+  }
+
+  function toggleBurgLockButton() {
+    const id = +elSelected.attr("data-id");
+    toggleBurgLock(id);
+    updateBurgLockIcon();
+  }
+
+  function updateBurgLockIcon() {
+    const id = +elSelected.attr("data-id");
+    const b = pack.burgs[id];
+    if (b.lock) {document.getElementById("burgLock").classList.remove("icon-lock-open"); document.getElementById("burgLock").classList.add("icon-lock");}
+    else {document.getElementById("burgLock").classList.remove("icon-lock"); document.getElementById("burgLock").classList.add("icon-lock-open");}
+
   }
 
   function showStyleSection() {

--- a/modules/ui/burg-editor.js
+++ b/modules/ui/burg-editor.js
@@ -49,6 +49,7 @@ function editBurg(id) {
   document.getElementById("burgRelocate").addEventListener("click", toggleRelocateBurg);
   document.getElementById("burglLegend").addEventListener("click", editBurgLegend);
   document.getElementById("burgLock").addEventListener("click", toggleBurgLockButton);
+  document.getElementById("burgLock").addEventListener("mouseover", showBurgELockTip);
   document.getElementById("burgRemove").addEventListener("click", removeSelectedBurg);
 
   function updateBurgValues() {
@@ -224,12 +225,12 @@ function editBurg(id) {
     for (let i=0; i < group.children.length; i++) {
       burgsInGroup.push(+group.children[i].dataset.id);
     }
-    const burgsToRemove = burgsInGroup.filter(b => !pack.burgs[b].capital);
+    const burgsToRemove = burgsInGroup.filter(b => !(pack.burgs[b].capital || pack.burgs[b].lock));
     const capital = burgsToRemove.length < burgsInGroup.length;
 
     alertMessage.innerHTML = `Are you sure you want to remove
-      ${basic || capital ? "all elements in the group" : "the entire burg group"}?
-      <br>Please note that capital burgs will not be deleted.
+      ${basic || capital ? "all unlocked elements in the group" : "the entire burg group"}?
+      <br>Please note that capital or locked burgs will not be deleted.
       <br><br>Burgs to be removed: ${burgsToRemove.length}`;
     $("#alert").dialog({resizable: false, title: "Remove route group",
       buttons: {
@@ -315,6 +316,11 @@ function editBurg(id) {
     if (b.lock) {document.getElementById("burgLock").classList.remove("icon-lock-open"); document.getElementById("burgLock").classList.add("icon-lock");}
     else {document.getElementById("burgLock").classList.remove("icon-lock"); document.getElementById("burgLock").classList.add("icon-lock-open");}
 
+  }
+
+  function showBurgELockTip() {
+    const id = +elSelected.attr("data-id");
+    showBurgLockTip(id);
   }
 
   function showStyleSection() {

--- a/modules/ui/burgs-overview.js
+++ b/modules/ui/burgs-overview.js
@@ -86,7 +86,7 @@ function overviewBurgs() {
           <span data-tip="Click to toggle port status" class="icon-anchor pointer${b.port ? '' : ' inactive'}" style="font-size:.9em"></span>
         </div>
         <span data-tip="Edit burg" class="icon-pencil"></span>
-        <span data-tip="Lock Burg" class="locks   ${b.lock ? 'icon-lock' : 'icon-lock-open inactive'}"></span>
+        <span class="locks pointer  ${b.lock ? 'icon-lock' : 'icon-lock-open inactive'}"></span>
         <span data-tip="Remove burg" class="icon-trash-empty"></span>
       </div>`;
     }
@@ -106,6 +106,7 @@ function overviewBurgs() {
     body.querySelectorAll("div > span.icon-star-empty").forEach(el => el.addEventListener("click", toggleCapitalStatus));
     body.querySelectorAll("div > span.icon-anchor").forEach(el => el.addEventListener("click", togglePortStatus));
     body.querySelectorAll("div > span.locks").forEach(el => el.addEventListener("click", toggleBurgLockStatus));
+    body.querySelectorAll("div > span.locks").forEach(el => el.addEventListener("mouseover", showBurgOLockTip));
     body.querySelectorAll("div > span.icon-pencil").forEach(el => el.addEventListener("click", openBurgEditor));
     body.querySelectorAll("div > span.icon-trash-empty").forEach(el => el.addEventListener("click", triggerBurgRemove));
 
@@ -185,6 +186,11 @@ function overviewBurgs() {
     toggleBurgLock(burg);
     if (this.classList.contains("icon-lock")) {this.classList.remove("icon-lock"); this.classList.add("icon-lock-open"); this.classList.add("inactive");}
     else {this.classList.remove("icon-lock-open"); this.classList.add("icon-lock"); this.classList.remove("inactive");}
+  }
+
+  function showBurgOLockTip() {
+    const burg = +this.parentNode.dataset.id;
+    showBurgLockTip(burg);
   }
 
   function openBurgEditor() {
@@ -467,7 +473,7 @@ function overviewBurgs() {
   }
 
   function triggerAllBurgsRemove() {
-    alertMessage.innerHTML = `Are you sure you want to remove all burgs except of capitals?
+    alertMessage.innerHTML = `Are you sure you want to remove all unlocked burgs except for capitals?
       <br><i>To remove a capital you have to remove a state first</i>`;
     $("#alert").dialog({resizable: false, title: "Remove all burgs",
       buttons: {

--- a/modules/ui/burgs-overview.js
+++ b/modules/ui/burgs-overview.js
@@ -86,6 +86,7 @@ function overviewBurgs() {
           <span data-tip="Click to toggle port status" class="icon-anchor pointer${b.port ? '' : ' inactive'}" style="font-size:.9em"></span>
         </div>
         <span data-tip="Edit burg" class="icon-pencil"></span>
+        <span data-tip="Lock Burg" class="locks   ${b.lock ? 'icon-lock' : 'icon-lock-open inactive'}"></span>
         <span data-tip="Remove burg" class="icon-trash-empty"></span>
       </div>`;
     }
@@ -104,6 +105,7 @@ function overviewBurgs() {
     body.querySelectorAll("div > input.burgPopulation").forEach(el => el.addEventListener("change", changeBurgPopulation));
     body.querySelectorAll("div > span.icon-star-empty").forEach(el => el.addEventListener("click", toggleCapitalStatus));
     body.querySelectorAll("div > span.icon-anchor").forEach(el => el.addEventListener("click", togglePortStatus));
+    body.querySelectorAll("div > span.locks").forEach(el => el.addEventListener("click", toggleBurgLockStatus));
     body.querySelectorAll("div > span.icon-pencil").forEach(el => el.addEventListener("click", openBurgEditor));
     body.querySelectorAll("div > span.icon-trash-empty").forEach(el => el.addEventListener("click", triggerBurgRemove));
 
@@ -178,6 +180,13 @@ function overviewBurgs() {
     else this.classList.add("inactive");
   }
 
+  function toggleBurgLockStatus() {
+    const burg = +this.parentNode.dataset.id;
+    toggleBurgLock(burg);
+    if (this.classList.contains("icon-lock")) {this.classList.remove("icon-lock"); this.classList.add("icon-lock-open"); this.classList.add("inactive");}
+    else {this.classList.remove("icon-lock-open"); this.classList.add("icon-lock"); this.classList.remove("inactive");}
+  }
+
   function openBurgEditor() {
     const burg = +this.parentNode.dataset.id;
     editBurg(burg);
@@ -203,11 +212,14 @@ function overviewBurgs() {
   function regenerateNames() {
     body.querySelectorAll(":scope > div").forEach(function(el) {
       const burg = +el.dataset.id;
+      //if (pack.burgs[burg].lock) return;
       const culture = pack.burgs[burg].culture;
       const name = Names.getCulture(culture);
-      el.querySelector(".burgName").value = name;
-      pack.burgs[burg].name = el.dataset.name = name;
-      burgLabels.select("[data-id='" + burg + "']").text(name);
+      if (!pack.burgs[burg].lock) {
+        el.querySelector(".burgName").value = name;
+        pack.burgs[burg].name = el.dataset.name = name;
+        burgLabels.select("[data-id='" + burg + "']").text(name);
+      }
     });
   }
 
@@ -469,7 +481,7 @@ function overviewBurgs() {
   }
 
   function removeAllBurgs() {
-    pack.burgs.filter(b => b.i && !b.capital).forEach(b => removeBurg(b.i));
+    pack.burgs.filter(b => b.i && !(b.capital || b.lock)).forEach(b => removeBurg(b.i));
     burgsOverviewAddLines();
   }
 }

--- a/modules/ui/cultures-editor.js
+++ b/modules/ui/cultures-editor.js
@@ -335,7 +335,7 @@ function editCultures() {
   function cultureRegenerateBurgs() {
     if (customization === 4) return;
     const culture = +this.parentNode.dataset.id;
-    const cBurgs = pack.burgs.filter(b => b.culture === culture);
+    const cBurgs = pack.burgs.filter(b => b.culture === culture && !b.lock);
     cBurgs.forEach(b => {
       b.name = Names.getCulture(culture);
       labels.select("[data-id='" + b.i +"']").text(b.name);

--- a/modules/ui/editors.js
+++ b/modules/ui/editors.js
@@ -226,6 +226,15 @@ function toggleBurgLock(burg) {
   b.lock = b.lock ? 0 : 1;
 }
 
+function showBurgLockTip(burg) {
+  const b = pack.burgs[burg];
+  if (b.lock) {
+    tip("Click to Unlock burg and allow it to be change by regeneration tools");
+  } else {
+    tip("Click to Lock burg and prevent changes by regeneration tools");
+  }
+}
+
 // draw legend box
 function drawLegend(name, data) {
   legend.selectAll("*").remove(); // fully redraw every time

--- a/modules/ui/editors.js
+++ b/modules/ui/editors.js
@@ -221,6 +221,11 @@ function togglePort(burg) {
     .attr("width", size).attr("height", size);
 }
 
+function toggleBurgLock(burg) {
+  const b = pack.burgs[burg];
+  b.lock = b.lock ? 0 : 1;
+}
+
 // draw legend box
 function drawLegend(name, data) {
   legend.selectAll("*").remove(); // fully redraw every time

--- a/modules/ui/tools.js
+++ b/modules/ui/tools.js
@@ -103,7 +103,7 @@ function regenerateRivers() {
 function recalculatePopulation() {
   rankCells();
   pack.burgs.forEach(b => {
-    if (!b.i || b.removed) return;
+    if (!b.i || b.removed || b.lock) return;
     const i = b.cell;
 
     b.population = rn(Math.max((pack.cells.s[i] + pack.cells.road[i] / 2) / 8 + b.i / 1000 + i % 100 / 1000, .1), 3);
@@ -224,7 +224,7 @@ function regenerateProvinces() {
 }
 
 function regenerateBurgs() {
-  const cells = pack.cells, states = pack.states;
+  const cells = pack.cells, states = pack.states, Lockedburgs = pack.burgs.filter(b =>b.lock);
   rankCells();
   cells.burg = new Uint16Array(cells.i.length);
   const burgs = pack.burgs = [0]; // clear burgs array
@@ -236,6 +236,19 @@ function regenerateBurgs() {
   const sorted = cells.i.filter(i => score[i] > 0 && cells.culture[i]).sort((a, b) => score[b] - score[a]); // filtered and sorted array of indexes
   const burgsCount = manorsInput.value == 1000 ? rn(sorted.length / 5 / (grid.points.length / 10000) ** .8) + states.length : +manorsInput.value + states.length;
   const spacing = (graphWidth + graphHeight) / 150 / (burgsCount ** .7 / 66); // base min distance between towns
+
+  //clear locked list since ids will change
+  //burglock.selectAll("text").remove();
+  for (let j=0; j < Lockedburgs.length; j++) {
+    const id = burgs.length;
+    const oldBurg = Lockedburgs[j];
+    oldBurg.i = id;
+    burgs.push(oldBurg);
+    burgsTree.add([oldBurg.x, oldBurg.y]);
+    cells.burg[oldBurg.cell] = id;
+    if (oldBurg.capital) {states[oldBurg.state].capital = id; states[oldBurg.state].center = oldBurg.cell;}
+    //burglock.append("text").attr("data-id", id);
+  }
 
   for (let i=0; i < sorted.length && burgs.length < burgsCount; i++) {
     const id = burgs.length;


### PR DESCRIPTION
This adds a burg lock feature which can be accessed from the "burgs overview" and "burg editor" windows seen below.
![Walkthrough1](https://user-images.githubusercontent.com/1015483/112576783-f646bb80-8dc0-11eb-8af2-a8ea93f69755.png)
![Walkthrough3](https://user-images.githubusercontent.com/1015483/112576790-f9da4280-8dc0-11eb-888b-3e88ce712836.png)

The primary use is to keep selected burgs when using the regenerate Burgs feature. 
Other uses include:

- Locked burgs will not be renamed by the "regenerate burg names" in the burgs overview window
- Will not be deleted when using the remove all burgs option in the burgs overview window
- Will not have their population changed by regenerate population tool

Locked burgs can still be modified in the following ways:

- Will still be deleted if the group they are assigned to is removed
- Groups will still be re-assigned by regenerating burgs or states
- Capital status may still be changed by regenerating states
- Culture can still be changed
- The seed for Medieval Fantasy City Generator will be changed unless a custom one is set
- Emblems will sometimes change or stay the same depending on the order in which you change the culture and state, Regenerating Emblems will always change the emblem.
