### PR TITLE
Update State, Province, Burg exports to have both short and long names for State, Province

### DIFF
--- a/modules/ui/burgs-overview.js
+++ b/modules/ui/burgs-overview.js
@@ -454,8 +454,8 @@ function overviewBurgs() {
       data += b.i + ",";
       data += b.name + ",";
       const province = pack.cells.province[b.cell];
-      data += province ? pack.provinces[province].fullName + "," : ",";
-      data += b.state ? pack.states[b.state].fullName + "," : pack.states[b.state].name + ",";
+      data += province ? pack.provinces[province].name + "," : ",";
+      data += pack.states[b.state].name + ",";
       data += pack.cultures[b.culture].name + ",";
       data += pack.religions[pack.cells.religion[b.cell]].name + ",";
       data += rn(b.population * populationRate * urbanization) + ",";

--- a/modules/ui/burgs-overview.js
+++ b/modules/ui/burgs-overview.js
@@ -447,7 +447,7 @@ function overviewBurgs() {
   }
 
   function downloadBurgsData() {
-    let data = "Id,Burg,Province,State,Culture,Religion,Population,Longitude,Latitude,Elevation (" + heightUnit.value + "),Capital,Port,Citadel,Walls,Plaza,Temple,Shanty Town\n"; // headers
+    let data = "Id,Burg,Province,Province Full Name,State,State Full Name,Culture,Religion,Population,Longitude,Latitude,Elevation (" + heightUnit.value + "),Capital,Port,Citadel,Walls,Plaza,Temple,Shanty Town\n"; // headers
     const valid = pack.burgs.filter(b => b.i && !b.removed); // all valid burgs
 
     valid.forEach(b => {
@@ -455,7 +455,9 @@ function overviewBurgs() {
       data += b.name + ",";
       const province = pack.cells.province[b.cell];
       data += province ? pack.provinces[province].name + "," : ",";
+      data += province ? pack.provinces[province].fullName + "," : ",";
       data += pack.states[b.state].name + ",";
+      data += pack.states[b.state].fullName + ",";
       data += pack.cultures[b.culture].name + ",";
       data += pack.religions[pack.cells.religion[b.cell]].name + ",";
       data += rn(b.population * populationRate * urbanization) + ",";

--- a/modules/ui/provinces-editor.js
+++ b/modules/ui/provinces-editor.js
@@ -934,20 +934,22 @@ function editProvinces() {
 
   function downloadProvincesData() {
     const unit = areaUnit.value === "square" ? distanceUnitInput.value + "2" : areaUnit.value;
-    let data = "Id,Province,Form,State,Color,Capital,Area " + unit + ",Total Population,Rural Population,Urban Population\n"; // headers
+    let data = "Id,Province,Full Name,Form,State,Color,Capital,Area " + unit + ",Total Population,Rural Population,Urban Population\n"; // headers
 
     body.querySelectorAll(":scope > div").forEach(function (el) {
-      let key = parseInt(el.dataset.id);
+      const key = parseInt(el.dataset.id);
+      const provincePack = pack.provinces[key];
       data += el.dataset.id + ",";
       data += el.dataset.name + ",";
+      data += provincePack.fullName + ",";
       data += el.dataset.form + ",";
       data += el.dataset.state + ",";
       data += el.dataset.color + ",";
       data += el.dataset.capital + ",";
       data += el.dataset.area + ",";
       data += el.dataset.population + ",";
-      data += `${Math.round(pack.provinces[key].rural * populationRate)},`;
-      data += `${Math.round(pack.provinces[key].urban * populationRate * urbanization)}\n`;
+      data += `${Math.round(provincePack.rural * populationRate)},`;
+      data += `${Math.round(provincePack.urban * populationRate * urbanization)}\n`;
     });
 
     const name = getFileName("Provinces") + ".csv";

--- a/modules/ui/states-editor.js
+++ b/modules/ui/states-editor.js
@@ -1028,12 +1028,13 @@ function editStates() {
 
   function downloadStatesData() {
     const unit = areaUnit.value === "square" ? distanceUnitInput.value + "2" : areaUnit.value;
-    let data = "Id,State,Form,Color,Capital,Culture,Type,Expansionism,Cells,Burgs,Area " + unit + ",Total Population,Rural Population,Urban Population\n"; // headers
-
+    let data = "Id,State,Full Name,Form,Color,Capital,Culture,Type,Expansionism,Cells,Burgs,Area " + unit + ",Total Population,Rural Population,Urban Population\n"; // headers
     body.querySelectorAll(":scope > div").forEach(function (el) {
       const key = parseInt(el.dataset.id);
+      const statePack = pack.states[key];
       data += el.dataset.id + ",";
       data += el.dataset.name + ",";
+      data += (statePack.fullName ? statePack.fullName : "") + ",";
       data += el.dataset.form + ",";
       data += el.dataset.color + ",";
       data += el.dataset.capital + ",";
@@ -1044,8 +1045,8 @@ function editStates() {
       data += el.dataset.burgs + ",";
       data += el.dataset.area + ",";
       data += el.dataset.population + ",";
-      data += `${Math.round(pack.states[key].rural * populationRate)},`;
-      data += `${Math.round(pack.states[key].urban * populationRate * urbanization)}\n`;
+      data += `${Math.round(statePack.rural * populationRate)},`;
+      data += `${Math.round(statePack.urban * populationRate * urbanization)}\n`;
     });
 
     const name = getFileName("States") + ".csv";


### PR DESCRIPTION
Currently the export of Burg data uses the full name for both Province and State. This change makes them use the short name for each. This brings it in line with the exports for State and Province, both of which only include the short name. This makes it possible to cross-reference the exported Burg data with the exported State and Province data.