### PR TITLE
Attempt to rehabilitate taverns

### DIFF
--- a/modules/routes-generator.js
+++ b/modules/routes-generator.js
@@ -218,6 +218,7 @@ window.Routes = (function () {
             cells.crossroad[current] += score;
           }
         }
+        cells.crossroad[current] += score;
         segment = [];
         prev = current;
       } else {


### PR DESCRIPTION
I noticed that taverns and inns were in the generation code, yet I've never seen them on a map. The reason seems to be that no tiles ever get marked as "crossroads". There are, of course, two solutions - remove the "crossroads" requirement, or make crossroads start working.

The former results in inns dotted along major routes, and the latter results in inns appearing at crossroads, most of which are ports.

Both have their appeal, but I've gone for the latter.  I'm not sure what the general preferences are, or even whether inns were left in a seemingly non-functioning state on purpose.

So feel free to ignore this pull request if it's not a desirable change.