### PR TITLE
Changed text on burg group delete

### DIFF
--- a/modules/ui/burg-editor.js
+++ b/modules/ui/burg-editor.js
@@ -281,12 +281,12 @@ function editBurg(id) {
     const capital = burgsToRemove.length < burgsInGroup.length;
 
     alertMessage.innerHTML = `Are you sure you want to remove
-      ${basic || capital ? "all unlocked elements in the group" : "the entire burg group"}?
+      ${basic || capital ? "all unlocked elements in the burg group" : "the entire burg group"}?
       <br>Please note that capital or locked burgs will not be deleted.
       <br><br>Burgs to be removed: ${burgsToRemove.length}`;
     $("#alert").dialog({
       resizable: false,
-      title: "Remove route group",
+      title: "Remove burg group",
       buttons: {
         Remove: function () {
           $(this).dialog("close");


### PR DESCRIPTION
The caption for the delete burg group confirmation window currently shows "Remove route group", and should show "Remove burg group".  
The text when at least one element is locked should also say "burg group" and not just "group".

