### PR TITLE
Added lock/unlock all

### DIFF
--- a/index.html
+++ b/index.html
@@ -3284,8 +3284,7 @@
         <button id="addNewBurg" data-tip="Add a new burg. Hold Shift to add multiple" class="icon-plus"></button>
         <button id="burgsExport" data-tip="Save burgs-related data as a text file (.csv)" class="icon-download"></button>
         <button id="burgNamesImport" data-tip="Rename burgs in bulk" class="icon-upload"></button>
-		<button id="burgsLockAll" data-tip="Lock all burgs" class="icon-lock"></button>
-		<button id="burgsUnlockAll" data-tip="Unlock all burgs" class="icon-lock-open-alt"></button>
+        <button id="burgsonoff" data-tip="Lock / Unlock all burgs" class="icon-lock" value="Off"></button>
         <button id="burgsRemoveAll" data-tip="Remove all unlocked burgs except for capitals. To remove a capital remove its state first" class="icon-trash"></button>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -3284,7 +3284,7 @@
         <button id="addNewBurg" data-tip="Add a new burg. Hold Shift to add multiple" class="icon-plus"></button>
         <button id="burgsExport" data-tip="Save burgs-related data as a text file (.csv)" class="icon-download"></button>
         <button id="burgNamesImport" data-tip="Rename burgs in bulk" class="icon-upload"></button>
-        <button id="burgsonoff" data-tip="Lock / Unlock all burgs" class="icon-lock" value="Off"></button>
+        <button id="burgsonoff" data-tip="Lock / Unlock all burgs" class="icon-lock"></button>
         <button id="burgsRemoveAll" data-tip="Remove all unlocked burgs except for capitals. To remove a capital remove its state first" class="icon-trash"></button>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -3284,6 +3284,8 @@
         <button id="addNewBurg" data-tip="Add a new burg. Hold Shift to add multiple" class="icon-plus"></button>
         <button id="burgsExport" data-tip="Save burgs-related data as a text file (.csv)" class="icon-download"></button>
         <button id="burgNamesImport" data-tip="Rename burgs in bulk" class="icon-upload"></button>
+		<button id="burgsLockAll" data-tip="Lock all burgs" class="icon-lock"></button>
+		<button id="burgsUnlockAll" data-tip="Unlock all burgs" class="icon-lock-open-alt"></button>
         <button id="burgsRemoveAll" data-tip="Remove all unlocked burgs except for capitals. To remove a capital remove its state first" class="icon-trash"></button>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -3284,7 +3284,7 @@
         <button id="addNewBurg" data-tip="Add a new burg. Hold Shift to add multiple" class="icon-plus"></button>
         <button id="burgsExport" data-tip="Save burgs-related data as a text file (.csv)" class="icon-download"></button>
         <button id="burgNamesImport" data-tip="Rename burgs in bulk" class="icon-upload"></button>
-        <button id="burgsonoff" data-tip="Lock / Unlock all burgs" class="icon-lock"></button>
+        <button id="burgsLockAll" data-tip="Lock / Unlock all burgs" class="icon-lock"></button>
         <button id="burgsRemoveAll" data-tip="Remove all unlocked burgs except for capitals. To remove a capital remove its state first" class="icon-trash"></button>
       </div>
     </div>

--- a/modules/ui/burgs-overview.js
+++ b/modules/ui/burgs-overview.js
@@ -33,6 +33,8 @@ function overviewBurgs() {
   document.getElementById("burgsListToLoad").addEventListener("change", function () {
     uploadFile(this, importBurgNames);
   });
+  document.getElementById("burgsLockAll").addEventListener("click", lockAllBurgs);
+  document.getElementById("burgsUnlockAll").addEventListener("click", unlockAllBurgs);
   document.getElementById("burgsRemoveAll").addEventListener("click", triggerAllBurgsRemove);
   document.getElementById("burgsInvertLock").addEventListener("click", invertLock);
 
@@ -87,7 +89,7 @@ function overviewBurgs() {
         <input data-tip="Burg name. Click and type to change" class="burgName" value="${b.name}" autocorrect="off" spellcheck="false">
         <input data-tip="Burg province" class="burgState" value="${province}" disabled>
         <input data-tip="Burg state" class="burgState" value="${state}" disabled>
-        <select data-tip="Dominant culture. Click to change burg culture (to change cell cultrure use Cultures Editor)" class="stateCulture">${getCultureOptions(
+        <select data-tip="Dominant culture. Click to change burg culture (to change cell culture use Cultures Editor)" class="stateCulture">${getCultureOptions(
           b.culture
         )}</select>
         <span data-tip="Burg population" class="icon-male"></span>
@@ -561,5 +563,13 @@ function overviewBurgs() {
   function invertLock() {
     pack.burgs = pack.burgs.map(burg => ({...burg, lock: !burg.lock}));
     burgsOverviewAddLines();
+  }
+  function lockAllBurgs() {
+    pack.burgs = pack.burgs.map(burg => ({...burg, lock: burg.lock = true})); 
+    burgsOverviewAddLines();
+  }
+  function unlockAllBurgs() {
+    pack.burgs = pack.burgs.map(burg => ({...burg, lock: burg.lock = false}));
+   burgsOverviewAddLines();
   }
 }

--- a/modules/ui/burgs-overview.js
+++ b/modules/ui/burgs-overview.js
@@ -565,11 +565,13 @@ function overviewBurgs() {
     burgsOverviewAddLines();
   }
   function lockAllBurgs() {
-    pack.burgs = pack.burgs.map(burg => ({...burg, lock: burg.lock = true})); 
+	pack.burgs.forEach(burg => {
+		burg.lock = true;});
     burgsOverviewAddLines();
   }
   function unlockAllBurgs() {
-    pack.burgs = pack.burgs.map(burg => ({...burg, lock: burg.lock = false}));
+	pack.burgs.forEach(burg => {
+		burg.lock = false;});
    burgsOverviewAddLines();
   }
 }

--- a/modules/ui/burgs-overview.js
+++ b/modules/ui/burgs-overview.js
@@ -568,12 +568,15 @@ function overviewBurgs() {
   
   function lockAllBurgs() {
 	pack.burgs.forEach(burg => {
-		burg.lock = true;});
+		burg.lock = true;
+		});
     burgsOverviewAddLines();
   }
+  
   function unlockAllBurgs() {
 	pack.burgs.forEach(burg => {
-		burg.lock = false;});
+		burg.lock = false;
+		});
     burgsOverviewAddLines();
   }
   

--- a/modules/ui/burgs-overview.js
+++ b/modules/ui/burgs-overview.js
@@ -8,6 +8,7 @@ function overviewBurgs() {
   const body = document.getElementById("burgsBody");
   updateFilter();
   burgsOverviewAddLines();
+  setlockburgs();
   $("#burgsOverview").dialog();
 
   if (modules.overviewBurgs) return;
@@ -36,6 +37,12 @@ function overviewBurgs() {
   document.getElementById("burgsonoff").addEventListener("click", burgsonoff);
   document.getElementById("burgsRemoveAll").addEventListener("click", triggerAllBurgsRemove);
   document.getElementById("burgsInvertLock").addEventListener("click", invertLock);
+  document.getElementById("burgsonoff").addEventListener("click", function (toggleIcons) {
+  var target = toggleIcons.target;
+
+    target.classList.toggle("icon-lock");
+    target.classList.toggle("icon-lock-open");
+    }, false);
 
   function refreshBurgsEditor() {
     updateFilter();
@@ -558,11 +565,16 @@ function overviewBurgs() {
     pack.burgs.filter(b => b.i && !(b.capital || b.lock)).forEach(b => removeBurg(b.i));
     burgsOverviewAddLines();
   }
+  
+  function setlockburgs() {
+    (pack.burgs.filter(b => b.lock)).length === pack.burgs.length ? burgsonoff.value = "true" : burgsonoff.value = "false"; //Only true if all of them are locked
+  }
 
   function invertLock() {
     pack.burgs = pack.burgs.map(burg => ({...burg, lock: !burg.lock}));
     burgsOverviewAddLines();
   }
+  
   function lockAllBurgs() {
 	pack.burgs.forEach(burg => {
 		burg.lock = true;});
@@ -571,16 +583,16 @@ function overviewBurgs() {
   function unlockAllBurgs() {
 	pack.burgs.forEach(burg => {
 		burg.lock = false;});
-   burgsOverviewAddLines();
+    burgsOverviewAddLines();
   }
   function burgsonoff(){
-  const currentvalue = document.getElementById('burgsonoff').value;
-  if(currentvalue == "Off"){
-	lockAllBurgs();
-	document.getElementById("burgsonoff").value="On";
-  }else{
+	const currentvalue = document.getElementById('burgsonoff').value;
+  if(currentvalue == "true"){
 	unlockAllBurgs();
-	document.getElementById("burgsonoff").value="Off";
+	document.getElementById("burgsonoff").value="false";
+  }else{
+	lockAllBurgs();
+	document.getElementById("burgsonoff").value="true";
        }
   }
 }

--- a/modules/ui/burgs-overview.js
+++ b/modules/ui/burgs-overview.js
@@ -8,7 +8,7 @@ function overviewBurgs() {
   const body = document.getElementById("burgsBody");
   updateFilter();
   burgsOverviewAddLines();
-  setlockburgs();
+  setLockIcon();
   $("#burgsOverview").dialog();
 
   if (modules.overviewBurgs) return;
@@ -34,15 +34,10 @@ function overviewBurgs() {
   document.getElementById("burgsListToLoad").addEventListener("change", function () {
     uploadFile(this, importBurgNames);
   });
-  document.getElementById("burgsonoff").addEventListener("click", burgsonoff);
+  document.getElementById("burgsLockAll").addEventListener("click", setLockBurgs);
+  document.getElementById("burgsLockAll").addEventListener("click", setLockIcon);
   document.getElementById("burgsRemoveAll").addEventListener("click", triggerAllBurgsRemove);
   document.getElementById("burgsInvertLock").addEventListener("click", invertLock);
-  document.getElementById("burgsonoff").addEventListener("click", function (toggleIcons) {
-  var target = toggleIcons.target;
-
-    target.classList.toggle("icon-lock");
-    target.classList.toggle("icon-lock-open");
-    }, false);
 
   function refreshBurgsEditor() {
     updateFilter();
@@ -565,10 +560,6 @@ function overviewBurgs() {
     pack.burgs.filter(b => b.i && !(b.capital || b.lock)).forEach(b => removeBurg(b.i));
     burgsOverviewAddLines();
   }
-  
-  function setlockburgs() {
-    (pack.burgs.filter(b => b.lock)).length === pack.burgs.length ? burgsonoff.value = "true" : burgsonoff.value = "false"; //Only true if all of them are locked
-  }
 
   function invertLock() {
     pack.burgs = pack.burgs.map(burg => ({...burg, lock: !burg.lock}));
@@ -585,14 +576,27 @@ function overviewBurgs() {
 		burg.lock = false;});
     burgsOverviewAddLines();
   }
-  function burgsonoff(){
-	const currentvalue = document.getElementById('burgsonoff').value;
-  if(currentvalue == "true"){
-	unlockAllBurgs();
-	document.getElementById("burgsonoff").value="false";
-  }else{
-	lockAllBurgs();
-	document.getElementById("burgsonoff").value="true";
-       }
+  
+  function setLockBurgs() {
+    const allLocked = pack.burgs.every(({lock, i, removed}) => lock || !i || removed);
+
+    if (allLocked) {
+    unlockAllBurgs();
+    } else {
+    lockAllBurgs();
+           }
+    setLockIcon();
+  }
+  
+  function setLockIcon() {
+	const allLocked = pack.burgs.every(({lock, i, removed}) => lock || !i || removed);
+
+	if (allLocked) {
+      burgsLockAll.classList.remove("icon-lock");
+      burgsLockAll.classList.add("icon-lock-open");
+    } else {
+      burgsLockAll.classList.add("icon-lock");
+      burgsLockAll.classList.remove("icon-lock-open");  
+         }
   }
 }

--- a/modules/ui/burgs-overview.js
+++ b/modules/ui/burgs-overview.js
@@ -33,8 +33,7 @@ function overviewBurgs() {
   document.getElementById("burgsListToLoad").addEventListener("change", function () {
     uploadFile(this, importBurgNames);
   });
-  document.getElementById("burgsLockAll").addEventListener("click", lockAllBurgs);
-  document.getElementById("burgsUnlockAll").addEventListener("click", unlockAllBurgs);
+  document.getElementById("burgsonoff").addEventListener("click", burgsonoff);
   document.getElementById("burgsRemoveAll").addEventListener("click", triggerAllBurgsRemove);
   document.getElementById("burgsInvertLock").addEventListener("click", invertLock);
 
@@ -573,5 +572,15 @@ function overviewBurgs() {
 	pack.burgs.forEach(burg => {
 		burg.lock = false;});
    burgsOverviewAddLines();
+  }
+  function burgsonoff(){
+  const currentvalue = document.getElementById('burgsonoff').value;
+  if(currentvalue == "Off"){
+	lockAllBurgs();
+	document.getElementById("burgsonoff").value="On";
+  }else{
+	unlockAllBurgs();
+	document.getElementById("burgsonoff").value="Off";
+       }
   }
 }


### PR DESCRIPTION
Lock All , Unlock All as separate buttons. Additionally to InvertLock.
People might sometimes want to lock all burgs again after adding new ones. Sometimes simply unlock all if only some are locked, instead of checking one by one.
InvertLock is untouched. Has same icon and functionality.

Use case by an user:
I locked all my burgs, forgot that, then added some more. To lock all of them again, i had to hunt through the burg overview to find the more recently added ones.

Having separate buttons is a QOL update.