### PR TITLE
fillrect pointer to 1.5em

### DIFF
--- a/modules/ui/biomes-editor.js
+++ b/modules/ui/biomes-editor.js
@@ -94,7 +94,7 @@ function editBiomes() {
 
       lines += `<div class="states biomes" data-id="${i}" data-name="${b.name[i]}" data-habitability="${b.habitability[i]}"
       data-cells=${b.cells[i]} data-area=${area} data-population=${population} data-color=${b.color[i]}>
-        <svg data-tip="Biomes fill style. Click to change" width=".9em" height=".9em" style="margin-bottom:-1px"><rect x="0" y="0" width="100%" height="100%" fill="${
+        <svg data-tip="Biomes fill style. Click to change" width="1.5em" height="1.5em" style="margin-bottom:-5px"><rect x="0" y="0" width="100%" height="100%" fill="${
           b.color[i]
         }" class="fillRect pointer"></svg>
         <input data-tip="Biome name. Click and type to change" class="biomeName" value="${b.name[i]}" autocorrect="off" spellcheck="false">
@@ -270,7 +270,7 @@ function editBiomes() {
 
     const unit = areaUnit.value === "square" ? " " + distanceUnitInput.value + "²" : " " + areaUnit.value;
     const line = `<div class="states biomes" data-id="${i}" data-name="${b.name[i]}" data-habitability=${b.habitability[i]} data-cells=0 data-area=0 data-population=0 data-color=${b.color[i]}>
-      <svg data-tip="Biomes fill style. Click to change" width=".9em" height=".9em" style="margin-bottom:-1px"><rect x="0" y="0" width="100%" height="100%" fill="${b.color[i]}" class="fillRect pointer"></svg>
+      <svg data-tip="Biomes fill style. Click to change" width="1.5em" height="1.5em" style="margin-bottom:-5px"><rect x="0" y="0" width="100%" height="100%" fill="${b.color[i]}" class="fillRect pointer"></svg>
       <input data-tip="Biome name. Click and type to change" class="biomeName" value="${b.name[i]}" autocorrect="off" spellcheck="false">
       <span data-tip="Biome habitability percent" class="hide">%</span>
       <input data-tip="Biome habitability percent. Click and set new value to change" type="number" min=0 max=9999 step=1 class="biomeHabitability hide" value=${b.habitability[i]}>

--- a/modules/ui/states-editor.js
+++ b/modules/ui/states-editor.js
@@ -132,7 +132,7 @@ function editStates() {
         data-area=${area} data-population=${population} data-burgs=${s.burgs} data-culture=${pack.cultures[s.culture].name} data-type=${
         s.type
       } data-expansionism=${s.expansionism}>
-        <svg data-tip="State fill style. Click to change" width=".9em" height=".9em" style="margin-bottom:-1px"><rect x="0" y="0" width="100%" height="100%" fill="${
+        <svg data-tip="State fill style. Click to change" width="1.5em" height="1.5em" style="margin-bottom:-5px"><rect x="0" y="0" width="100%" height="100%" fill="${
           s.color
         }" class="fillRect pointer"></svg>
         <input data-tip="State name. Click to change" class="stateName name pointer" value="${s.name}" readonly>


### PR DESCRIPTION
Increased the size of the rectangles for states and biomes from 0.9em to 1.5em
With rectangles slightly bigger, they can be seen better, and the boundbox for clicking inside is bigger. This makes it essier to click and open the color picker dialog.