### PR TITLE
fix exact multiple error for spacing

### DIFF
--- a/main.js
+++ b/main.js
@@ -760,8 +760,8 @@ function placePoints() {
   const spacing = (grid.spacing = rn(Math.sqrt((graphWidth * graphHeight) / cellsDesired), 2)); // spacing between points before jirrering
   grid.boundary = getBoundaryPoints(graphWidth, graphHeight, spacing);
   grid.points = getJitteredGrid(graphWidth, graphHeight, spacing); // jittered square grid
-  grid.cellsX = Math.floor((graphWidth + 0.5 * spacing) / spacing);
-  grid.cellsY = Math.floor((graphHeight + 0.5 * spacing) / spacing);
+  grid.cellsX = Math.floor((graphWidth + 0.5 * spacing - 1e-10) / spacing);
+  grid.cellsY = Math.floor((graphHeight + 0.5 * spacing - 1e-10) / spacing);
   TIME && console.timeEnd("placePoints");
 }
 


### PR DESCRIPTION
Fix annoying bug where FMG crushes for specific canvas size / cell-count ratios. 2 lines change for 2 hours of debugging. :-D
(Problem: if there is no remainder for spacing/2+width , cellsX calculation is wrong  (one more column) which causes Array overflow.)
