### PR TITLE
align with the spec: no implicit ids

### DIFF
--- a/modules/ui/general.js
+++ b/modules/ui/general.js
@@ -202,10 +202,10 @@ function showMapTooltip(point, e, i, g) {
     const province = pack.cells.province[i];
     const prov = province ? pack.provinces[province].fullName + ", " : "";
     tip(prov + stateName);
-    if (statesEditor?.offsetParent) highlightEditorLine(statesEditor, state);
-    if (diplomacyEditor?.offsetParent) highlightEditorLine(diplomacyEditor, state);
-    if (militaryOverview?.offsetParent) highlightEditorLine(militaryOverview, state);
-    if (provincesEditor?.offsetParent) highlightEditorLine(provincesEditor, province);
+    if (document.getElementById('statesEditor')?.offsetParent) highlightEditorLine(statesEditor, state);
+    if (document.getElementById('diplomacyEditor')?.offsetParent) highlightEditorLine(diplomacyEditor, state);
+    if (document.getElementById('militaryOverview')?.offsetParent) highlightEditorLine(militaryOverview, state);
+    if (document.getElementById('provincesEditor')?.offsetParent) highlightEditorLine(provincesEditor, province);
   } else if (layerIsOn("toggleCultures") && pack.cells.culture[i]) {
     const culture = pack.cells.culture[i];
     tip("Culture: " + pack.cultures[culture].name);


### PR DESCRIPTION
In strict mode there can not be undefined variables. We are using implicit id vars  (variables implicitly declared by DomElement ids) which is deprecated and should be avoided. Normally it causes no problems (most browsers are supporting it (yet)) but with loadable modules this approach is failing. 

Before module load implicit variables are undefined which causes error messages (correctly) on firefox. (Current) chrome is lazy but future versions might not.

BTW we are using document.getElementById many many places (1112 occurances), probably it's a good idea to introduce some standardized shortcut like const id=document.getElementById as a utility function.