### PR TITLE
Data Charts screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -1967,6 +1967,13 @@
 
           <p>Click to overview:</p>
           <div>
+            <button
+              id="overviewChartsButton"
+              data-tip="Click to open Charts to overview cells data"
+              data-shortcut="Shift + A"
+            >
+              Charts
+            </button>
             <button id="overviewBurgsButton" data-tip="Click to open Burgs Overview" data-shortcut="Shift + T">
               Burgs
             </button>

--- a/index.html
+++ b/index.html
@@ -108,14 +108,9 @@
       }
     </style>
 
-    <link rel="preload" href="index.css?v=12062022" as="style" onload="this.onload=null; this.rel='stylesheet'" />
-    <link rel="preload" href="icons.css?v=04062022" as="style" onload="this.onload=null; this.rel='stylesheet'" />
-    <link
-      rel="preload"
-      href="libs/jquery-ui.css?v=04062022"
-      as="style"
-      onload="this.onload=null; this.rel='stylesheet'"
-    />
+    <link rel="preload" href="index.css" as="style" onload="this.onload=null; this.rel='stylesheet'" />
+    <link rel="preload" href="icons.css" as="style" onload="this.onload=null; this.rel='stylesheet'" />
+    <link rel="preload" href="libs/jquery-ui.css" as="style" onload="this.onload=null; this.rel='stylesheet'" />
   </head>
   <body>
     <svg
@@ -7786,89 +7781,89 @@
 
     <script src="utils/shorthands.js"></script>
     <script src="utils/commonUtils.js"></script>
-    <script src="utils/arrayUtils.js?v=02062022"></script>
+    <script src="utils/arrayUtils.js"></script>
     <script src="utils/colorUtils.js"></script>
-    <script src="utils/graphUtils.js?v=02062022"></script>
+    <script src="utils/graphUtils.js"></script>
     <script src="utils/nodeUtils.js"></script>
     <script src="utils/numberUtils.js"></script>
     <script src="utils/polyfills.js"></script>
-    <script src="utils/probabilityUtils.js?v=29052022"></script>
-    <script src="utils/stringUtils.js?v=04062022"></script>
+    <script src="utils/probabilityUtils.js"></script>
+    <script src="utils/stringUtils.js"></script>
     <script src="utils/languageUtils.js"></script>
-    <script src="utils/unitUtils.js"></script>
+    <script src="utils/unitUtils.js?v=1.87.00"></script>
 
     <script src="modules/voronoi.js"></script>
     <script src="config/heightmap-templates.js"></script>
     <script src="config/precreated-heightmaps.js"></script>
-    <script src="modules/heightmap-generator.js?v=29052020"></script>
-    <script src="modules/ocean-layers.js?v=29052022"></script>
+    <script src="modules/heightmap-generator.js"></script>
+    <script src="modules/ocean-layers.js"></script>
     <script src="modules/river-generator.js"></script>
     <script src="modules/lakes.js"></script>
     <script src="modules/names-generator.js"></script>
-    <script src="modules/cultures-generator.js?v=06062022"></script>
-    <script src="modules/burgs-and-states.js?v=29052022"></script>
+    <script src="modules/cultures-generator.js"></script>
+    <script src="modules/burgs-and-states.js"></script>
     <script src="modules/routes-generator.js"></script>
-    <script src="modules/religions-generator.js?v=12062022"></script>
+    <script src="modules/religions-generator.js"></script>
     <script src="modules/military-generator.js"></script>
     <script src="modules/markers-generator.js"></script>
     <script src="modules/coa-generator.js"></script>
-    <script src="modules/submap.js?v=02062022"></script>
+    <script src="modules/submap.js"></script>
     <script src="libs/polylabel.min.js"></script>
     <script src="libs/lineclip.min.js"></script>
     <script src="libs/alea.min.js"></script>
-    <script src="modules/fonts.js?v=11052022"></script>
-    <script src="modules/ui/layers.js?v=06062022"></script>
-    <script src="modules/ui/measurers.js?v=18052022"></script>
+    <script src="modules/fonts.js"></script>
+    <script src="modules/ui/layers.js"></script>
+    <script src="modules/ui/measurers.js"></script>
     <script src="modules/ui/stylePresets.js"></script>
 
-    <script src="modules/ui/general.js?v=02062022"></script>
-    <script src="modules/ui/options.js?v=040620222"></script>
-    <script src="main.js?v=020620222"></script>
+    <script src="modules/ui/general.js?v=1.87.00"></script>
+    <script src="modules/ui/options.js?v=1.87.00"></script>
+    <script src="main.js"></script>
 
     <script defer src="modules/relief-icons.js"></script>
     <script defer src="modules/ui/style.js"></script>
-    <script defer src="modules/ui/editors.js?v=12062022"></script>
-    <script defer src="modules/ui/tools.js?v=12062022"></script>
-    <script defer src="modules/ui/world-configurator.js?v=29052022"></script>
-    <script defer src="modules/ui/heightmap-editor.js?v=29052020"></script>
-    <script defer src="modules/ui/provinces-editor.js?v=29052022"></script>
-    <script defer src="modules/ui/biomes-editor.js?v=29052022"></script>
+    <script defer src="modules/ui/editors.js?v=1.87.00"></script>
+    <script defer src="modules/ui/tools.js?v=1.87.00"></script>
+    <script defer src="modules/ui/world-configurator.js"></script>
+    <script defer src="modules/ui/heightmap-editor.js"></script>
+    <script defer src="modules/ui/provinces-editor.js"></script>
+    <script defer src="modules/ui/biomes-editor.js"></script>
     <script defer src="modules/ui/namesbase-editor.js"></script>
-    <script defer src="modules/ui/elevation-profile.js?v=29052022"></script>
+    <script defer src="modules/ui/elevation-profile.js"></script>
     <script defer src="modules/ui/temperature-graph.js"></script>
     <script defer src="modules/ui/routes-editor.js"></script>
-    <script defer src="modules/ui/ice-editor.js?v=29052022"></script>
-    <script defer src="modules/ui/lakes-editor.js?v=18052022"></script>
-    <script defer src="modules/ui/coastline-editor.js?v=18052022"></script>
+    <script defer src="modules/ui/ice-editor.js"></script>
+    <script defer src="modules/ui/lakes-editor.js"></script>
+    <script defer src="modules/ui/coastline-editor.js"></script>
     <script defer src="modules/ui/labels-editor.js"></script>
     <script defer src="modules/ui/rivers-editor.js"></script>
     <script defer src="modules/ui/rivers-creator.js"></script>
     <script defer src="modules/ui/relief-editor.js"></script>
     <script defer src="modules/ui/burg-editor.js"></script>
     <script defer src="modules/ui/units-editor.js"></script>
-    <script defer src="modules/ui/notes-editor.js?v=29052022"></script>
-    <script defer src="modules/ui/diplomacy-editor.js?v=04062022"></script>
-    <script defer src="modules/ui/zones-editor.js?v=18052022"></script>
-    <script defer src="modules/ui/burgs-overview.js?v=29052022"></script>
-    <script defer src="modules/ui/rivers-overview.js?v=29052022"></script>
-    <script defer src="modules/ui/military-overview.js?v=29052022"></script>
-    <script defer src="modules/ui/regiments-overview.js?v=29052022"></script>
-    <script defer src="modules/ui/markers-overview.js?v=29052022"></script>
-    <script defer src="modules/ui/regiment-editor.js?v=12062022"></script>
+    <script defer src="modules/ui/notes-editor.js"></script>
+    <script defer src="modules/ui/diplomacy-editor.js"></script>
+    <script defer src="modules/ui/zones-editor.js"></script>
+    <script defer src="modules/ui/burgs-overview.js"></script>
+    <script defer src="modules/ui/rivers-overview.js"></script>
+    <script defer src="modules/ui/military-overview.js"></script>
+    <script defer src="modules/ui/regiments-overview.js"></script>
+    <script defer src="modules/ui/markers-overview.js"></script>
+    <script defer src="modules/ui/regiment-editor.js"></script>
     <script defer src="modules/ui/battle-screen.js"></script>
     <script defer src="modules/ui/emblems-editor.js"></script>
     <script defer src="modules/ui/markers-editor.js"></script>
     <script defer src="modules/ui/3d.js"></script>
-    <script defer src="modules/ui/submap.js?v=29052022"></script>
-    <script defer src="modules/ui/hotkeys.js?v=29052022"></script>
+    <script defer src="modules/ui/submap.js"></script>
+    <script defer src="modules/ui/hotkeys.js?v=1.87.00"></script>
     <script defer src="modules/coa-renderer.js"></script>
     <script defer src="libs/rgbquant.min.js"></script>
     <script defer src="libs/jquery.ui.touch-punch.min.js"></script>
 
-    <script defer src="modules/io/save.js?v=29052022"></script>
-    <script defer src="modules/io/load.js?v=12062022"></script>
-    <script defer src="modules/io/cloud.js?v=04062022"></script>
-    <script defer src="modules/io/export.js?v=04062022"></script>
+    <script defer src="modules/io/save.js"></script>
+    <script defer src="modules/io/load.js?v=1.87.00"></script>
+    <script defer src="modules/io/cloud.js"></script>
+    <script defer src="modules/io/export.js"></script>
     <script defer src="modules/io/formats.js"></script>
 
     <!-- Web Components -->

--- a/modules/dynamic/editors/cultures-editor.js
+++ b/modules/dynamic/editors/cultures-editor.js
@@ -630,7 +630,7 @@ function togglePercentageMode() {
 
 async function showHierarchy() {
   if (customization) return;
-  const HeirarchyTree = await import("../hierarchy-tree.js");
+  const HeirarchyTree = await import("../hierarchy-tree.js?v=1.87.00");
 
   const getDescription = culture => {
     const {name, type, rural, urban} = culture;

--- a/modules/dynamic/editors/religions-editor.js
+++ b/modules/dynamic/editors/religions-editor.js
@@ -533,7 +533,7 @@ function togglePercentageMode() {
 
 async function showHierarchy() {
   if (customization) return;
-  const HeirarchyTree = await import("../hierarchy-tree.js");
+  const HeirarchyTree = await import("../hierarchy-tree.js?v=1.87.00");
 
   const getDescription = religion => {
     const {name, type, form, rural, urban} = religion;

--- a/modules/dynamic/heightmap-selection.js
+++ b/modules/dynamic/heightmap-selection.js
@@ -42,7 +42,8 @@ export function open() {
 }
 
 function appendStyleSheet() {
-  const styles = /* css */ `
+  const style = document.createElement("style");
+  style.textContent = /* css */ `
     div.dialog > div.heightmap-selection {
       width: 70vw;
       height: 70vh;
@@ -145,8 +146,6 @@ function appendStyleSheet() {
     }
   `;
 
-  const style = document.createElement("style");
-  style.appendChild(document.createTextNode(styles));
   document.head.appendChild(style);
 }
 

--- a/modules/dynamic/hierarchy-tree.js
+++ b/modules/dynamic/hierarchy-tree.js
@@ -1,6 +1,5 @@
 appendStyleSheet();
 insertHtml();
-addListeners();
 
 const MARGINS = {top: 10, right: 10, bottom: -5, left: 10};
 
@@ -158,8 +157,6 @@ function insertHtml() {
 
   byId("dialogs").insertAdjacentHTML("beforeend", html);
 }
-
-function addListeners() {}
 
 function getRoot() {
   const root = d3

--- a/modules/dynamic/hierarchy-tree.js
+++ b/modules/dynamic/hierarchy-tree.js
@@ -62,7 +62,8 @@ export function open(props) {
 }
 
 function appendStyleSheet() {
-  const styles = /* css */ `
+  const style = document.createElement("style");
+  style.textContent = /* css */ `
     #hierarchyTree_selectedOrigins > button {
       margin: 0 2px;
     }
@@ -122,8 +123,6 @@ function appendStyleSheet() {
     }
   `;
 
-  const style = document.createElement("style");
-  style.appendChild(document.createTextNode(styles));
   document.head.appendChild(style);
 }
 

--- a/modules/dynamic/overview/charts-overview.js
+++ b/modules/dynamic/overview/charts-overview.js
@@ -4,24 +4,33 @@ import {stack} from "https://cdn.skypack.dev/d3-shape@3";
 const entitiesMap = {
   states: {
     label: "State",
-    array: pack.states,
     cellsData: pack.cells.state,
     getName: nameGetter("states"),
     getColors: colorsGetter("states")
   },
   cultures: {
     label: "Culture",
-    array: pack.cultures,
     cellsData: pack.cells.culture,
     getName: nameGetter("cultures"),
     getColors: colorsGetter("cultures")
   },
   religions: {
     label: "Religion",
-    array: pack.religions,
     cellsData: pack.cells.religion,
     getName: nameGetter("religions"),
     getColors: colorsGetter("religions")
+  },
+  provinces: {
+    label: "Province",
+    cellsData: pack.cells.province,
+    getName: nameGetter("provinces"),
+    getColors: colorsGetter("provinces")
+  },
+  biomes: {
+    label: "Biome",
+    cellsData: pack.cells.biome,
+    getName: biomeNameGetter,
+    getColors: biomeColorsGetter
   }
 };
 
@@ -176,7 +185,6 @@ function renderChart(event) {
   const sorting = byId("chartsOverview__sortingSelect").value;
 
   const noGrouping = groupBy === entity;
-
   const filterWater = true;
 
   const {label: plotByLabel, stringify, quantize, formatTicks} = quantizationMap[plotBy];
@@ -361,13 +369,23 @@ function updateDialog() {
 
 // config
 const NEUTRAL_COLOR = "#ccc";
+const EMPTY_NAME = "no";
 
 // helper functions
 function nameGetter(entity) {
-  return i => pack[entity][i].name;
+  return i => pack[entity][i].name || EMPTY_NAME;
 }
+
 function colorsGetter(entity) {
-  return () => Object.fromEntries(pack[entity].map(({name, color}) => [name, color || NEUTRAL_COLOR]));
+  return () => Object.fromEntries(pack[entity].map(({name, color}) => [name || EMPTY_NAME, color || NEUTRAL_COLOR]));
+}
+
+function biomeNameGetter(i) {
+  return biomesData.name[i] || EMPTY_NAME;
+}
+
+function biomeColorsGetter() {
+  return Object.fromEntries(biomesData.i.map(i => [biomesData.name[i], biomesData.color[i]]));
 }
 
 function getUrbanPopulation(cellId) {

--- a/modules/dynamic/overview/charts-overview.js
+++ b/modules/dynamic/overview/charts-overview.js
@@ -1,0 +1,230 @@
+const entities = ["states", "cultures", "religions"];
+const quantitatives = ["total_population", "urban_population", "rural_population", "area", "cells"];
+const groupings = ["cultures", "states", "religions"];
+
+const dataMap = {
+  states: {array: pack.states, getName: i => pack.states[i].name, cellsData: pack.cells.state},
+  cultures: {array: pack.cultures, getName: i => pack.cultures[i].name, cellsData: pack.cells.culture},
+  religions: {array: pack.religions, getName: i => pack.religions[i].name, cellsData: pack.cells.religion}
+};
+
+const quantizationMap = {
+  total_population: cellId => getUrbanPopulation(cellId) + getRuralPopulation(cellId),
+  urban_population: getUrbanPopulation,
+  rural_population: getRuralPopulation,
+  area: cellId => getArea(pack.cells.area[cellId]),
+  cells: () => 1
+};
+
+appendStyleSheet();
+
+insertHtml();
+const $entitiesSelect = byId("chartsOverview__entitiesSelect");
+const $plotBySelect = byId("chartsOverview__plotBySelect");
+const $groupBySelect = byId("chartsOverview__groupBySelect");
+updateSelectorOptions();
+addListeners();
+
+export function open() {
+  renderChart();
+
+  $("#chartsOverview").dialog({
+    title: "Charts"
+  });
+}
+
+function appendStyleSheet() {
+  const styles = /* css */ `
+  `;
+
+  const style = document.createElement("style");
+  style.appendChild(document.createTextNode(styles));
+  document.head.appendChild(style);
+}
+
+function insertHtml() {
+  const createOption = value => `<option value="${value}">${value.replaceAll("_", " ")}</option>`;
+  const createOptions = values => values.map(createOption).join("");
+
+  const html = /* html */ `<div id="chartsOverview" style="overflow: disabled;">
+    <div>
+      <span>Plot</span>
+      <select id="chartsOverview__entitiesSelect">${createOptions(entities)}</select>
+
+      <span>by</span>
+      <select id="chartsOverview__plotBySelect">${createOptions(quantitatives)}</select>
+
+      <span>grouped by</span>
+      <select id="chartsOverview__groupBySelect">${createOptions(groupings)}</select>
+    </div>
+
+    <div id="chartsOverview__svgContainer"></div>
+  </div>`;
+
+  byId("dialogs").insertAdjacentHTML("beforeend", html);
+}
+
+function addListeners() {
+  $entitiesSelect.on("change", renderChart);
+  $plotBySelect.on("change", renderChart);
+  $groupBySelect.on("change", renderChart);
+
+  $entitiesSelect.on("change", updateSelectorOptions);
+  $groupBySelect.on("change", updateSelectorOptions);
+}
+
+function renderChart() {
+  const entity = $entitiesSelect.value;
+  const plotBy = $plotBySelect.value;
+  const groupBy = $groupBySelect.value;
+
+  const {array: entityArray, getName: getEntityName, cellsData: entityCells} = dataMap[entity];
+  const {getName: getGroupName, cellsData: groupCells} = dataMap[groupBy];
+  const quantize = quantizationMap[plotBy];
+
+  const chartData = entityArray
+    .filter(element => !element.removed)
+    .map(({i}) => {
+      const cells = pack.cells.i.filter(cellId => entityCells[cellId] === i);
+      const name = getEntityName(i);
+
+      return Array.from(cells).map(cellId => {
+        const group = getGroupName(groupCells[cellId]);
+        const value = quantize(cellId);
+        return {name, group, value};
+      });
+    })
+    .flat();
+
+  console.log(chartData);
+  const chart = plot(chartData, {});
+  byId("chartsOverview__svgContainer").appendChild(chart);
+}
+
+function updateSelectorOptions() {
+  const entity = $entitiesSelect.value;
+  $groupBySelect.querySelector("option[disabled]")?.removeAttribute("disabled");
+  $groupBySelect.querySelector(`option[value="${entity}"]`)?.setAttribute("disabled", "");
+
+  const group = $groupBySelect.value;
+  $entitiesSelect.querySelector("option[disabled]")?.removeAttribute("disabled");
+  $entitiesSelect.querySelector(`option[value="${group}"]`)?.setAttribute("disabled", "");
+}
+
+// based on https://observablehq.com/@d3/grouped-bar-chart
+function plot(
+  data,
+  {
+    title, // given d in data, returns the title text
+    marginTop = 30, // top margin, in pixels
+    marginRight = 0, // right margin, in pixels
+    marginBottom = 40, // bottom margin, in pixels
+    marginLeft = 100, // left margin, in pixels
+    width = 2400, // outer width, in pixels
+    height = 400, // outer height, in pixels
+    xRange = [marginLeft, width - marginRight], // [xmin, xmax]
+    xPadding = 0.1, // amount of x-range to reserve to separate groups
+    yType = d3.scaleLinear, // type of y-scale
+    yRange = [height - marginBottom, marginTop], // [ymin, ymax]
+    zPadding = 0.05, // amount of x-range to reserve to separate bars
+    yFormat, // a format specifier string for the y-axis
+    yLabel, // a label for the y-axis
+    colors = d3.schemeCategory10 // array of colors
+  } = {}
+) {
+  const X = data.map(d => d.name);
+  const Y = data.map(d => d.value);
+  const Z = data.map(d => d.group);
+
+  const xDomain = new Set(X);
+  const yDomain = [0, d3.max(Y)];
+  const zDomain = new Set(Z);
+
+  // omit any data not present in both the x- and z-domain
+  const I = d3.range(X.length).filter(i => xDomain.has(X[i]) && zDomain.has(Z[i]));
+
+  const xDomainArray = Array.from(xDomain);
+  const zDomainArray = Array.from(zDomain);
+
+  // Construct scales, axes, and formats
+  const xScale = d3.scaleBand(xDomainArray, xRange).paddingInner(xPadding);
+  const xzScale = d3.scaleBand(zDomainArray, [0, xScale.bandwidth()]).padding(zPadding);
+  const yScale = yType(yDomain, yRange);
+  const zScale = d3.scaleOrdinal(zDomainArray, colors);
+  const xAxis = d3.axisBottom(xScale).tickSizeOuter(0);
+  const yAxis = d3.axisLeft(yScale).ticks(height / 60, yFormat);
+
+  // Compute titles
+  if (title === undefined) {
+    const formatValue = yScale.tickFormat(100, yFormat);
+    title = i => `${X[i]}\n${Z[i]}\n${formatValue(Y[i])}`;
+  } else {
+    const O = d3.map(data, d => d);
+    const T = title;
+    title = i => T(O[i], i, data);
+  }
+
+  const svg = d3
+    .create("svg")
+    .attr("width", width)
+    .attr("height", height)
+    .attr("viewBox", [0, 0, width, height])
+    .attr("style", "max-width: 100%; height: auto; height: intrinsic;");
+
+  svg
+    .append("g")
+    .attr("transform", `translate(${marginLeft},0)`)
+    .call(yAxis)
+    .call(g => g.select(".domain").remove())
+    .call(g =>
+      g
+        .selectAll(".tick line")
+        .clone()
+        .attr("x2", width - marginLeft - marginRight)
+        .attr("stroke-opacity", 0.1)
+    )
+    .call(g =>
+      g
+        .append("text")
+        .attr("x", -marginLeft)
+        .attr("y", 10)
+        .attr("fill", "currentColor")
+        .attr("text-anchor", "start")
+        .text(yLabel)
+    );
+
+  const bar = svg
+    .append("g")
+    .selectAll("rect")
+    .data(I)
+    .join("rect")
+    .attr("x", i => xScale(X[i]) + xzScale(Z[i]))
+    .attr("y", i => yScale(Y[i]))
+    .attr("width", xzScale.bandwidth())
+    .attr("height", i => yScale(0) - yScale(Y[i]))
+    .attr("fill", i => zScale(Z[i]));
+
+  if (title) bar.append("title").text(title);
+
+  svg
+    .append("g")
+    .attr("transform", `translate(0,${height - marginBottom})`)
+    .call(xAxis);
+
+  const chart = Object.assign(svg.node(), {scales: {color: zScale}});
+  console.log(chart);
+  return chart;
+}
+
+// helper functions
+function getUrbanPopulation(cellId) {
+  const burgId = pack.cells.burg[cellId];
+  if (!burgId) return 0;
+  const populationPoints = pack.burgs[burgId].population;
+  return populationPoints * populationRate * urbanization;
+}
+
+function getRuralPopulation(cellId) {
+  const populationPoints = pack.cells.pop[cellId] * populationRate;
+  return populationPoints * populationRate;
+}

--- a/modules/dynamic/overview/charts-overview.js
+++ b/modules/dynamic/overview/charts-overview.js
@@ -1,48 +1,112 @@
 import {rollup} from "../../../utils/functionUtils.js";
 import {stack} from "https://cdn.skypack.dev/d3-shape@3";
 
-const entities = ["states", "cultures", "religions"];
-const quantitatives = ["total_population", "urban_population", "rural_population", "area", "cells"];
-const groupings = ["cultures", "states", "religions"];
-
-const dataMap = {
-  states: {array: pack.states, getName: i => pack.states[i].name, cellsData: pack.cells.state},
-  cultures: {array: pack.cultures, getName: i => pack.cultures[i].name, cellsData: pack.cells.culture},
-  religions: {array: pack.religions, getName: i => pack.religions[i].name, cellsData: pack.cells.religion}
+const entitiesMap = {
+  states: {
+    label: "State",
+    array: pack.states,
+    cellsData: pack.cells.state,
+    getName: nameGetter("states"),
+    getColors: colorsGetter("states")
+  },
+  cultures: {
+    label: "Culture",
+    array: pack.cultures,
+    cellsData: pack.cells.culture,
+    getName: nameGetter("cultures"),
+    getColors: colorsGetter("cultures")
+  },
+  religions: {
+    label: "Religion",
+    array: pack.religions,
+    cellsData: pack.cells.religion,
+    getName: nameGetter("religions"),
+    getColors: colorsGetter("religions")
+  }
 };
 
 const quantizationMap = {
-  total_population: cellId => getUrbanPopulation(cellId) + getRuralPopulation(cellId),
-  urban_population: getUrbanPopulation,
-  rural_population: getRuralPopulation,
-  area: cellId => getArea(pack.cells.area[cellId]),
-  cells: () => 1
-};
-
-const sortingMap = {
-  value: (a, b) => b.value - a.value,
-  name: (a, b) => a.name.localeCompare(b.name)
+  total_population: {
+    label: "Total population",
+    quantize: cellId => getUrbanPopulation(cellId) + getRuralPopulation(cellId),
+    formatTicks: value => si(value),
+    stringify: value => `${value.toLocaleString()} people`
+  },
+  urban_population: {
+    label: "Urban population",
+    quantize: getUrbanPopulation,
+    formatTicks: value => si(value),
+    stringify: value => `${value.toLocaleString()} people`
+  },
+  rural_population: {
+    label: "Rural population",
+    quantize: getRuralPopulation,
+    formatTicks: value => si(value),
+    stringify: value => `${value.toLocaleString()} people`
+  },
+  area: {
+    label: "Land area",
+    quantize: cellId => getArea(pack.cells.area[cellId]),
+    formatTicks: value => `${si(value)} ${getAreaUnit()}`,
+    stringify: value => `${value.toLocaleString()} ${getAreaUnit()}`
+  },
+  cells: {
+    label: "Number of cells",
+    quantize: () => 1,
+    formatTicks: value => value,
+    stringify: value => `${value.toLocaleString()} cells`
+  }
 };
 
 appendStyleSheet();
 
 insertHtml();
-const $entitiesSelect = byId("chartsOverview__entitiesSelect");
-const $plotBySelect = byId("chartsOverview__plotBySelect");
-const $groupBySelect = byId("chartsOverview__groupBySelect");
-updateSelectorOptions();
 addListeners();
+changeViewColumns();
 
 export function open() {
-  renderChart();
+  const charts = byId("chartsOverview__charts").childElementCount;
+  if (!charts) renderChart();
 
-  $("#chartsOverview").dialog({
-    title: "Charts"
-  });
+  $("#chartsOverview").dialog({title: "Data Charts"});
 }
 
 function appendStyleSheet() {
   const styles = /* css */ `
+    #chartsOverview {
+      max-width: 90vw !important;
+      max-height: 90vh !important;
+      overflow: hidden;
+      display: grid;
+      grid-template-rows: auto 1fr;
+    }
+
+    #chartsOverview__form {
+      font-size: 1.1em;
+      margin: 0.3em;
+      display: flex;
+      justify-content: space-between;
+    }
+
+    #chartsOverview__charts {
+      overflow: auto;
+      scroll-behavior: smooth;
+      display: grid;
+    }
+
+    #chartsOverview__charts figure {
+      margin: 0;
+    }
+
+    #chartsOverview__charts figcaption {
+      font-size: 1.2em;
+      margin-left: 4%;
+    }
+
+    .chartsOverview__bars {
+      stroke: #666;
+      stroke-width: 0.5;
+    }
   `;
 
   const style = document.createElement("style");
@@ -51,48 +115,83 @@ function appendStyleSheet() {
 }
 
 function insertHtml() {
-  const createOption = value => `<option value="${value}">${value.replaceAll("_", " ")}</option>`;
+  const entities = Object.entries(entitiesMap).map(([entity, {label}]) => [entity, label]);
+  const plotBy = Object.entries(quantizationMap).map(([plotBy, {label}]) => [plotBy, label]);
+
+  const createOption = ([value, label]) => `<option value="${value}">${label}</option>`;
   const createOptions = values => values.map(createOption).join("");
 
-  const html = /* html */ `<div id="chartsOverview" style="overflow: disabled;">
-    <div>
-      <span>Plot</span>
-      <select id="chartsOverview__entitiesSelect">${createOptions(entities)}</select>
+  const html = /* html */ `<div id="chartsOverview">
+    <form id="chartsOverview__form">
+      <div>
+        <button type="submit">Plot</button>
+        <select id="chartsOverview__entitiesSelect">${createOptions(entities)}</select>
 
-      <span>by</span>
-      <select id="chartsOverview__plotBySelect">${createOptions(quantitatives)}</select>
+        <span>by</span>
+        <select id="chartsOverview__plotBySelect">${createOptions(plotBy)}</select>
 
-      <span>grouped by</span>
-      <select id="chartsOverview__groupBySelect">${createOptions(groupings)}</select>
-    </div>
+        <span>grouped by</span>
+        <select id="chartsOverview__groupBySelect">${createOptions(entities)}</select>
 
-    <div id="chartsOverview__svgContainer"></div>
+        <span>sorted</span>
+        <select id="chartsOverview__sortingSelect">
+          <option value="value">by value</option>
+          <option value="name">by name</option>
+          <option value="natural">naturally</option>
+        </select>
+      </div>
+      <div>
+        <span>Columns</span>
+        <select id="chartsOverview__viewColumns">
+          <option value="1" selected>1</option>
+          <option value="2">2</option>
+          <option value="3">3</option>
+          <option value="4">4</option>
+        </select>
+      </div>
+    </form>
+
+    <section id="chartsOverview__charts"></section>
   </div>`;
 
   byId("dialogs").insertAdjacentHTML("beforeend", html);
+
+  // set defaults
+  byId("chartsOverview__entitiesSelect").value = "states";
+  byId("chartsOverview__plotBySelect").value = "total_population";
+  byId("chartsOverview__groupBySelect").value = "cultures";
 }
 
 function addListeners() {
-  $entitiesSelect.on("change", renderChart);
-  $plotBySelect.on("change", renderChart);
-  $groupBySelect.on("change", renderChart);
-
-  $entitiesSelect.on("change", updateSelectorOptions);
-  $groupBySelect.on("change", updateSelectorOptions);
+  byId("chartsOverview__form").on("submit", renderChart);
+  byId("chartsOverview__viewColumns").on("change", changeViewColumns);
 }
 
-function renderChart() {
-  const entity = $entitiesSelect.value;
-  const plotBy = $plotBySelect.value;
-  const groupBy = $groupBySelect.value;
+function renderChart(event) {
+  if (event) event.preventDefault();
+
+  const entity = byId("chartsOverview__entitiesSelect").value;
+  const plotBy = byId("chartsOverview__plotBySelect").value;
+  const groupBy = byId("chartsOverview__groupBySelect").value;
+  const sorting = byId("chartsOverview__sortingSelect").value;
+
+  const noGrouping = groupBy === entity;
 
   const filterWater = true;
   const filterZeroes = true;
-  const sorting = sortingMap["value"];
 
-  const {getName: getEntityName, cellsData: entityCells} = dataMap[entity];
-  const {getName: getGroupName, cellsData: groupCells} = dataMap[groupBy];
-  const quantize = quantizationMap[plotBy];
+  const {label: plotByLabel, stringify, quantize, formatTicks} = quantizationMap[plotBy];
+  const {label: entityLabel, getName: getEntityName, cellsData: entityCells} = entitiesMap[entity];
+  const {label: groupLabel, getName: getGroupName, cellsData: groupCells, getColors} = entitiesMap[groupBy];
+
+  const title = `${capitalize(entity)} by ${plotByLabel}${noGrouping ? "" : " grouped by " + groupLabel}`;
+
+  const tooltip = (entity, group, value) => {
+    const entityTip = `${entityLabel}: ${entity}`;
+    const groupTip = noGrouping ? "" : `${groupLabel}: ${group}`;
+    const valueTip = `${plotByLabel}: ${stringify(value)}`;
+    tip([entityTip, groupTip, valueTip].filter(Boolean).join(". "));
+  };
 
   const dataCollection = {};
   for (const cellId of pack.cells.i) {
@@ -118,77 +217,66 @@ function renderChart() {
     .flat();
 
   const chartDataFiltered = filterZeroes ? chartData.filter(({value}) => value > 0) : chartData;
+  const colors = getColors();
 
-  const chart = plot(chartDataFiltered, {sorting});
-  byId("chartsOverview__svgContainer").appendChild(chart);
+  const chart = plot(chartDataFiltered, {sorting, colors, formatTicks, tooltip});
+  insertChart(chart, title);
+
+  byId("chartsOverview__charts").lastChild.scrollIntoView();
+  updateDialog();
 }
 
-function updateSelectorOptions() {
-  const entity = $entitiesSelect.value;
-  $groupBySelect.querySelector("option[disabled]")?.removeAttribute("disabled");
-  $groupBySelect.querySelector(`option[value="${entity}"]`)?.setAttribute("disabled", "");
-
-  const group = $groupBySelect.value;
-  $entitiesSelect.querySelector("option[disabled]")?.removeAttribute("disabled");
-  $entitiesSelect.querySelector(`option[value="${group}"]`)?.setAttribute("disabled", "");
-}
-
-// based on https://observablehq.com/@d3/grouped-bar-chart
+// based on observablehq.com/@d3/stacked-horizontal-bar-chart
 function plot(
   data,
   {
     marginTop = 30, // top margin, in pixels
-    marginRight = 0, // right margin, in pixels
-    marginBottom = 40, // bottom margin, in pixels
-    marginLeft = 100, // left margin, in pixels
+    marginRight = 10, // right margin, in pixels
+    marginBottom = 10, // bottom margin, in pixels
+    marginLeft = 80, // left margin, in pixels
     width = 800, // outer width, in pixels
     xRange = [marginLeft, width - marginRight], // [xmin, xmax]
     yPadding = 0.2,
-    xFormat,
-    xLabel = "Population (millions) →",
-    sorting
+    sorting,
+    colors,
+    formatTicks,
+    tooltip
   } = {}
 ) {
   const X = data.map(d => d.value);
   const Y = data.map(d => d.name);
   const Z = data.map(d => d.group);
 
-  const yDomain = new Set(Y); // get from parent, already sorted
+  const sortedY = sortData({array: Y, sorting, data, dataKey: "name", reverse: true});
+  const sortedZ = sortData({array: Z, sorting, data, dataKey: "group", reverse: false});
+  const yDomain = new Set(sortedY);
   const zDomain = new Set(Z);
 
-  // omit any data not present in both the y- and z-domain
-  const I = d3.range(X.length).filter(i => yDomain.has(Y[i]) && zDomain.has(Z[i]));
+  const I = d3.range(X.length).filter(i => X[i] > 0 && yDomain.has(Y[i]) && zDomain.has(Z[i]));
 
   const height = yDomain.size * 25 + marginTop + marginBottom;
   const yRange = [height - marginBottom, marginTop];
 
-  const offset = d3.stackOffsetDiverging;
-  const order = d3.stackOrderNone;
+  const rolled = rollup(...[I, ([i]) => i, i => Y[i], i => Z[i]]);
 
   const series = stack()
     .keys(zDomain)
     .value(([, I], z) => X[I.get(z)])
-    .order(order)
-    .offset(offset)(
-      rollup(
-        I,
-        ([i]) => i,
-        i => Y[i],
-        i => Z[i]
-      )
-    )
-    .map(s => s.map(d => Object.assign(d, {i: d.data[1].get(s.key)})));
+    .order(d3.stackOrderNone)
+    .offset(d3.stackOffsetDiverging)(rolled)
+    .map(s => {
+      const nonNull = s.filter(d => Boolean(d[1]));
+      const data = nonNull.map(d => Object.assign(d, {i: d.data[1].get(s.key)}));
+      return {key: s.key, data};
+    });
 
-  const xDomain = d3.extent(series.flat(2));
+  const xDomain = d3.extent(series.map(d => d.data).flat(2));
 
   const xScale = d3.scaleLinear(xDomain, xRange);
   const yScale = d3.scaleBand(Array.from(yDomain), yRange).paddingInner(yPadding);
-  const color = d3.scaleOrdinal(Array.from(zDomain), d3.schemeCategory10);
-  const xAxis = d3.axisTop(xScale).ticks(width / 80, xFormat);
-  const yAxis = d3.axisLeft(yScale).tickSizeOuter(0);
 
-  const formatValue = xScale.tickFormat(100, xFormat);
-  const title = i => `${Y[i]}\n${Z[i]}\n${formatValue(X[i])}`;
+  const xAxis = d3.axisTop(xScale).ticks(width / 80, null);
+  const yAxis = d3.axisLeft(yScale).tickSizeOuter(0);
 
   const svg = d3
     .create("svg")
@@ -202,48 +290,77 @@ function plot(
     .attr("transform", `translate(0,${marginTop})`)
     .call(xAxis)
     .call(g => g.select(".domain").remove())
+    .call(g => g.selectAll("text").text(d => formatTicks(d)))
     .call(g =>
       g
         .selectAll(".tick line")
         .clone()
         .attr("y2", height - marginTop - marginBottom)
         .attr("stroke-opacity", 0.1)
-    )
-    .call(g =>
-      g
-        .append("text")
-        .attr("x", width - marginRight)
-        .attr("y", -22)
-        .attr("fill", "currentColor")
-        .attr("text-anchor", "end")
-        .text(xLabel)
     );
 
   const bar = svg
     .append("g")
+    .attr("class", "chartsOverview__bars")
     .selectAll("g")
     .data(series)
     .join("g")
-    .attr("fill", ([{i}]) => color(Z[i]))
+    .attr("fill", d => colors[d.key])
     .selectAll("rect")
-    .data(d => d.filter(d => d.i !== undefined))
+    .data(d => d.data)
     .join("rect")
     .attr("x", ([x1, x2]) => Math.min(xScale(x1), xScale(x2)))
     .attr("y", ({i}) => yScale(Y[i]))
     .attr("width", ([x1, x2]) => Math.abs(xScale(x1) - xScale(x2)))
     .attr("height", yScale.bandwidth());
 
-  bar.append("title").text(({i}) => title(i));
+  bar.on("mouseover", ({i}) => tooltip(Y[i], Z[i], X[i]));
 
   svg
     .append("g")
     .attr("transform", `translate(${xScale(0)},0)`)
     .call(yAxis);
 
-  return Object.assign(svg.node(), {scales: {color}});
+  return svg.node();
 }
 
+function insertChart(chart, title) {
+  const $chartContainer = byId("chartsOverview__charts");
+
+  const $figure = document.createElement("figure");
+  const $caption = document.createElement("figcaption");
+
+  const figureNo = $chartContainer.childElementCount + 1;
+  $caption.innerHTML = `<strong>Figure ${figureNo}</strong>. ${title}`;
+
+  $figure.appendChild(chart);
+  $figure.appendChild($caption);
+
+  $chartContainer.appendChild($figure);
+}
+
+function changeViewColumns() {
+  const columns = byId("chartsOverview__viewColumns").value;
+  const $charts = byId("chartsOverview__charts");
+  $charts.style.gridTemplateColumns = `repeat(${columns}, 1fr)`;
+  updateDialog();
+}
+
+function updateDialog() {
+  $("#chartsOverview").dialog({position: {my: "center", at: "center", of: window}});
+}
+
+// config
+const NEUTRAL_COLOR = "#ccc";
+
 // helper functions
+function nameGetter(entity) {
+  return i => pack[entity][i].name;
+}
+function colorsGetter(entity) {
+  return () => Object.fromEntries(pack[entity].map(({name, color}) => [name, color || NEUTRAL_COLOR]));
+}
+
 function getUrbanPopulation(cellId) {
   const burgId = pack.cells.burg[cellId];
   if (!burgId) return 0;
@@ -253,4 +370,19 @@ function getUrbanPopulation(cellId) {
 
 function getRuralPopulation(cellId) {
   return pack.cells.pop[cellId] * populationRate;
+}
+
+function sortData({array, sorting, data, dataKey, reverse}) {
+  if (sorting === "natural") return array;
+  if (sorting === "name") return array.sort((a, b) => (reverse ? b.localeCompare(a) : a.localeCompare(b)));
+
+  if (sorting === "value") {
+    return [...new Set(array)].sort((a, b) => {
+      const valueA = d3.sum(data.filter(d => d[dataKey] === a).map(d => d.value));
+      const valueB = d3.sum(data.filter(d => d[dataKey] === b).map(d => d.value));
+      return reverse ? valueA - valueB : valueB - valueA;
+    });
+  }
+
+  return array;
 }

--- a/modules/dynamic/overview/charts-overview.js
+++ b/modules/dynamic/overview/charts-overview.js
@@ -6,31 +6,36 @@ const entitiesMap = {
     label: "State",
     cellsData: pack.cells.state,
     getName: nameGetter("states"),
-    getColors: colorsGetter("states")
+    getColors: colorsGetter("states"),
+    landOnly: true
   },
   cultures: {
     label: "Culture",
     cellsData: pack.cells.culture,
     getName: nameGetter("cultures"),
-    getColors: colorsGetter("cultures")
+    getColors: colorsGetter("cultures"),
+    landOnly: true
   },
   religions: {
     label: "Religion",
     cellsData: pack.cells.religion,
     getName: nameGetter("religions"),
-    getColors: colorsGetter("religions")
+    getColors: colorsGetter("religions"),
+    landOnly: true
   },
   provinces: {
     label: "Province",
     cellsData: pack.cells.province,
     getName: nameGetter("provinces"),
-    getColors: colorsGetter("provinces")
+    getColors: colorsGetter("provinces"),
+    landOnly: true
   },
   biomes: {
     label: "Biome",
     cellsData: pack.cells.biome,
     getName: biomeNameGetter,
-    getColors: biomeColorsGetter
+    getColors: biomeColorsGetter,
+    landOnly: false
   }
 };
 
@@ -38,32 +43,155 @@ const quantizationMap = {
   total_population: {
     label: "Total population",
     quantize: cellId => getUrbanPopulation(cellId) + getRuralPopulation(cellId),
+    aggregate: values => rn(d3.sum(values)),
     formatTicks: value => si(value),
-    stringify: value => `${value.toLocaleString()} people`
+    stringify: value => value.toLocaleString(),
+    stackable: true,
+    landOnly: true
   },
   urban_population: {
     label: "Urban population",
     quantize: getUrbanPopulation,
+    aggregate: values => rn(d3.sum(values)),
     formatTicks: value => si(value),
-    stringify: value => `${value.toLocaleString()} people`
+    stringify: value => value.toLocaleString(),
+    stackable: true,
+    landOnly: true
   },
   rural_population: {
     label: "Rural population",
     quantize: getRuralPopulation,
+    aggregate: values => rn(d3.sum(values)),
     formatTicks: value => si(value),
-    stringify: value => `${value.toLocaleString()} people`
+    stringify: value => value.toLocaleString(),
+    stackable: true,
+    landOnly: true
   },
   area: {
     label: "Land area",
     quantize: cellId => getArea(pack.cells.area[cellId]),
+    aggregate: values => rn(d3.sum(values)),
     formatTicks: value => `${si(value)} ${getAreaUnit()}`,
-    stringify: value => `${value.toLocaleString()} ${getAreaUnit()}`
+    stringify: value => `${value.toLocaleString()} ${getAreaUnit()}`,
+    stackable: true,
+    landOnly: true
   },
   cells: {
     label: "Number of cells",
     quantize: () => 1,
+    aggregate: values => d3.sum(values),
     formatTicks: value => value,
-    stringify: value => `${value.toLocaleString()} cells`
+    stringify: value => value.toLocaleString(),
+    stackable: true,
+    landOnly: true
+  },
+  burgs_number: {
+    label: "Number of burgs",
+    quantize: cellId => (pack.cells.burg[cellId] ? 1 : 0),
+    aggregate: values => d3.sum(values),
+    formatTicks: value => value,
+    stringify: value => value.toLocaleString(),
+    stackable: true,
+    landOnly: true
+  },
+  average_elevation: {
+    label: "Average elevation",
+    quantize: cellId => pack.cells.h[cellId],
+    aggregate: values => d3.mean(values),
+    formatTicks: value => getHeight(value),
+    stringify: value => getHeight(value),
+    stackable: false,
+    landOnly: false
+  },
+  max_elevation: {
+    label: "Maximum mean elevation",
+    quantize: cellId => pack.cells.h[cellId],
+    aggregate: values => d3.max(values),
+    formatTicks: value => getHeight(value),
+    stringify: value => getHeight(value),
+    stackable: false,
+    landOnly: false
+  },
+  min_elevation: {
+    label: "Minimum mean elevation",
+    quantize: cellId => pack.cells.h[cellId],
+    aggregate: values => d3.min(values),
+    formatTicks: value => getHeight(value),
+    stringify: value => getHeight(value),
+    stackable: false,
+    landOnly: false
+  },
+  average_temperature: {
+    label: "Annual mean temperature",
+    quantize: cellId => grid.cells.temp[pack.cells.g[cellId]],
+    aggregate: values => d3.mean(values),
+    formatTicks: value => convertTemperature(value),
+    stringify: value => convertTemperature(value),
+    stackable: false,
+    landOnly: false
+  },
+  max_temperature: {
+    label: "Mean annual maximum temperature",
+    quantize: cellId => grid.cells.temp[pack.cells.g[cellId]],
+    aggregate: values => d3.max(values),
+    formatTicks: value => convertTemperature(value),
+    stringify: value => convertTemperature(value),
+    stackable: false,
+    landOnly: false
+  },
+  min_temperature: {
+    label: "Mean annual minimum temperature",
+    quantize: cellId => grid.cells.temp[pack.cells.g[cellId]],
+    aggregate: values => d3.min(values),
+    formatTicks: value => convertTemperature(value),
+    stringify: value => convertTemperature(value),
+    stackable: false,
+    landOnly: false
+  },
+  average_precipitation: {
+    label: "Annual mean precipitation",
+    quantize: cellId => grid.cells.prec[pack.cells.g[cellId]],
+    aggregate: values => rn(d3.mean(values)),
+    formatTicks: value => getPrecipitation(rn(value)),
+    stringify: value => getPrecipitation(rn(value)),
+    stackable: false,
+    landOnly: true
+  },
+  max_precipitation: {
+    label: "Mean annual maximum precipitation",
+    quantize: cellId => grid.cells.prec[pack.cells.g[cellId]],
+    aggregate: values => rn(d3.max(values)),
+    formatTicks: value => getPrecipitation(rn(value)),
+    stringify: value => getPrecipitation(rn(value)),
+    stackable: false,
+    landOnly: true
+  },
+  min_precipitation: {
+    label: "Mean annual minimum precipitation",
+    quantize: cellId => grid.cells.prec[pack.cells.g[cellId]],
+    aggregate: values => rn(d3.min(values)),
+    formatTicks: value => getPrecipitation(rn(value)),
+    stringify: value => getPrecipitation(rn(value)),
+    stackable: false,
+    landOnly: true
+  },
+  coastal_cells: {
+    label: "Number of coastal cells",
+    quantize: cellId => (pack.cells.t[cellId] === 1 ? 1 : 0),
+    aggregate: values => d3.sum(values),
+    formatTicks: value => value,
+    stringify: value => value.toLocaleString(),
+    stackable: true,
+    landOnly: true
+  },
+  river_cells: {
+    label: "Number of river cells",
+    quantize: cellId => (pack.cells.r[cellId] ? 1 : 0),
+    aggregate: values => d3.sum(values),
+    formatTicks: value => value,
+    stringify: value => value.toLocaleString(),
+    stackable: true,
+    landOnly: true
   }
 };
 
@@ -181,14 +309,32 @@ function renderChart(event) {
 
   const entity = byId("chartsOverview__entitiesSelect").value;
   const plotBy = byId("chartsOverview__plotBySelect").value;
-  const groupBy = byId("chartsOverview__groupBySelect").value;
+  let groupBy = byId("chartsOverview__groupBySelect").value;
   const sorting = byId("chartsOverview__sortingSelect").value;
 
-  const noGrouping = groupBy === entity;
-  const filterWater = true;
+  const {
+    label: plotByLabel,
+    stringify,
+    quantize,
+    aggregate,
+    formatTicks,
+    stackable,
+    landOnly: plotByLandOnly
+  } = quantizationMap[plotBy];
 
-  const {label: plotByLabel, stringify, quantize, formatTicks} = quantizationMap[plotBy];
-  const {label: entityLabel, getName: getEntityName, cellsData: entityCells} = entitiesMap[entity];
+  if (!stackable && groupBy !== entity) {
+    tip("Grouping is not supported for this chart type", false, "warn", 4000);
+    groupBy = entity;
+  }
+
+  const noGrouping = groupBy === entity;
+
+  const {
+    label: entityLabel,
+    getName: getEntityName,
+    cellsData: entityCells,
+    landOnly: entityLandOnly
+  } = entitiesMap[entity];
   const {label: groupLabel, getName: getGroupName, cellsData: groupCells, getColors} = entitiesMap[groupBy];
 
   const title = `${capitalize(entity)} by ${plotByLabel}${noGrouping ? "" : " grouped by " + groupLabel}`;
@@ -204,31 +350,24 @@ function renderChart(event) {
   const groups = new Set();
 
   for (const cellId of pack.cells.i) {
-    if (filterWater && isWater(cellId)) continue;
+    if ((entityLandOnly || plotByLandOnly) && isWater(cellId)) continue;
     const entityId = entityCells[cellId];
     const groupId = groupCells[cellId];
     const value = quantize(cellId);
 
-    if (!dataCollection[entityId]) dataCollection[entityId] = {[groupId]: value};
-    else if (!dataCollection[entityId][groupId]) dataCollection[entityId][groupId] = value;
-    else dataCollection[entityId][groupId] += value;
+    if (!dataCollection[entityId]) dataCollection[entityId] = {[groupId]: [value]};
+    else if (!dataCollection[entityId][groupId]) dataCollection[entityId][groupId] = [value];
+    else dataCollection[entityId][groupId].push(value);
 
     groups.add(groupId);
-  }
-
-  // fill missing groups with 0
-  for (const entityId in dataCollection) {
-    for (const groupId of groups) {
-      if (!dataCollection[entityId][groupId]) dataCollection[entityId][groupId] = 0;
-    }
   }
 
   const chartData = Object.entries(dataCollection)
     .map(([entityId, groupData]) => {
       const name = getEntityName(entityId);
-      return Object.entries(groupData).map(([groupId, rawValue]) => {
+      return Object.entries(groupData).map(([groupId, values]) => {
         const group = getGroupName(groupId);
-        const value = rn(rawValue);
+        const value = aggregate(values);
         return {name, group, value};
       });
     })
@@ -269,7 +408,7 @@ function plot(
   const yDomain = new Set(Y);
   const zDomain = new Set(Z);
 
-  const I = d3.range(X.length).filter(i => X[i] > 0 && yDomain.has(Y[i]) && zDomain.has(Z[i]));
+  const I = d3.range(X.length).filter(i => yDomain.has(Y[i]) && zDomain.has(Z[i]));
 
   const height = yDomain.size * 25 + marginTop + marginBottom;
   const yRange = [height - marginBottom, marginTop];
@@ -282,8 +421,8 @@ function plot(
     .order(d3.stackOrderNone)
     .offset(d3.stackOffsetDiverging)(rolled)
     .map(s => {
-      const nonNull = s.filter(d => Boolean(d[1]));
-      const data = nonNull.map(d => Object.assign(d, {i: d.data[1].get(s.key)}));
+      const defined = s.filter(d => !isNaN(d[1]));
+      const data = defined.map(d => Object.assign(d, {i: d.data[1].get(s.key)}));
       return {key: s.key, data};
     });
 
@@ -324,7 +463,7 @@ function plot(
     .join("g")
     .attr("fill", d => colors[d.key])
     .selectAll("rect")
-    .data(d => d.data)
+    .data(d => d.data.filter(([x1, x2]) => x1 !== x2))
     .join("rect")
     .attr("x", ([x1, x2]) => Math.min(xScale(x1), xScale(x2)))
     .attr("y", ({i}) => yScale(Y[i]))

--- a/modules/dynamic/overview/charts-overview.js
+++ b/modules/dynamic/overview/charts-overview.js
@@ -208,7 +208,7 @@ changeViewColumns();
 export function open() {
   const charts = byId("chartsOverview__charts").childElementCount;
   if (!charts) renderChart();
-  else $("#chartsOverview").dialog({title: "Data Charts"});
+  $("#chartsOverview").dialog({title: "Data Charts"});
 }
 
 function appendStyleSheet() {
@@ -271,19 +271,25 @@ function insertHtml() {
   const html = /* html */ `<div id="chartsOverview">
     <form id="chartsOverview__form">
       <div>
-        <button type="submit">Plot</button>
+        <button data-tip="Add a chart" type="submit">Plot</button>
 
-        <select id="chartsOverview__entitiesSelect">${createOptions(entities)}</select>
+        <select data-tip="Select entity (y axis)" id="chartsOverview__entitiesSelect">${createOptions(
+          entities
+        )}</select>
 
         <label>by
-          <select id="chartsOverview__plotBySelect">${createOptions(plotBy)}</select>
+          <select data-tip="Select value to plot by (x axis)" id="chartsOverview__plotBySelect">${createOptions(
+            plotBy
+          )}</select>
         </label>
 
         <label>grouped by
-          <select id="chartsOverview__groupBySelect">${createOptions(entities)}</select>
+          <select data-tip="Select entoty to group by. If you don't need grouping, set it the same as the entity" id="chartsOverview__groupBySelect">${createOptions(
+            entities
+          )}</select>
         </label>
 
-        <label>sorted
+        <label data-tip="Sorting type">sorted
           <select id="chartsOverview__sortingSelect">
             <option value="value">by value</option>
             <option value="name">by name</option>
@@ -292,13 +298,13 @@ function insertHtml() {
         </label>
       </div>
       <div>
-        <span>Type</span>
+        <span data-tip="Chart type">Type</span>
         <select id="chartsOverview__chartType">
           <option value="stackedBar" selected>Stacked Bar</option>
           <option value="normalizedStackedBar">Normalized Stacked Bar</option>
         </select>
 
-        <span>Columns</span>
+        <span data-tip="Columns to display">Columns</span>
         <select id="chartsOverview__viewColumns">
           <option value="1" selected>1</option>
           <option value="2">2</option>
@@ -344,7 +350,7 @@ function renderChart(event) {
   } = quantizationMap[plotBy];
 
   if (!stackable && groupBy !== entity) {
-    tip("Grouping is not supported for this chart type", false, "warn", 4000);
+    tip(`Grouping is not supported for ${plotByLabel}`, false, "warn", 4000);
     groupBy = entity;
   }
 
@@ -549,8 +555,8 @@ function insertChart(chart, title) {
       <strong>Figure ${figureNo}</strong>. ${title}
     </div>
     <div>
-      <button class="icon-download"></button>
-      <button class="icon-trash"></button>
+      <button data-tip="Download the chart in svg format (can open in browser or Inkscape)" class="icon-download"></button>
+      <button data-tip="Remove the chart" class="icon-trash"></button>
     </div>
   `;
 
@@ -590,7 +596,7 @@ const EMPTY_NAME = "no";
 const WIDTH = 800;
 const Y_PADDING = 0.2;
 
-const RESERVED_PX_PER_CHAR = 6;
+const RESERVED_PX_PER_CHAR = 7;
 const LABEL_GAP = 10;
 
 function getTextMinWidth(entities) {

--- a/modules/dynamic/overview/charts-overview.js
+++ b/modules/dynamic/overview/charts-overview.js
@@ -1,5 +1,4 @@
-import {rollup, rollups} from "../../../utils/functionUtils.js";
-import {stack} from "https://cdn.skypack.dev/d3-shape@3";
+import {rollups} from "../../../utils/functionUtils.js";
 
 const entitiesMap = {
   states: {
@@ -434,16 +433,17 @@ function createStackedBarChart(data, {sorting, colors, tooltip, offset, formatX}
   const height = yDomain.size * 25 + margin.top + margin.bottom;
   const yRange = [height - margin.bottom, margin.top];
 
-  const rolled = rollup(...[I, ([i]) => i, i => Y[i], i => Z[i]]);
+  const rolled = rollups(...[I, ([i]) => i, i => Y[i], i => Z[i]]);
 
-  const series = stack()
-    .keys(zDomain)
-    .value(([, I], z) => X[I.get(z)])
+  const series = d3
+    .stack()
+    .keys(groups)
+    .value(([, I], z) => X[new Map(I).get(z)])
     .order(d3.stackOrderNone)
     .offset(offset)(rolled)
     .map(s => {
       const defined = s.filter(d => !isNaN(d[1]));
-      const data = defined.map(d => Object.assign(d, {i: d.data[1].get(s.key)}));
+      const data = defined.map(d => Object.assign(d, {i: new Map(d.data[1]).get(s.key)}));
       return {key: s.key, data};
     });
 

--- a/modules/ui/editors.js
+++ b/modules/ui/editors.js
@@ -1180,12 +1180,12 @@ async function editStates() {
 
 async function editCultures() {
   if (customization) return;
-  const Editor = await import("../dynamic/editors/cultures-editor.js?v=12062022");
+  const Editor = await import("../dynamic/editors/cultures-editor.js?v=1.87.00");
   Editor.open();
 }
 
 async function editReligions() {
   if (customization) return;
-  const Editor = await import("../dynamic/editors/religions-editor.js?v=12062022");
+  const Editor = await import("../dynamic/editors/religions-editor.js?v=1.87.00");
   Editor.open();
 }

--- a/modules/ui/general.js
+++ b/modules/ui/general.js
@@ -121,7 +121,11 @@ function showMapTooltip(point, e, i, g) {
   if (group === "emblems" && e.target.tagName === "use") {
     const parent = e.target.parentNode;
     const [g, type] =
-      parent.id === "burgEmblems" ? [pack.burgs, "burg"] : parent.id === "provinceEmblems" ? [pack.provinces, "province"] : [pack.states, "state"];
+      parent.id === "burgEmblems"
+        ? [pack.burgs, "burg"]
+        : parent.id === "provinceEmblems"
+        ? [pack.provinces, "province"]
+        : [pack.states, "state"];
     const i = +e.target.dataset.i;
     if (event.shiftKey) highlightEmblemElement(type, g[i]);
 
@@ -161,8 +165,10 @@ function showMapTooltip(point, e, i, g) {
   if (group === "ruler") {
     const tag = e.target.tagName;
     const className = e.target.getAttribute("class");
-    if (tag === "circle" && className === "edge") return tip("Drag to adjust. Hold Ctrl and drag to add a point. Click to remove the point");
-    if (tag === "circle" && className === "control") return tip("Drag to adjust. Hold Shift and drag to keep axial direction. Click to remove the point");
+    if (tag === "circle" && className === "edge")
+      return tip("Drag to adjust. Hold Ctrl and drag to add a point. Click to remove the point");
+    if (tag === "circle" && className === "control")
+      return tip("Drag to adjust. Hold Shift and drag to keep axial direction. Click to remove the point");
     if (tag === "circle") return tip("Drag to adjust the measurer");
     if (tag === "polyline") return tip("Click on drag to add a control point");
     if (tag === "path") return tip("Drag to move the measurer");
@@ -248,10 +254,19 @@ function updateCellInfo(point, i, g) {
   infoTemp.innerHTML = convertTemperature(grid.cells.temp[g]);
   infoPrec.innerHTML = cells.h[i] >= 20 ? getFriendlyPrecipitation(i) : "n/a";
   infoRiver.innerHTML = cells.h[i] >= 20 && cells.r[i] ? getRiverInfo(cells.r[i]) : "no";
-  infoState.innerHTML = cells.h[i] >= 20 ? (cells.state[i] ? `${pack.states[cells.state[i]].fullName} (${cells.state[i]})` : "neutral lands (0)") : "no";
-  infoProvince.innerHTML = cells.province[i] ? `${pack.provinces[cells.province[i]].fullName} (${cells.province[i]})` : "no";
+  infoState.innerHTML =
+    cells.h[i] >= 20
+      ? cells.state[i]
+        ? `${pack.states[cells.state[i]].fullName} (${cells.state[i]})`
+        : "neutral lands (0)"
+      : "no";
+  infoProvince.innerHTML = cells.province[i]
+    ? `${pack.provinces[cells.province[i]].fullName} (${cells.province[i]})`
+    : "no";
   infoCulture.innerHTML = cells.culture[i] ? `${pack.cultures[cells.culture[i]].name} (${cells.culture[i]})` : "no";
-  infoReligion.innerHTML = cells.religion[i] ? `${pack.religions[cells.religion[i]].name} (${cells.religion[i]})` : "no";
+  infoReligion.innerHTML = cells.religion[i]
+    ? `${pack.religions[cells.religion[i]].name} (${cells.religion[i]})`
+    : "no";
   infoPopulation.innerHTML = getFriendlyPopulation(i);
   infoBurg.innerHTML = cells.burg[i] ? pack.burgs[cells.burg[i]].name + " (" + cells.burg[i] + ")" : "no";
   infoFeature.innerHTML = f ? pack.features[f].group + " (" + f + ")" : "n/a";
@@ -300,8 +315,7 @@ function getFriendlyHeight([x, y]) {
 function getHeight(h, abs) {
   const unit = heightUnit.value;
   let unitRatio = 3.281; // default calculations are in feet
-  if (unit === "m") unitRatio = 1;
-  // if meter
+  if (unit === "m") unitRatio = 1; // if meter
   else if (unit === "f") unitRatio = 0.5468; // if fathom
 
   let height = -990;
@@ -312,10 +326,14 @@ function getHeight(h, abs) {
   return rn(height * unitRatio) + " " + unit;
 }
 
+function getPrecipitation(prec) {
+  return prec * 100 + " mm";
+}
+
 // get user-friendly (real-world) precipitation value from map data
 function getFriendlyPrecipitation(i) {
   const prec = grid.cells.prec[pack.cells.g[i]];
-  return prec * 100 + " mm";
+  return getPrecipitation(prec);
 }
 
 function getRiverInfo(id) {
@@ -399,7 +417,8 @@ function highlightEmblemElement(type, el) {
 // assign lock behavior
 document.querySelectorAll("[data-locked]").forEach(function (e) {
   e.addEventListener("mouseover", function (event) {
-    if (this.className === "icon-lock") tip("Click to unlock the option and allow it to be randomized on new map generation");
+    if (this.className === "icon-lock")
+      tip("Click to unlock the option and allow it to be randomized on new map generation");
     else tip("Click to lock the option and always use the current value on new map generation");
     event.stopPropagation();
   });
@@ -476,7 +495,10 @@ function showInfo() {
   const Patreon = link("https://www.patreon.com/azgaar", "Patreon");
   const Armoria = link("https://azgaar.github.io/Armoria", "Armoria");
 
-  const QuickStart = link("https://github.com/Azgaar/Fantasy-Map-Generator/wiki/Quick-Start-Tutorial", "Quick start tutorial");
+  const QuickStart = link(
+    "https://github.com/Azgaar/Fantasy-Map-Generator/wiki/Quick-Start-Tutorial",
+    "Quick start tutorial"
+  );
   const QAA = link("https://github.com/Azgaar/Fantasy-Map-Generator/wiki/Q&A", "Q&A page");
   const VideoTutorial = link("https://youtube.com/playlist?list=PLtgiuDC8iVR2gIG8zMTRn7T_L0arl9h1C", "Video tutorial");
 

--- a/modules/ui/hotkeys.js
+++ b/modules/ui/hotkeys.js
@@ -49,6 +49,7 @@ function handleKeyup(event) {
   else if (shift && code === "KeyY") openEmblemEditor();
   else if (shift && code === "KeyQ") editUnits();
   else if (shift && code === "KeyO") editNotes();
+  else if (shift && code === "KeyA") overviewCharts();
   else if (shift && code === "KeyT") overviewBurgs();
   else if (shift && code === "KeyV") overviewRivers();
   else if (shift && code === "KeyM") overviewMilitary();
@@ -114,12 +115,17 @@ function pressNumpadSign(key) {
   let brush = null;
 
   if (document.getElementById("brushRadius")?.offsetParent) brush = document.getElementById("brushRadius");
-  else if (document.getElementById("biomesManuallyBrush")?.offsetParent) brush = document.getElementById("biomesManuallyBrush");
-  else if (document.getElementById("statesManuallyBrush")?.offsetParent) brush = document.getElementById("statesManuallyBrush");
-  else if (document.getElementById("provincesManuallyBrush")?.offsetParent) brush = document.getElementById("provincesManuallyBrush");
-  else if (document.getElementById("culturesManuallyBrush")?.offsetParent) brush = document.getElementById("culturesManuallyBrush");
+  else if (document.getElementById("biomesManuallyBrush")?.offsetParent)
+    brush = document.getElementById("biomesManuallyBrush");
+  else if (document.getElementById("statesManuallyBrush")?.offsetParent)
+    brush = document.getElementById("statesManuallyBrush");
+  else if (document.getElementById("provincesManuallyBrush")?.offsetParent)
+    brush = document.getElementById("provincesManuallyBrush");
+  else if (document.getElementById("culturesManuallyBrush")?.offsetParent)
+    brush = document.getElementById("culturesManuallyBrush");
   else if (document.getElementById("zonesBrush")?.offsetParent) brush = document.getElementById("zonesBrush");
-  else if (document.getElementById("religionsManuallyBrush")?.offsetParent) brush = document.getElementById("religionsManuallyBrush");
+  else if (document.getElementById("religionsManuallyBrush")?.offsetParent)
+    brush = document.getElementById("religionsManuallyBrush");
 
   if (brush) {
     const value = minmax(+brush.value + change, +brush.min, +brush.max);
@@ -133,18 +139,26 @@ function pressNumpadSign(key) {
 
 function toggleMode() {
   if (zonesRemove?.offsetParent) {
-    zonesRemove.classList.contains("pressed") ? zonesRemove.classList.remove("pressed") : zonesRemove.classList.add("pressed");
+    zonesRemove.classList.contains("pressed")
+      ? zonesRemove.classList.remove("pressed")
+      : zonesRemove.classList.add("pressed");
   }
 }
 
 function removeElementOnKey() {
-  const fastDelete = Array.from(document.querySelectorAll("[role='dialog'] .fastDelete")).find(dialog => dialog.style.display !== "none");
+  const fastDelete = Array.from(document.querySelectorAll("[role='dialog'] .fastDelete")).find(
+    dialog => dialog.style.display !== "none"
+  );
   if (fastDelete) fastDelete.click();
 
-  const visibleDialogs = Array.from(document.querySelectorAll("[role='dialog']")).filter(dialog => dialog.style.display !== "none");
+  const visibleDialogs = Array.from(document.querySelectorAll("[role='dialog']")).filter(
+    dialog => dialog.style.display !== "none"
+  );
   if (!visibleDialogs.length) return;
 
-  visibleDialogs.forEach(dialog => dialog.querySelectorAll("button").forEach(button => button.textContent === "Remove" && button.click()));
+  visibleDialogs.forEach(dialog =>
+    dialog.querySelectorAll("button").forEach(button => button.textContent === "Remove" && button.click())
+  );
 }
 
 function closeAllDialogs() {

--- a/modules/ui/options.js
+++ b/modules/ui/options.js
@@ -635,7 +635,7 @@ function changeEra() {
 }
 
 async function openTemplateSelectionDialog() {
-  const HeightmapSelectionDialog = await import("../dynamic/heightmap-selection.js?v=290520222");
+  const HeightmapSelectionDialog = await import("../dynamic/heightmap-selection.js?v=1.87.00");
   HeightmapSelectionDialog.open();
 }
 

--- a/modules/ui/tools.js
+++ b/modules/ui/tools.js
@@ -19,6 +19,7 @@ toolsContent.addEventListener("click", function (event) {
   else if (button === "editUnitsButton") editUnits();
   else if (button === "editNotesButton") editNotes();
   else if (button === "editZonesButton") editZones();
+  else if (button === "overviewChartsButton") overviewCharts();
   else if (button === "overviewBurgsButton") overviewBurgs();
   else if (button === "overviewRiversButton") overviewRivers();
   else if (button === "overviewMilitaryButton") overviewMilitary();
@@ -854,4 +855,9 @@ function viewCellDetails() {
     title: "Cell Details",
     position: {my: "right top", at: "right-10 top+10", of: "svg", collision: "fit"}
   });
+}
+
+async function overviewCharts() {
+  const Overview = await import("../dynamic/overview/charts-overview.js");
+  Overview.open();
 }

--- a/utils/functionUtils.js
+++ b/utils/functionUtils.js
@@ -1,14 +1,5 @@
-function identity(x) {
-  return x;
-}
-
-export function group(values, ...keys) {
-  return nest(values, identity, identity, keys);
-}
-
-export function rollup(values, reduce, ...keys) {
-  return nest(values, identity, reduce, keys);
-}
+// extracted d3 code to bypass version conflicts
+// https://github.com/d3/d3-array/blob/main/src/group.js
 
 export function rollups(values, reduce, ...keys) {
   return nest(values, Array.from, reduce, keys);

--- a/utils/functionUtils.js
+++ b/utils/functionUtils.js
@@ -1,0 +1,26 @@
+function identity(x) {
+  return x;
+}
+
+export function rollup(values, reduce, ...keys) {
+  return nest(values, identity, reduce, keys);
+}
+
+function nest(values, map, reduce, keys) {
+  return (function regroup(values, i) {
+    if (i >= keys.length) return reduce(values);
+    const groups = new Map();
+    const keyof = keys[i++];
+    let index = -1;
+    for (const value of values) {
+      const key = keyof(value, ++index, values);
+      const group = groups.get(key);
+      if (group) group.push(value);
+      else groups.set(key, [value]);
+    }
+    for (const [key, values] of groups) {
+      groups.set(key, regroup(values, i));
+    }
+    return map(groups);
+  })(values, 0);
+}

--- a/utils/functionUtils.js
+++ b/utils/functionUtils.js
@@ -2,8 +2,16 @@ function identity(x) {
   return x;
 }
 
+export function group(values, ...keys) {
+  return nest(values, identity, identity, keys);
+}
+
 export function rollup(values, reduce, ...keys) {
   return nest(values, identity, reduce, keys);
+}
+
+export function rollups(values, reduce, ...keys) {
+  return nest(values, Array.from, reduce, keys);
 }
 
 function nest(values, map, reduce, keys) {

--- a/utils/unitUtils.js
+++ b/utils/unitUtils.js
@@ -2,27 +2,20 @@
 // FMG utils related to units
 
 // conver temperature from °C to other scales
+const temperatureConversionMap = {
+  "°C": temp => rn(temp) + "°C",
+  "°F": temp => rn((temp * 9) / 5 + 32) + "°F",
+  K: temp => rn(temp + 273.15) + "K",
+  "°R": temp => rn(((temp + 273.15) * 9) / 5) + "°R",
+  "°De": temp => rn(((100 - temp) * 3) / 2) + "°De",
+  "°N": temp => rn((temp * 33) / 100) + "°N",
+  "°Ré": temp => rn((temp * 4) / 5) + "°Ré",
+  "°Rø": temp => rn((temp * 21) / 40 + 7.5) + "°Rø"
+};
+
 function convertTemperature(temp) {
-  switch (temperatureScale.value) {
-    case "°C":
-      return rn(temp) + "°C";
-    case "°F":
-      return rn((temp * 9) / 5 + 32) + "°F";
-    case "K":
-      return rn(temp + 273.15) + "K";
-    case "°R":
-      return rn(((temp + 273.15) * 9) / 5) + "°R";
-    case "°De":
-      return rn(((100 - temp) * 3) / 2) + "°De";
-    case "°N":
-      return rn((temp * 33) / 100) + "°N";
-    case "°Ré":
-      return rn((temp * 4) / 5) + "°Ré";
-    case "°Rø":
-      return rn((temp * 21) / 40 + 7.5) + "°Rø";
-    default:
-      return rn(temp) + "°C";
-  }
+  const scale = temperatureScale.value || "°C";
+  return temperatureConversionMap[scale](temp);
 }
 
 // corvent number to short string with SI postfix

--- a/versioning.js
+++ b/versioning.js
@@ -28,6 +28,7 @@ const version = "1.87.00"; // generator version, update each time
 
       <ul>
         <strong>Latest changes:</strong>
+        <li>Data Charts screen</li>
         <li>Сultures and religions can have multiple parents in hierarchy tree</li>
         <li>Heightmap selection screen</li>
         <li>Dialogs optimization for mobile</li>
@@ -36,9 +37,6 @@ const version = "1.87.00"; // generator version, update each time
         <li>Ability to install the App</li>
         <li>14 new default fonts</li>
         <li>Caching for faster startup</li>
-        <li>Submap tool by Goteguru</li>
-        <li>Resample tool by Goteguru</li>
-        <li>Pre-defined heightmaps</li>
       </ul>
 
       <p>Join our <a href="${discord}" target="_blank">Discord server</a> and <a href="${reddit}" target="_blank">Reddit community</a> to ask questions, share maps, discuss the Generator and Worlbuilding, report bugs and propose new features.</p>

--- a/versioning.js
+++ b/versioning.js
@@ -1,7 +1,7 @@
 "use strict";
 // version and caching control
 
-const version = "1.86.07"; // generator version, update each time
+const version = "1.87.00"; // generator version, update each time
 
 {
   document.title += " v" + version;


### PR DESCRIPTION
# Description

Ability to show charts for various FMG data in a form like: plot `states` by `population` grouped by `cultures`. 5 types of data for . 2 types of charts (stacked bar and normalized stacked bar). About 500 different charts in total...

![charts](https://user-images.githubusercontent.com/26469650/175390914-f68a0c33-3ac2-4a54-bb01-e4f07f3f592c.png)

# Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring / style
- [ ] Documentation update / chore
- [ ] Other (please describe)

# Versioning
- [x] Version is updated
- [x] Changed files hash is updated
