### PR TITLE
Fix for State opacity slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -794,7 +794,7 @@
               </tr>
             </tbody>
 
-            <tbody id="styleOpacity" style="display: block">
+            <tbody id="styleOpacity" style="display: none">
               <tr data-tip="Set opacity. 0: transparent, 1: solid">
                 <td>Opacity</td>
                 <td>

--- a/modules/ui/style.js
+++ b/modules/ui/style.js
@@ -292,7 +292,7 @@ styleGroupSelect.addEventListener("change", selectStyleElement);
 function getEl() {
   const el = styleElementSelect.value;
   const g = styleGroupSelect.value;
-  if (g === el) return svg.select("#" + el);
+  if (g === el || g === "") return svg.select("#" + el);
   else return svg.select("#" + el).select("#" + g);
 }
 


### PR DESCRIPTION
# Description

Fix for States opacity - it was showing two opacity sliders under Style, and using the first one caused console errors.  

# Type of change

- [X ] Bug fix
- [ ] New feature
- [ ] Refactoring / style
- [ ] Documentation update / chore
- [ ] Other (please describe)

# Versioning

- [ ] Version is updated
- [ ] Changed files hash is updated
