### PR TITLE
Reducing the size of the culture center circle

### DIFF
--- a/modules/dynamic/editors/cultures-editor.js
+++ b/modules/dynamic/editors/cultures-editor.js
@@ -310,7 +310,7 @@ const cultureHighlightOn = debounce(event => {
     .select("#cultureCenter" + cultureId)
     .raise()
     .transition(animate)
-    .attr("r", 2)
+    .attr("r", 3)
     .attr("stroke", "#d0240f");
 }, 200);
 
@@ -326,7 +326,7 @@ function cultureHighlightOff(event) {
   debug
     .select("#cultureCenter" + cultureId)
     .transition()
-    .attr("r", 1)
+    .attr("r", 2)
     .attr("stroke", null);
 }
 
@@ -557,7 +557,7 @@ function drawCultureCenters() {
   const cultureCenters = debug
     .append("g")
     .attr("id", "cultureCenters")
-    .attr("stroke-width", 0.5)
+    .attr("stroke-width", 0.8)
     .attr("stroke", "#444444")
     .style("cursor", "move");
 
@@ -569,7 +569,7 @@ function drawCultureCenters() {
     .append("circle")
     .attr("id", d => "cultureCenter" + d.i)
     .attr("data-id", d => d.i)
-    .attr("r", 1)
+    .attr("r", 2)
     .attr("fill", d => d.color)
     .attr("cx", d => pack.cells.p[d.center][0])
     .attr("cy", d => pack.cells.p[d.center][1])

--- a/modules/dynamic/editors/cultures-editor.js
+++ b/modules/dynamic/editors/cultures-editor.js
@@ -310,7 +310,7 @@ const cultureHighlightOn = debounce(event => {
     .select("#cultureCenter" + cultureId)
     .raise()
     .transition(animate)
-    .attr("r", 8)
+    .attr("r", 2)
     .attr("stroke", "#d0240f");
 }, 200);
 
@@ -326,7 +326,7 @@ function cultureHighlightOff(event) {
   debug
     .select("#cultureCenter" + cultureId)
     .transition()
-    .attr("r", 6)
+    .attr("r", 1)
     .attr("stroke", null);
 }
 
@@ -557,7 +557,7 @@ function drawCultureCenters() {
   const cultureCenters = debug
     .append("g")
     .attr("id", "cultureCenters")
-    .attr("stroke-width", 2)
+    .attr("stroke-width", 0.5)
     .attr("stroke", "#444444")
     .style("cursor", "move");
 
@@ -569,7 +569,7 @@ function drawCultureCenters() {
     .append("circle")
     .attr("id", d => "cultureCenter" + d.i)
     .attr("data-id", d => d.i)
-    .attr("r", 6)
+    .attr("r", 1)
     .attr("fill", d => d.color)
     .attr("cx", d => pack.cells.p[d.center][0])
     .attr("cy", d => pack.cells.p[d.center][1])


### PR DESCRIPTION
This makes it easier to place the center more precisely and to see what cell it is in.

# Description

The culture centers are currently displayed far too prominently. For culture centers placed closed together, it makes it near impossible to view them properly. Even for culture centers placed far apart, due to the size of the circle, it makes it difficult to figure out what cell the center is actually in.

While decreasing the visual size of the culture centers in this manner is not ideal (ideally there should be an option to adjust their size in the future), it is better than the present.

# Type of change

<!-- Please put X into brackers of required option OR delete options that are not relevant -->

- [X] Bug fix
- [ ] New feature
- [X] Refactoring / style
- [ ] Documentation update / chore
- [ ] Other (please describe)

# Versioning

<!-- Update the version if you want the PR to be merged fast. Currently it's a manual 3-steps process:
  * update version in `versioning.js` using semver principle. Just set the next patch (for fixes) or minor version (for new features)
  * for all changed files update hash (the part after `?`) in place where file is requested (usually it's `index.html`)
  * if the change can be really interesting for end-users, describe it inside the `showUpdateWindow()` function in `versioning.js` -->

- [ ] Version is updated
- [X] Changed files hash is updated
