### PR TITLE
Fix: min zoom extent is allowed to be negative.

### DIFF
--- a/index.html
+++ b/index.html
@@ -7817,7 +7817,7 @@
     <script src="modules/ui/stylePresets.js"></script>
 
     <script src="modules/ui/general.js?v=1.87.00"></script>
-    <script src="modules/ui/options.js?v=1.87.00"></script>
+    <script src="modules/ui/options.js?v=1.87.09"></script>
     <script src="main.js"></script>
 
     <script defer src="modules/relief-icons.js"></script>

--- a/modules/ui/options.js
+++ b/modules/ui/options.js
@@ -461,7 +461,7 @@ function changeDialogsTheme(themeColor, transparency) {
 }
 
 function changeZoomExtent(value) {
-  if(zoomExtentMin.value > zoomExtentMax.value) {
+  if(+zoomExtentMin.value > +zoomExtentMax.value) {
     [zoomExtentMin.value, zoomExtentMax.value]=[zoomExtentMax.value, zoomExtentMin.value];
   }
   const min = Math.max(+zoomExtentMin.value, 0.01);

--- a/modules/ui/options.js
+++ b/modules/ui/options.js
@@ -461,8 +461,13 @@ function changeDialogsTheme(themeColor, transparency) {
 }
 
 function changeZoomExtent(value) {
+  if(zoomExtentMin.value > zoomExtentMax.value) {
+    [zoomExtentMin.value, zoomExtentMax.value]=[zoomExtentMax.value, zoomExtentMin.value];
+  }
   const min = Math.max(+zoomExtentMin.value, 0.01);
   const max = Math.min(+zoomExtentMax.value, 200);
+  zoomExtentMin.value = min;
+  zoomExtentMax.value = max;
   zoom.scaleExtent([min, max]);
   const scale = minmax(+value, 0.01, 200);
   zoom.scaleTo(svg, scale);

--- a/versioning.js
+++ b/versioning.js
@@ -1,7 +1,7 @@
 "use strict";
 
 // version and caching control
-const version = "1.87.08"; // generator version, update each time
+const version = "1.87.09"; // generator version, update each time
 
 {
   document.title += " v" + version;


### PR DESCRIPTION
Min and Max Zoom fields are now bound by 0.01 and 200

# Description

<!-- Please include a summary of the change, motivation and context. It it's a but fix, add a reference in format #issue_number -->
The values of the Zoom field and the internal zoom scale could be different if the value breaked the bounds. The changes ensure that:
1. The value zoomExtentMin is always the smaller value of both zoomExtentMin and zoomExtentMax
2. The respective UI parts are set to the bounded min and max values
This ensures that zero or negative values are not present even when a new Map is generated.

# Type of change

<!-- Please put X into brackers of required option OR delete options that are not relevant -->

- [X] Bug fix
- [X] Refactoring / style

# Versioning

<!-- Update the version if you want the PR to be merged fast. Currently it's a manual 3-steps process:
  * update version in `versioning.js` using semver principle. Just set the next patch (for fixes) or minor version (for new features)
  * for all changed files update hash (the part after `?`) in place where file is requested (usually it's `index.html`)
  * if the change can be really interesting for end-users, describe it inside the `showUpdateWindow()` function in `versioning.js` -->

- [x] Version is updated
- [x] Changed files hash is updated
