### PR TITLE
adding a way to manage state relations in batch

### DIFF
--- a/index.css
+++ b/index.css
@@ -2346,3 +2346,10 @@ svg.button {
         background: #25252a;
     }
 }
+div.states > div.diploDivChk {
+    width: 1.5em;
+    display: inline-block;
+}
+input.diploChk {
+     display: block;
+}

--- a/index.html
+++ b/index.html
@@ -4428,6 +4428,9 @@
 
       <div id="diplomacyEditor" class="dialog stable" style="display: none">
         <div id="diplomacyHeader" class="header" style="grid-template-columns: 15em 6em">
+        <div class="diploDivChk" style="display:none; width:1.5em">
+            &nbsp;
+          </div>
           <div data-tip="Click to sort by state name" class="sortable alphabetically" data-sortby="name">
             State&nbsp;
           </div>
@@ -4462,6 +4465,24 @@
             id="diplomacyExport"
             data-tip="Save state relations matrix as a text file (.csv)"
             class="icon-download"
+          ></button>
+                    <button
+                  id="diplomacyBatchEdit"
+                  data-tip=""
+                  class="icon-edit"
+          ></button>
+            <hr>
+                      <!--<button
+            id="diplomacyImport"
+            data-tip=""
+            class="icon-download"
+          ></button>-->
+          <select id="diplomacyRelationSelect" style="display:none"></select>
+          <button
+                  id="diplomacyBatchEditConfirm"
+                  data-tip=""
+                  class="icon-ok-circled"
+                  style="display:none"
           ></button>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -4466,21 +4466,16 @@
             data-tip="Save state relations matrix as a text file (.csv)"
             class="icon-download"
           ></button>
-                    <button
+            <button
                   id="diplomacyBatchEdit"
-                  data-tip=""
+                  data-tip="Toggle bacth edit of relations"
                   class="icon-edit"
           ></button>
-            <hr>
-                      <!--<button
-            id="diplomacyImport"
-            data-tip=""
-            class="icon-download"
-          ></button>-->
+          <hr id="BatchEditHr" style="display:none">
           <select id="diplomacyRelationSelect" style="display:none"></select>
           <button
                   id="diplomacyBatchEditConfirm"
-                  data-tip=""
+                  data-tip="Change relation of selected states"
                   class="icon-ok-circled"
                   style="display:none"
           ></button>

--- a/modules/ui/diplomacy-editor.js
+++ b/modules/ui/diplomacy-editor.js
@@ -85,7 +85,6 @@ function editDiplomacy() {
   document.getElementById("diplomacyShowMatrix").addEventListener("click", showRelationsMatrix);
   document.getElementById("diplomacyHistory").addEventListener("click", showRelationsHistory);
   document.getElementById("diplomacyExport").addEventListener("click", downloadDiplomacyData);
-  //document.getElementById("diplomacyImport").addEventListener("click", uploadDiplomacyData);
   document.getElementById("diplomacyBatchEdit").addEventListener("click", toggleDiplomacyCheckbox);
   document.getElementById("diplomacyBatchEditConfirm").addEventListener("click", ConfirmDiplomacyBatch);
 
@@ -121,10 +120,8 @@ function editDiplomacy() {
   function diplomacyEditorAddLines() {
     const states = pack.states;
     const selectedLine = body.querySelector("div.Self");
-    
     const selectedId = selectedLine ? +selectedLine.dataset.id : states.find(s => s.i && !s.removed).i;
     const selectedName = states[selectedId].name;
-
     const toggleState = modules.batchEditDiplomacy ? 'inline-block' : 'none';
 
     COArenderer.trigger("stateCOA" + selectedId, states[selectedId].coa);
@@ -145,8 +142,6 @@ function editDiplomacy() {
 
       const name = state.fullName.length < 23 ? state.fullName : state.name;
       COArenderer.trigger("stateCOA" + state.i, state.coa);
-
-     
 
       lines += /* html */ `<div class="states" data-id=${state.i} data-name="${name}" data-relations="${relation}">
        <div data-tip="${tipSelect}" style="display:${toggleState}" class="diploDivChk"><input class="diploChk" type="checkbox" name="chk[${selectedId}][]" value="${state.i}"></div>
@@ -465,10 +460,7 @@ function editDiplomacy() {
     const name = getFileName("Relations") + ".csv";
     downloadFile(data, name);
   }
-
-  function uploadDiplomacyData() {
-  }
-
+  
   function closeDiplomacyEditor() {
     restoreDefaultEvents();
     clearMainTip();
@@ -482,6 +474,7 @@ function editDiplomacy() {
   function toggleDiplomacyCheckbox(){
     modules.batchEditDiplomacy = !modules.batchEditDiplomacy;
 
+    BatchEditHr.style.display = (modules.batchEditDiplomacy?"block":"none");
     diplomacyRelationSelect.style.display = (modules.batchEditDiplomacy?"inline-block":"none");
     diplomacyBatchEditConfirm.style.display = (modules.batchEditDiplomacy?"inline-block":"none");
     diplomacyHeader.style['grid-template-columns'] = (modules.batchEditDiplomacy?"1.5em 15em 6em":"15em 6em");
@@ -495,9 +488,7 @@ function editDiplomacy() {
     document.querySelectorAll(".diploDivChk > input.diploChk:checked").forEach(function(ipt){
         const objectId = +body.querySelector("div.Self").dataset.id;
         const subjectId =ipt.value;
-
         changeRelation(subjectId, objectId, states[subjectId].diplomacy[objectId], diplomacyRelationSelect.value);
-
     });
     //Clear selection waiting for next batch
     document.querySelectorAll(".diploDivChk").forEach(el => (el.checked = false));


### PR DESCRIPTION
# Description
Added a button in the Diplomacy editor that toggles a column with one checkbox for each state, and two new component in the footer (one select and one button).
The relation selected in the select, is applied to all checked states when the confirm button is pressed
In this way is possible to manage similar relations of one state in batchs.
[https://github.com/Azgaar/Fantasy-Map-Generator/issues/891](https://github.com/Azgaar/Fantasy-Map-Generator/issues/891)

# Type of change

<!-- Please put X into brackers of required option OR delete options that are not relevant -->

- [ ] Bug fix
- [ x] New feature
- [ ] Refactoring / style
- [ ] Documentation update / chore
- [ ] Other (please describe)

# Versioning

<!-- Update the version if you want the PR to be merged fast. Currently it's a manual 3-steps process:
  * update version in `versioning.js` using semver principle. Just set the next patch (for fixes) or minor version (for new features)
  * for all changed files update hash (the part after `?`) in place where file is requested (usually it's `index.html`)
  * if the change can be really interesting for end-users, describe it inside the `showUpdateWindow()` function in `versioning.js` -->

- [ ] Version is updated
- [ ] Changed files hash is updated
