### PR TITLE
Fix typo and remove spurious quotes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1919,7 +1919,7 @@
               <td>
                 <select id="shapeRendering" data-stored="shapeRendering">
                   <option value="geometricPrecision">Best quality</option>
-                  <option value="optimizeSpeed" selected>Best performace</option>
+                  <option value="optimizeSpeed" selected>Best performance</option>
                 </select>
               </td>
               <td></td>
@@ -3813,8 +3813,8 @@
           <button id="battleNameShow" data-tip="Set battle name" class="icon-font"></button>
           <div id="battleNameSection" style="display: none">
             <button id="battleNameHide" data-tip="Hide the battle name section" class="icon-font"></button>
-            <input id="battleNamePlace" data-tip="Type place name"" style="width: 30%"> <input id="battleNameFull"
-            data-tip="Type full battle name"" style="width: 46%">
+            <input id="battleNamePlace" data-tip="Type place name" style="width: 30%"> <input id="battleNameFull"
+            data-tip="Type full battle name" style="width: 46%">
             <button
               id="battleNameCulture"
               data-tip="Generate culture-specific name for place and battle"

--- a/versioning.js
+++ b/versioning.js
@@ -1,7 +1,7 @@
 "use strict";
 
 // version and caching control
-const version = "1.93.04"; // generator version, update each time
+const version = "1.93.05"; // generator version, update each time
 
 {
   document.title += " v" + version;


### PR DESCRIPTION
# Description

Fixes a typo (`performace` -> `performance`) and removes two quotes (`"`) which I think shouldn't have been there.

# Type of change

- [x] Documentation update / chore

# Versioning

- [x] Version is updated
- [x] Changed files hash is updated
    (not applicable because only `index.html` was updated)
