### PR TITLE
Add the name of culture and namesbase in the name editor dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -4612,7 +4612,7 @@
           <span data-tip="Speak the name. You can change voice and language in options" class="speaker">🔊</span>
           <span
             id="provinceNameEditorShortCulture"
-            data-tip="Generate culture-specific name"
+            data-tip="Generate culture-specific name for the province"
             class="icon-book pointer"
           ></span>
           <span id="provinceNameEditorShortRandom" data-tip="Generate random name" class="icon-globe pointer"></span>
@@ -4688,6 +4688,13 @@
             class="icon-arrows-cw pointer"
           ></span>
         </div>
+		
+		<div id="provinceCultureName" data-tip="Dominant culture in the province. This decides the naming criteria">
+		Province culture:&nbsp;<span id="provinceCultureDisplay"></span>
+		</div>
+		<div id="provinceCultureBaseName" data-tip="Namesbase used by the dominant culture in the province.">
+		Province language:&nbsp;<span id="provinceLanguageDisplay"></span>
+		</div>
       </div>
 
       <div id="namesbaseEditor" class="dialog stable textual" style="display: none">

--- a/modules/dynamic/editors/states-editor.js
+++ b/modules/dynamic/editors/states-editor.js
@@ -434,13 +434,13 @@ function editStateName(state) {
   modules.editStateName = true;
 
   // add listeners
-  byId("stateNameEditorShortCulture").on("click", regenerateShortNameCuture);
+  byId("stateNameEditorShortCulture").on("click", regenerateShortNameCulture);
   byId("stateNameEditorShortRandom").on("click", regenerateShortNameRandom);
   byId("stateNameEditorAddForm").on("click", addCustomForm);
   byId("stateNameEditorCustomForm").on("change", addCustomForm);
   byId("stateNameEditorFullRegenerate").on("click", regenerateFullName);
 
-  function regenerateShortNameCuture() {
+  function regenerateShortNameCulture() {
     const state = +stateNameEditor.dataset.state;
     const culture = pack.states[state].culture;
     const name = Names.getState(Names.getCultureShort(culture), culture);

--- a/modules/ui/provinces-editor.js
+++ b/modules/ui/provinces-editor.js
@@ -294,7 +294,7 @@ function editProvinces() {
     // move all burgs to a new state
     province.burgs.forEach(b => (burgs[b].state = newStateId));
 
-    // difine new state attributes
+    // define new state attributes
     const {cell: center, culture} = burgs[burgId];
     const color = getRandomColor();
     const coa = province.coa;
@@ -500,6 +500,12 @@ function editProvinces() {
     document.getElementById("provinceNameEditorShort").value = p.name;
     applyOption(provinceNameEditorSelectForm, p.formName);
     document.getElementById("provinceNameEditorFull").value = p.fullName;
+	
+    const cultureName = pack.cultures[pack.cells.culture[pack.provinces[province].center]].name; // to display the culture name
+    const provinceLangID = pack.cultures[pack.cells.culture[pack.provinces[province].center]].base;
+    const provinceNameBase = Names.getNameBases()[provinceLangID].name;
+    document.getElementById("provinceCultureDisplay").innerText = cultureName;
+    document.getElementById("provinceLanguageDisplay").innerText = provinceNameBase;
 
     $("#provinceNameEditor").dialog({
       resizable: false,
@@ -520,12 +526,17 @@ function editProvinces() {
     modules.editProvinceName = true;
 
     // add listeners
-    document.getElementById("provinceNameEditorShortCulture").addEventListener("click", regenerateShortNameCuture);
+    document.getElementById("provinceNameEditorShortCulture").addEventListener("click", regenerateShortNameCulture);
     document.getElementById("provinceNameEditorShortRandom").addEventListener("click", regenerateShortNameRandom);
     document.getElementById("provinceNameEditorAddForm").addEventListener("click", addCustomForm);
     document.getElementById("provinceNameEditorFullRegenerate").addEventListener("click", regenerateFullName);
+	
+    document.getElementById("provinceNameEditorShortCulture").addEventListener("mouseover", showdatatipNamesbase);
+    function showdatatipNamesbase() {
+      tip("namesbase " + this.id + Names.getNameBases()[provinceCultureID].name);
+	}
 
-    function regenerateShortNameCuture() {
+    function regenerateShortNameCulture() {
       const province = +provinceNameEditor.dataset.province;
       const culture = pack.cells.culture[pack.provinces[province].center];
       const name = Names.getState(Names.getCultureShort(culture), culture);


### PR DESCRIPTION
Added the name of the culture and  namesbase in the dialog "name editor". This tells information on the "click to generate a culture-specific name" It tells you the culture before changing name.

# Description

Added the name of the culture and  namesbase in the dialog "name editor". This tells information on the "click to generate a culture-specific name" It tells you the culture before changing name.

# Type of change

- [X] New feature

# Versioning

I did not change the version. Maybe this can be combined with other changes in the same version.
