### PR TITLE
Fix regiments getting bugged when merging states

### DIFF
--- a/modules/dynamic/editors/states-editor.js
+++ b/modules/dynamic/editors/states-editor.js
@@ -1427,7 +1427,7 @@ function openStateMergeDialog() {
         if (element) {
           element.id = newId;
           element.dataset.state = rulingStateId;
-          element.dataset.i = newIndex;
+          element.dataset.id = newIndex;
           rulingStateArmy.appendChild(element);
         }
       });

--- a/modules/ui/editors.js
+++ b/modules/ui/editors.js
@@ -1224,7 +1224,7 @@ function refreshAllEditors() {
 // dynamically loaded editors
 async function editStates() {
   if (customization) return;
-  const Editor = await import("../dynamic/editors/states-editor.js?v=1.96.06");
+  const Editor = await import("../dynamic/editors/states-editor.js?v=1.97.06");
   Editor.open();
 }
 

--- a/versioning.js
+++ b/versioning.js
@@ -1,7 +1,7 @@
 "use strict";
 
 // version and caching control
-const version = "1.97.05"; // generator version, update each time
+const version = "1.97.06"; // generator version, update each time
 
 {
   document.title += " v" + version;


### PR DESCRIPTION
# Description

`dataset.i` -> `dataset.id`

Fixes regiments of merged states getting bugged when merging states.
When a state was merged, the "data-id" field of regiments from the merged state was not updated, causing them to get mixed up with regiments of the ruling state.

# Type of change

<!-- Please put X into brackers of required option OR delete options that are not relevant -->

- [X] Bug fix
- [ ] New feature
- [ ] Refactoring / style
- [ ] Documentation update / chore
- [ ] Other (please describe)

# Versioning

<!-- Update the version if you want the PR to be merged fast. Currently it's a manual 3-steps process:
  * update version in `versioning.js` using semver principle. Just set the next patch (for fixes) or minor version (for new features)
  * for all changed files update hash (the part after `?`) in place where file is requested (usually it's `index.html`)
  * if the change can be really interesting for end-users, describe it inside the `showUpdateWindow()` function in `versioning.js` -->

- [X] Version is updated
- [X] Changed files hash is updated
