### PR TITLE
Fixes/hide unneeded burg labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -8053,7 +8053,7 @@
 
     <script src="modules/ui/general.js?v=1.96.00"></script>
     <script src="modules/ui/options.js?v=1.96.00"></script>
-    <script src="main.js?v=1.97.00"></script>
+    <script src="main.js?v=1.97.08"></script>
 
     <script defer src="modules/relief-icons.js"></script>
     <script defer src="modules/ui/style.js?v=1.96.00"></script>

--- a/main.js
+++ b/main.js
@@ -429,7 +429,11 @@ function findBurgForMFCG(params) {
 function handleZoom(isScaleChanged, isPositionChanged) {
   viewbox.attr("transform", `translate(${viewX} ${viewY}) scale(${scale})`);
 
-  if (isPositionChanged) drawCoordinates();
+  if (isPositionChanged) {
+    drawCoordinates();
+    hideOutOfViewLabels();
+  }
+
 
   if (isScaleChanged) {
     invokeActiveZooming();
@@ -451,6 +455,35 @@ function handleZoom(isScaleChanged, isPositionChanged) {
     ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
   }
 }
+
+function hideOutOfViewLabels() {
+  const towns = pack.burgs.filter(b => b.i && !b.capital && !b.removed);
+  const townLabels = burgLabels.select("#towns");
+
+
+  const bounds = getViewBoxExtent()
+
+  const minX = bounds[0][0];
+  const maxX = bounds[1][0];
+
+  const minY = bounds[0][1];
+  const maxY = bounds[1][1];
+
+  console.log("TownLabels:", townLabels.selectAll("text"));
+
+  townLabels.selectAll("text").each(function (burg, i, z) {
+    burg = towns[i];
+    if(!burg) return;
+
+    if(burg.x < minX || burg.x > maxX || burg.y < minY || burg.y > maxY) {
+      d3.select(this).classed("hidden", true);
+    }
+    else {
+      d3.select(this).classed("hidden", false);
+    }
+  })
+}
+
 
 // Zoom to a specific point
 function zoomTo(x, y, z = 8, d = 2000) {

--- a/versioning.js
+++ b/versioning.js
@@ -1,7 +1,7 @@
 "use strict";
 
 // version and caching control
-const version = "1.97.07"; // generator version, update each time
+const version = "1.97.08"; // generator version, update each time
 
 {
   document.title += " v" + version;


### PR DESCRIPTION
# Description

Labels seem to be a considerable drain on resources, especially when a lot of them are being rendered at once. To help alleviate this, burg labels that are no longer on the screen can be set to hidden so that they are not rendered by the browser, and thus do not take up resources to render anymore. I did a bit of checking to make sure it didn't break anything, but let me know if I've missed something or missed part of this pull request process since this is the first one I've done.

# Type of change

<!-- Please put X into brackets of required option OR delete options that are not relevant -->

- [X] Bug fix

# Versioning

<!-- Update the version if you want the PR to be merged fast. Currently it's a manual 3-steps process:
  * update version in `versioning.js` using semver principle. Just set the next patch (for fixes) or minor version (for new features)
  * for all changed files update hash (the part after `?`) in place where file is requested (usually it's `index.html`)
  * if the change can be really interesting for end-users, describe it inside the `showUpdateWindow()` function in `versioning.js` -->

- [X] Version is updated
- [X] Changed files hash is updated
