### PR TITLE
Add lock year feature and icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -1595,9 +1595,12 @@
 
             <tr data-tip="Define current year and era name">
               <td>
-                <i data-locked="0" id="lock_era" class="icon-lock-open"></i>
+                <i data-locked="0" id="lock_year" class="icon-lock-open"></i>
               </td>
-              <td>Year and era</td>
+              <td>
+                Year and
+                <i data-locked="0" id="lock_era" class="icon-lock-open"></i> Era
+              </td>
               <td>
                 <input
                   id="yearInput"


### PR DESCRIPTION
In menu → Options → Year and era, there is only one lock for era. This idea adds a second lock for year and move the icon-lock-open for era (previously at the left) in the space between "and" and "era" in the sentence "year and era".

# Description

New Feature. I added a second lock icon for "year and era".
Previous icon was only for era. This era icon is now moved near the word "era".
A new icon only for lock year is close to the word "year".

# Type of change

<!-- Please put X into brackers of required option OR delete options that are not relevant -->

- [ ] Bug fix
- [X] New feature
- [ ] Refactoring / style
- [ ] Documentation update / chore
- [ ] Other (please describe)

# Versioning

I didn't change the version. You can decide what version this is.

- [x] Version is not updated
