### PR TITLE
added icon-dot-circled to locate burg in burg editor menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -3513,8 +3513,8 @@
 
           <button id="burgEditEmblem" data-tip="Edit emblem" class="icon-shield-alt"></button>
           <button id="burgTogglePreview" data-tip="Toggle preview" class="icon-map"></button>
-          <button id="burgLocate" data-tip="Zoom map and center view in the burg" class="icon-dot-circled"></button>
-          <button id="burgRelocate" data-tip="Relocate burg" class="icon-target"></button>
+          <button id="burgLocate" data-tip="Zoom map and center view in the burg" class="icon-target"></button>
+          <button id="burgRelocate" data-tip="Relocate burg. Click on map to move the burg" class="icon-map-pin"></button>
           <button id="burglLegend" data-tip="Edit free text notes (legend) for this burg" class="icon-edit"></button>
           <button id="burgLock" class="icon-lock-open" onmouseover="showElementLockTip(event)"></button>
           <button

--- a/index.html
+++ b/index.html
@@ -3513,6 +3513,7 @@
 
           <button id="burgEditEmblem" data-tip="Edit emblem" class="icon-shield-alt"></button>
           <button id="burgTogglePreview" data-tip="Toggle preview" class="icon-map"></button>
+          <button id="burgLocate" data-tip="Zoom map and center view in the burg" class="icon-dot-circled"></button>
           <button id="burgRelocate" data-tip="Relocate burg" class="icon-target"></button>
           <button id="burglLegend" data-tip="Edit free text notes (legend) for this burg" class="icon-edit"></button>
           <button id="burgLock" class="icon-lock-open" onmouseover="showElementLockTip(event)"></button>

--- a/index.html
+++ b/index.html
@@ -8074,7 +8074,7 @@
     <script defer src="modules/ui/rivers-editor.js?v=1.99.00"></script>
     <script defer src="modules/ui/rivers-creator.js?v=1.99.00"></script>
     <script defer src="modules/ui/relief-editor.js?v=1.99.00"></script>
-    <script defer src="modules/ui/burg-editor.js?v=1.100.00"></script>
+    <script defer src="modules/ui/burg-editor.js?v=1.102.00"></script>
     <script defer src="modules/ui/units-editor.js?v=1.99.05"></script>
     <script defer src="modules/ui/notes-editor.js?v=1.99.06"></script>
     <script defer src="modules/ui/ai-generator.js?v=1.99.09"></script>

--- a/modules/ui/burg-editor.js
+++ b/modules/ui/burg-editor.js
@@ -399,10 +399,10 @@ function editBurg(id) {
   }
 
   function zoomIntoBurg() {
-    const id = elSelected.attr("data-id");
-    const label = document.querySelector("#burgLabels [data-id='" + id + "']");
-    const x = +label.getAttribute("x");
-    const y = +label.getAttribute("y");
+    const id = +elSelected.attr("data-id");
+    const burg = pack.burgs[id];
+    const x = burg.x;
+    const y = burg.y;
     zoomTo(x, y, 8, 2000);
   }
 

--- a/modules/ui/burg-editor.js
+++ b/modules/ui/burg-editor.js
@@ -47,6 +47,7 @@ function editBurg(id) {
   byId("burgEmblem").addEventListener("click", openEmblemEdit);
   byId("burgTogglePreview").addEventListener("click", toggleBurgPreview);
   byId("burgEditEmblem").addEventListener("click", openEmblemEdit);
+  byId("burgLocate").addEventListener("click", zoomIntoBurg);
   byId("burgRelocate").addEventListener("click", toggleRelocateBurg);
   byId("burglLegend").addEventListener("click", editBurgLegend);
   byId("burgLock").addEventListener("click", toggleBurgLockButton);
@@ -395,6 +396,14 @@ function editBurg(id) {
     options.showBurgPreview = !options.showBurgPreview;
     byId("burgPreviewSection").style.display = options.showBurgPreview ? "block" : "none";
     byId("burgTogglePreview").className = options.showBurgPreview ? "icon-map" : "icon-map-o";
+  }
+
+  function zoomIntoBurg() {
+    const id = elSelected.attr("data-id");
+    const label = document.querySelector("#burgLabels [data-id='" + id + "']");
+    const x = +label.getAttribute("x");
+    const y = +label.getAttribute("y");
+    zoomTo(x, y, 8, 2000);
   }
 
   function toggleRelocateBurg() {

--- a/versioning.js
+++ b/versioning.js
@@ -12,7 +12,7 @@
  *
  * Example: 1.102.0 -> Major version 1, Minor version 102, Patch version 0
  */
-const VERSION = "1.101.02";
+const VERSION = "1.102.0";
 
 {
   document.title += " v" + VERSION;


### PR DESCRIPTION
- icon dot-circled
- function zoomIntoBurg()

# Description

This is an idea to put a button to "find" or locate where is the burg in the map, on the "Burg editor" menu.

Sometimes you open the edit burg menu, but later you don't know where the burg is. You can try searching for the burg scrolling through the map or open the "burgs overview" to click on "zoom into view" but your burg editor menu is going to be closed.

You can have the "zoom" icon in the same menu burg editor.  Near to the relocate button.

In this idea, there are two functions zoomIntoBurg(), one in [burgs-overview.js](https://github.com/Azgaar/Fantasy-Map-Generator/blob/master/modules/ui/burgs-overview.js) and one in [burg-editor.js](https://github.com/Azgaar/Fantasy-Map-Generator/blob/master/modules/ui/burg-editor.js)

# Type of change

<!-- Please put X into brackers of required option OR delete options that are not relevant -->

- [ ] Bug fix
- [X] New feature
- [ ] Refactoring / style
- [ ] Documentation update / chore
- [ ] Other (please describe)

# Versioning

I didn't change the version number. This number could change meanwhile I wait for this idea to be accepted or declined.
