### PR TITLE
[Draft] gridOverlay cell with labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -1114,6 +1114,13 @@
                   <input id="styleGridShiftY" type="number" data-tip="Shift by y axis in pixels" />
                 </td>
               </tr>
+
+              <tr data-tip="Show cell numbers on the grid">
+               <td colspan="2">
+                 <input id="gridCellNumbers" class="checkbox" type="checkbox" />
+                 <label for="gridCellNumbers" class="checkbox-label">Show cell numbers</label>
+               </td>
+              </tr>
             </tbody>
 
             <tbody id="styleCompass">

--- a/index.html
+++ b/index.html
@@ -1121,6 +1121,13 @@
                  <label for="gridCellNumbers" class="checkbox-label">Show cell numbers</label>
                </td>
               </tr>
+
+              <tr data-tip="Set the color of grid cell numbers">
+                <td>Cell num color</td>
+                <td>
+                  <input id="gridCellNumbersStrokeColor" type="color" value="#000000" />
+                </td>
+              </tr>
             </tbody>
 
             <tbody id="styleCompass">

--- a/index.html
+++ b/index.html
@@ -1125,7 +1125,8 @@
               <tr data-tip="Set the color of grid cell numbers">
                 <td>Cell num color</td>
                 <td>
-                  <input id="gridCellNumbersStrokeColor" type="color" value="#000000" />
+                  <input id="gridCellNumbersColorInput" type="color" value="#000000" />
+                  <output id="gridCellNumbersColorOutput">#000000</output>
                 </td>
               </tr>
             </tbody>

--- a/modules/ui/layers.js
+++ b/modules/ui/layers.js
@@ -1443,6 +1443,43 @@ function drawGrid() {
     .attr("height", maxHeight)
     .attr("fill", "url(" + pattern + ")")
     .attr("stroke", "none");
+  if (gridOverlay.attr("cell-numbers") === "true") {
+    drawCellNumbers();
+  }
+}
+
+function drawCellNumbers() {
+  const pattern = gridOverlay.attr("type") || "pointyHex";
+  const scale = +gridOverlay.attr("scale") || 1;
+  const dx = +gridOverlay.attr("dx") || 0;
+  const dy = +gridOverlay.attr("dy") || 0;
+
+  const patternElement = document.getElementById("pattern_" + pattern);
+  const patternWidth = +patternElement.getAttribute("width") * scale;
+  const patternHeight = +patternElement.getAttribute("height") * scale;
+
+  const maxWidth = Math.max(+mapWidthInput.value, graphWidth);
+  const maxHeight = Math.max(+mapHeightInput.value, graphHeight);
+
+  const columns = Math.ceil(maxWidth / patternWidth);
+  const rows = Math.ceil(maxHeight / patternHeight);
+
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < columns; col++) {
+      const x = col * patternWidth + dx;
+      const y = row * patternHeight + dy;
+      const cellNumber = row * columns + col + 1;
+
+      gridOverlay
+        .append("text")
+        .attr("x", x + patternWidth / 2)
+        .attr("y", y + patternHeight / 2)
+        .attr("text-anchor", "middle")
+        .attr("dominant-baseline", "central")
+        .attr("font-size", Math.min(patternWidth, patternHeight) / 4)
+        .text(cellNumber);
+    }
+  }
 }
 
 function toggleCoordinates(event) {

--- a/modules/ui/layers.js
+++ b/modules/ui/layers.js
@@ -1414,6 +1414,9 @@ function toggleGrid(event) {
     turnButtonOff("toggleGrid");
     gridOverlay.selectAll("*").remove();
   }
+
+  // Update the checkbox state when toggling the grid
+  document.getElementById("gridCellNumbers").checked = gridOverlay.attr("cell-numbers") === "true";
 }
 
 function drawGrid() {
@@ -1443,10 +1446,14 @@ function drawGrid() {
     .attr("height", maxHeight)
     .attr("fill", "url(" + pattern + ")")
     .attr("stroke", "none");
-  if (gridOverlay.attr("cell-numbers") === "true") {
-    drawCellNumbers();
-  }
+
+    // Check both the attribute and the checkbox state
+    if (gridOverlay.attr("cell-numbers") === "true" || document.getElementById("gridCellNumbers").checked) {
+      drawCellNumbers();
+    }
 }
+
+
 
 function drawCellNumbers() {
   const pattern = gridOverlay.attr("type") || "pointyHex";

--- a/modules/ui/layers.js
+++ b/modules/ui/layers.js
@@ -1447,13 +1447,10 @@ function drawGrid() {
     .attr("fill", "url(" + pattern + ")")
     .attr("stroke", "none");
 
-    // Check both the attribute and the checkbox state
     if (gridOverlay.attr("cell-numbers") === "true" || document.getElementById("gridCellNumbers").checked) {
       drawCellNumbers();
     }
 }
-
-
 
 function drawCellNumbers() {
   const pattern = gridOverlay.attr("type") || "pointyHex";
@@ -1471,6 +1468,8 @@ function drawCellNumbers() {
   const columns = Math.ceil(maxWidth / patternWidth);
   const rows = Math.ceil(maxHeight / patternHeight);
 
+  const labelStyle = gridOverlay.attr("data-label-style") || "stroke: #000000;";
+
   for (let row = 0; row < rows; row++) {
     for (let col = 0; col < columns; col++) {
       const x = col * patternWidth + dx;
@@ -1484,6 +1483,8 @@ function drawCellNumbers() {
         .attr("text-anchor", "middle")
         .attr("dominant-baseline", "central")
         .attr("font-size", Math.min(patternWidth, patternHeight) / 4)
+        .attr("fill", "none")  // Set fill to none so only stroke is visible
+        .attr("style", labelStyle)
         .text(cellNumber);
     }
   }

--- a/modules/ui/style.js
+++ b/modules/ui/style.js
@@ -70,6 +70,31 @@ function getColorScheme(scheme = "bright") {
   return heightmapColorSchemes[scheme];
 }
 
+function createGridSection() {
+  const gridSection = byId("styleGrid");
+  if (!gridSection) return null;
+
+  // Verificar si el checkbox ya existe
+  if (byId("gridCellNumbers")) return;
+
+  const cellNumbersDiv = document.createElement("div");
+  cellNumbersDiv.className = "option";
+  
+  const checkbox = document.createElement("input");
+  checkbox.id = "gridCellNumbers";
+  checkbox.type = "checkbox";
+  
+  const label = document.createElement("label");
+  label.htmlFor = "gridCellNumbers";
+  label.textContent = "Show cell numbers";
+
+  cellNumbersDiv.appendChild(checkbox);
+  cellNumbersDiv.appendChild(label);
+  gridSection.appendChild(cellNumbersDiv);
+}
+
+document.addEventListener("DOMContentLoaded", createGridSection);
+
 // Toggle style sections on element select
 styleElementSelect.on("change", selectStyleElement);
 
@@ -191,12 +216,23 @@ function selectStyleElement() {
   }
 
   if (styleElement === "gridOverlay") {
+    const gridCellNumbers = byId("gridCellNumbers");
     styleGrid.style.display = "block";
     styleGridType.value = el.attr("type");
     styleGridScale.value = el.attr("scale") || 1;
     styleGridShiftX.value = el.attr("dx") || 0;
     styleGridShiftY.value = el.attr("dy") || 0;
     calculateFriendlyGridSize();
+  
+    if (gridCellNumbers) {
+      gridCellNumbers.checked = el.attr("cell-numbers") === "true";
+      gridCellNumbers.addEventListener("change", function() {
+        el.attr("cell-numbers", this.checked);
+        drawGrid();
+      });
+    } else {
+      console.warn("gridCellNumbers element not found");
+    }
   }
 
   if (styleElement === "compass") {
@@ -522,6 +558,16 @@ styleGridShiftX.on("input", function () {
 styleGridShiftY.on("input", function () {
   getEl().attr("dy", this.value);
   if (layerIsOn("toggleGrid")) drawGrid();
+});
+
+styleGridNumbers.on("change", function () {
+  getEl().attr("cell-numbers", this.checked);
+  if (layerIsOn("toggleGrid")) drawGrid();
+});
+
+byId("gridCellNumbers")?.addEventListener("change", function() {
+  gridOverlay.attr("cell-numbers", this.checked);
+  drawGrid();
 });
 
 styleRescaleMarkers.on("change", function () {

--- a/modules/ui/style.js
+++ b/modules/ui/style.js
@@ -201,6 +201,8 @@ function selectStyleElement() {
   
     if (gridCellNumbers) {
       gridCellNumbers.checked = el.attr("cell-numbers") === "true";
+      styleStroke.style.display = "block";
+      styleStrokeInput.value = styleStrokeOutput.value = gridOverlay.attr("data-label-style")?.match(/stroke: ([^;]+)/)?.[1] || "#000000";
       gridCellNumbers.addEventListener("change", function() {
         el.attr("cell-numbers", this.checked);
         drawGrid();
@@ -208,6 +210,7 @@ function selectStyleElement() {
     } else {
       console.warn("gridCellNumbers element not found");
     }
+    
   }
 
   if (styleElement === "compass") {
@@ -542,9 +545,20 @@ styleGridNumbers.on("change", function () {
 
 byId("gridCellNumbers")?.addEventListener("change", function() {
   gridOverlay.attr("cell-numbers", this.checked);
-  // drawGrid(); // without condition of if layerIsOn.
+  updateGridCellNumbersStyle();
   if (layerIsOn("toggleGrid")) drawGrid();
 });
+
+document.getElementById("gridCellNumbersColor").addEventListener("input", updateGridCellNumbersStyle);
+
+function updateGridCellNumbersStyle() {
+  const color = document.getElementById("gridCellNumbersColor").value;
+  
+  const style = `stroke: ${color};`;
+  gridOverlay.attr("data-label-style", style);
+  
+  if (layerIsOn("toggleGrid")) drawGrid();
+}
 
 styleRescaleMarkers.on("change", function () {
   markers.attr("rescale", +this.checked);

--- a/modules/ui/style.js
+++ b/modules/ui/style.js
@@ -549,7 +549,7 @@ byId("gridCellNumbers")?.addEventListener("change", function() {
   if (layerIsOn("toggleGrid")) drawGrid();
 });
 
-document.getElementById("gridCellNumbersColor").addEventListener("input", updateGridCellNumbersStyle);
+ById("gridCellNumbersColor").addEventListener("input", updateGridCellNumbersStyle);
 
 function updateGridCellNumbersStyle() {
   const color = document.getElementById("gridCellNumbersColor").value;

--- a/modules/ui/style.js
+++ b/modules/ui/style.js
@@ -70,31 +70,6 @@ function getColorScheme(scheme = "bright") {
   return heightmapColorSchemes[scheme];
 }
 
-function createGridSection() {
-  const gridSection = byId("styleGrid");
-  if (!gridSection) return null;
-
-  // Verificar si el checkbox ya existe
-  if (byId("gridCellNumbers")) return;
-
-  const cellNumbersDiv = document.createElement("div");
-  cellNumbersDiv.className = "option";
-  
-  const checkbox = document.createElement("input");
-  checkbox.id = "gridCellNumbers";
-  checkbox.type = "checkbox";
-  
-  const label = document.createElement("label");
-  label.htmlFor = "gridCellNumbers";
-  label.textContent = "Show cell numbers";
-
-  cellNumbersDiv.appendChild(checkbox);
-  cellNumbersDiv.appendChild(label);
-  gridSection.appendChild(cellNumbersDiv);
-}
-
-document.addEventListener("DOMContentLoaded", createGridSection);
-
 // Toggle style sections on element select
 styleElementSelect.on("change", selectStyleElement);
 
@@ -567,7 +542,8 @@ styleGridNumbers.on("change", function () {
 
 byId("gridCellNumbers")?.addEventListener("change", function() {
   gridOverlay.attr("cell-numbers", this.checked);
-  drawGrid();
+  // drawGrid(); // without condition of if layerIsOn.
+  if (layerIsOn("toggleGrid")) drawGrid();
 });
 
 styleRescaleMarkers.on("change", function () {


### PR DESCRIPTION
# Description

This branch has the idea of putting text labels above gridOverlay cells to numerate the cells. This approach puts one text label above each "rect" cell on the grid. So in this preview version, the labels are only aligned with the square grid and similar grids.

What I wanted with this branch is to show this idea so we can talk about how we want to implement it, if we do.
- Is it a good idea to render all text labels at once? With scale 1, the browser has no problem. It creates around 1k-2k text labels. But with scale 0.1, it might crash because the cells are smaller and many more labels are created.
- Ideas to prevent the program from creating too many labels if the grid size is too small.
- 1. limit the number of labels that are created.
- 2. limit the region in which they are created. What do you think? Any ideas?
- About having a separate color picker for the text. If the color picker is on the #gridOverlay HTML element and not on the rectangle that displays the grid, the text is also tinted with that same color. How to fix this?
- I'm having trouble getting the text to be colored differently with a UI color selector. Would it be ok if we move the gridOverlay stroke parameter to the child rectangle, leave the gridOverlay with no stroke defined, and use another stroke attribute for the text color Or do you have a better idea? to have different colors?

# Type of change

- [X] New feature
- [ ] Refactoring / style

# Versioning

The version is not changed yet. We have to discuss how to do this idea first.
