### PR TITLE
Make id field in exports more consistent.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8146,7 +8146,7 @@
     <script defer src="modules/ui/rivers-overview.js?v=1.99.00"></script>
     <script defer src="modules/ui/military-overview.js?v=1.108.5"></script>
     <script defer src="modules/ui/regiments-overview.js?v=1.108.5"></script>
-    <script defer src="modules/ui/markers-overview.js?v=1.108.5"></script>
+    <script defer src="modules/ui/markers-overview.js?v=1.108.7"></script>
     <script defer src="modules/ui/regiment-editor.js?v=1.108.5"></script>
     <script defer src="modules/ui/battle-screen.js?v=1.108.5"></script>
     <script defer src="modules/ui/emblems-editor.js?v=1.99.00"></script>
@@ -8161,7 +8161,7 @@
     <script defer src="modules/io/save.js?v=1.107.4"></script>
     <script defer src="modules/io/load.js?v=1.108.0"></script>
     <script defer src="modules/io/cloud.js?v=1.106.0"></script>
-    <script defer src="modules/io/export.js?v=1.100.00"></script>
+    <script defer src="modules/io/export.js?v=1.108.7"></script>
 
     <script defer src="modules/renderers/draw-features.js?v=1.108.2"></script>
     <script defer src="modules/renderers/draw-borders.js?v=1.104.0"></script>

--- a/modules/io/export.js
+++ b/modules/io/export.js
@@ -485,11 +485,10 @@ function saveGeoJsonCells() {
 function saveGeoJsonRoutes() {
   const features = pack.routes.map(({i, points, group, name = null}) => {
     const coordinates = points.map(([x, y]) => getCoordinates(x, y, 4));
-    const id = `route${i}`;
     return {
       type: "Feature",
       geometry: {type: "LineString", coordinates},
-      properties: {id, group, name}
+      properties: {id: i, group, name}
     };
   });
   const json = {type: "FeatureCollection", features};
@@ -504,11 +503,10 @@ function saveGeoJsonRivers() {
       if (!cells || cells.length < 2) return;
       const meanderedPoints = Rivers.addMeandering(cells, points);
       const coordinates = meanderedPoints.map(([x, y]) => getCoordinates(x, y, 4));
-      const id = `river${i}`;
       return {
         type: "Feature",
         geometry: {type: "LineString", coordinates},
-        properties: {id, source, mouth, parent, basin, widthFactor, sourceWidth, discharge, name, type}
+        properties: {id: i, source, mouth, parent, basin, widthFactor, sourceWidth, discharge, name, type}
       };
     }
   );
@@ -522,9 +520,8 @@ function saveGeoJsonMarkers() {
   const features = pack.markers.map(marker => {
     const {i, type, icon, x, y, size, fill, stroke} = marker;
     const coordinates = getCoordinates(x, y, 4);
-    const id = `marker${i}`;
     const note = notes.find(note => note.id === id);
-    const properties = {id, type, icon, x, y, ...note, size, fill, stroke};
+    const properties = {id: i, type, icon, x, y, ...note, size, fill, stroke};
     return {type: "Feature", geometry: {type: "Point", coordinates}, properties};
   });
 

--- a/modules/ui/markers-overview.js
+++ b/modules/ui/markers-overview.js
@@ -214,7 +214,7 @@ function overviewMarkers() {
 
     const body = pack.markers.map(marker => {
       const {i, type, icon, x, y} = marker;
-      const id = `marker${i}`;
+      
       const note = notes.find(note => note.id === id);
       const name = note ? quote(note.name) : "Unknown";
       const legend = note ? quote(note.legend) : "";
@@ -222,7 +222,7 @@ function overviewMarkers() {
       const lat = getLatitude(y, 2);
       const lon = getLongitude(x, 2);
 
-      return [id, type, icon, name, legend, x, y, lat, lon].join(",");
+      return [i, type, icon, name, legend, x, y, lat, lon].join(",");
     });
 
     const data = headers + body.join("\n");

--- a/versioning.js
+++ b/versioning.js
@@ -13,7 +13,7 @@
  * Example: 1.102.2 -> Major version 1, Minor version 102, Patch version 2
  */
 
-const VERSION = "1.108.6";
+const VERSION = "1.108.7";
 if (parseMapVersion(VERSION) !== VERSION) alert("versioning.js: Invalid format or parsing function");
 
 {


### PR DESCRIPTION
The id field for geojson export was not consistent with csv exports. Removes the prefix on routes, rivers and markers geojson, and on markers csv, to make them all use only an integer as id.

This makes it easier to import and do joins in other software.

# Versioning

<!-- Update the VERSION if you want the PR to be merged. Currently it's a manual 3-steps process:
  * update VERSION in `versioning.js` using semver principle
  * for all changed files update hash (the part after `?`) in place where file is requested (usually it's `index.html`)
  * if the change can be really interesting for end-users, describe it inside the `showUpdateWindow()` function in `versioning.js` -->

- [x] Version is updated
- [x] Changed files hash is updated
