### PR TITLE
fix regex of 'and' adjectivization rule

### DIFF
--- a/index.html
+++ b/index.html
@@ -8083,7 +8083,7 @@
     <script src="utils/polyfills.js?v=1.99.00"></script>
     <script src="utils/probabilityUtils.js?v=1.99.05"></script>
     <script src="utils/stringUtils.js?v=1.106.0"></script>
-    <script src="utils/languageUtils.js?v=1.99.00"></script>
+    <script src="utils/languageUtils.js?v=1.108.11"></script>
     <script src="utils/unitUtils.js?v=1.99.00"></script>
     <script src="utils/pathUtils.js?v=1.106.0"></script>
     <script defer src="utils/debugUtils.js?v=1.106.0"></script>

--- a/utils/languageUtils.js
+++ b/utils/languageUtils.js
@@ -135,7 +135,7 @@ const adjectivizationRules = [
   {
     name: "an",
     probability: 0.5,
-    condition: new RegExp("^[a-zA-Z]{0-7}$"),
+    condition: new RegExp("^[a-zA-Z]{0,7}$"),
     action: noun => trimVowels(noun) + "an"
   }
 ];


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change, motivation and context. It it's a but fix, add a reference in format #issue_number -->

This is a fix to the adjectivization rules of state names, correcting the regular expression that the "an" rule matches for.

# Type of change

<!-- Please put X into brackers of required option OR delete options that are not relevant -->

- [X] Bug fix

# Versioning

<!-- Update the VERSION if you want the PR to be merged. Currently it's a manual 3-steps process:
  * update VERSION in `versioning.js` using semver principle
  * for all changed files update hash (the part after `?`) in place where file is requested (usually it's `index.html`)
  * if the change can be really interesting for end-users, describe it inside the `showUpdateWindow()` function in `versioning.js` -->

- [X] Version is updated
- [X] Changed files hash is updated
