### PR TITLE
fix: add parameters to getLinePower in heightmap-generator.js

### DIFF
--- a/modules/heightmap-generator.js
+++ b/modules/heightmap-generator.js
@@ -106,7 +106,7 @@ window.HeightmapGenerator = (function () {
     return blobPowerMap[cells] || 0.98;
   }
 
-  function getLinePower() {
+  function getLinePower(cells) {
     const linePowerMap = {
       1000: 0.75,
       2000: 0.77,


### PR DESCRIPTION


# Description

<!-- Please include a summary of the change, motivation and context. It it's a but fix, add a reference in format #issue_number -->
Previously `getLinePower` was defined without any parameters, which meant callers had to rely on global variable `cells` which overrides `cellDesired` value.

# Type of change

<!-- Please put X into brackers of required option OR delete options that are not relevant -->

- [X] Bug fix
- [ ] New feature
- [ ] Refactoring / style
- [ ] Documentation update / chore
- [ ] Other (please describe)

# Versioning

<!-- Update the VERSION if you want the PR to be merged. Currently it's a manual 3-steps process:
  * update VERSION in `versioning.js` using semver principle
  * for all changed files update hash (the part after `?`) in place where file is requested (usually it's `index.html`)
  * if the change can be really interesting for end-users, describe it inside the `showUpdateWindow()` function in `versioning.js` -->
  
Since this change are very small and will break existing maps that have cell number other than 10k, I’ll leave the version number untouched. Feel free to merge or close this pr.

- [ ] Version is updated
- [ ] Changed files hash is updated
