### PR TITLE
fix: initialize heights array if not already set in HeightmapGenerator

### DIFF
--- a/src/modules/heightmap-generator.ts
+++ b/src/modules/heightmap-generator.ts
@@ -560,9 +560,7 @@ class HeightmapGenerator {
         if(!ctx) {
           throw new Error("Could not get canvas context");
         }
-        if(!this.heights) {
-          throw new Error("Heights array is not initialized");
-        }
+        this.heights = this.heights || new Uint8Array(cellsX * cellsY);
         ctx.drawImage(img, 0, 0, cellsX, cellsY);
         const imageData = ctx.getImageData(0, 0, cellsX, cellsY);
         this.setGraph(graph);

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -6,7 +6,7 @@ import { rn } from "./numberUtils";
  * @param {number} decimals - Number of decimal places (default is 1)
  * @returns {string} - The string with rounded numbers
  */
-export const round = (inputString: string, decimals: number = 1) => {
+export const round = (inputString: string = "", decimals: number = 1) => {
   return inputString.replace(/[\d\.-][\d\.e-]*/g, (n: string) => {
     return rn(parseFloat(n), decimals).toString();
   });


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change, motivation and context. It it's a but fix, add a reference in format #issue_number -->

# Type of change

<!-- Please put X into brackets of required option OR delete options that are not relevant -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring / style
- [ ] Documentation update / chore
- [ ] Other (please describe)

# Versioning

<!-- Update the VERSION if you want the PR to be merged. Currently it's a manual 3-steps process:
  * update VERSION in `versioning.js` using semver principle
  * for all changed files update hash (the part after `?`) in place where file is requested (usually it's `index.html`)
  * if the change can be really interesting for end-users, describe it inside the `showUpdateWindow()` function in `versioning.js` -->

- [ ] Version is updated
- [ ] Changed files hash is updated
