### PR TITLE
fix(ui): remove-all routes skips locked routes (#1298)

### DIFF
--- a/public/modules/ui/routes-overview.js
+++ b/public/modules/ui/routes-overview.js
@@ -171,16 +171,30 @@ function overviewRoutes() {
   }
 
   function triggerAllRoutesRemove() {
-    alertMessage.innerHTML = /* html */ `Are you sure you want to remove all routes? This action can't be undone`;
+    const toRemove = pack.routes.filter(route => !route.lock);
+    if (!toRemove.length) {
+      if (!pack.routes.length) {
+        tip("There are no routes to remove", false, "error");
+      } else {
+        tip("All routes are locked. Unlock routes to remove them, or use Lock all to unlock first.", false, "error");
+      }
+      return;
+    }
+
+    const lockedCount = pack.routes.length - toRemove.length;
+    alertMessage.innerHTML =
+      lockedCount > 0
+        ? /* html */ `Remove all <b>unlocked</b> routes (${toRemove.length})? <b>${lockedCount}</b> locked route(s) will be kept. This cannot be undone.`
+        : /* html */ `Are you sure you want to remove all routes? This action can't be undone`;
+
     $("#alert").dialog({
       resizable: false,
-      title: "Remove all routes",
+      title: lockedCount > 0 ? "Remove unlocked routes" : "Remove all routes",
       buttons: {
         Remove: function () {
-          pack.cells.routes = {};
-          pack.routes = [];
-          routes.selectAll("path").remove();
-
+          for (const route of [...toRemove]) {
+            Routes.remove(route);
+          }
           routesOverviewAddLines();
           $(this).dialog("close");
         },

--- a/public/modules/ui/routes-overview.js
+++ b/public/modules/ui/routes-overview.js
@@ -192,9 +192,20 @@ function overviewRoutes() {
       title: lockedCount > 0 ? "Remove unlocked routes" : "Remove all routes",
       buttons: {
         Remove: function () {
-          for (const route of [...toRemove]) {
+          const routesToRemove = pack.routes.filter(route => !route.lock);
+          if (!routesToRemove.length) {
+            if (!pack.routes.length) {
+              tip("There are no routes to remove", false, "error");
+            } else {
+              tip("All routes are now locked; nothing was removed.", false, "error");
+            }
+            $(this).dialog("close");
+            return;
+          }
+          for (const route of routesToRemove) {
             Routes.remove(route);
           }
+          pack.cells.routes = Routes.buildLinks(pack.routes);
           routesOverviewAddLines();
           $(this).dialog("close");
         },

--- a/src/index.html
+++ b/src/index.html
@@ -5523,7 +5523,7 @@
             class="icon-download"
           ></button>
           <button id="routesLockAll" data-tip="Lock or unlock all routes" class="icon-lock"></button>
-          <button id="routesRemoveAll" data-tip="Remove all routes" class="icon-trash"></button>
+          <button id="routesRemoveAll" data-tip="Remove all unlocked routes (locked routes are kept)" class="icon-trash"></button>
           <label for="routesSearch" data-tip="Filter by name or group" style="margin-left: 0.2em"
             >Search: <input id="routesSearch" type="search"
           /></label>


### PR DESCRIPTION
Summary
"Remove all routes" in the Routes Overview now deletes only unlocked routes. Locked routes and their geometry stay. Users who want a full wipe can unlock everything first (existing lock/unlock-all control).

Motivation
Implements the behavior requested in #1298: bulk delete should ignore locked routes so you can clear generated routes without losing hand-pinned or important ones.

Changes

- triggerAllRoutesRemove: filter !route.lock, call Routes.remove per unlocked route (keeps pack.cells.routes and SVG in sync).
- If every route is locked: show a tip instead of opening the delete dialog.
- If there are no routes: show a tip.
- Confirmation copy clarifies counts when some routes stay locked.
- Tooltip on the trash button: unlocked-only behavior.

How to test

1. Lock one route → remove all → locked route remains.
2. Unlock all → remove all → all removed.
3. Lock all → remove all → tip, nothing deleted.

https://github.com/Azgaar/Fantasy-Map-Generator/issues/1298