### PR TITLE
Improved panning and zooming smoothness on most layers.

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -186,9 +186,9 @@ function zoomRaf() {
   viewX = x;
   viewY = y;
 
-  // Avoids possible state mixup where a more recent call of
-  // zoomRaf() could update these flags before earlier RAF
-  // calls had time to run.
+  // Coalesce multiple zoom events into one paint.
+  // While a RAF is pending, keep updating latest transform state and OR-change flags.
+  // The scheduled RAF consumes these accumulated flags and then resets them.
   pendingScaleChange = pendingScaleChange || isScaleChanged;
   pendingPositionChange = pendingPositionChange || isPositionChanged;
 
@@ -494,34 +494,6 @@ function findBurgForMFCG(params) {
   zoomTo(b.x, b.y, 8, 1600);
   invokeActiveZooming();
   tip("Here stands the glorious city of " + b.name, true, "success", 15000);
-}
-
-function handleZoom(isScaleChanged, isPositionChanged) {
-  viewbox.attr("transform", `translate(${viewX} ${viewY}) scale(${scale})`);
-
-  if (isPositionChanged) {
-    if (layerIsOn("toggleCoordinates")) drawCoordinates();
-  }
-
-  if (isScaleChanged) {
-    invokeActiveZooming();
-    drawScaleBar(scaleBar, scale);
-    fitScaleBar(scaleBar, svgWidth, svgHeight);
-  }
-
-  // zoom image converter overlay
-  if (customization === 1) {
-    const canvas = byId("canvas");
-    if (!canvas || canvas.style.opacity === "0") return;
-
-    const img = byId("imageToConvert");
-    if (!img) return;
-
-    const ctx = canvas.getContext("2d");
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.setTransform(scale, 0, 0, scale, viewX, viewY);
-    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-  }
 }
 
 // Zoom to a specific point

--- a/public/main.js
+++ b/public/main.js
@@ -228,12 +228,11 @@ function zoomRaf() {
   })
 }
 
-const postZoom = debounce(() => {
+const postZoom = () => {
   invokeActiveZooming();
   drawScaleBar(scaleBar, scale);
   fitScaleBar(scaleBar, svgWidth, svgHeight);
-}, 50);
-
+}
 
 const zoom = d3.zoom().scaleExtent([1, 20]).on("zoom", zoomRaf);
 

--- a/public/main.js
+++ b/public/main.js
@@ -172,7 +172,10 @@ let scale = 1;
 let viewX = 0;
 let viewY = 0;
 
-const onZoom = debounce(function () {
+let rafId = null;
+let pendingScaleChange = false;
+let pendingPositionChange = false;
+function zoomRaf() {
   const {k, x, y} = d3.event.transform;
 
   const isScaleChanged = Boolean(scale - k);
@@ -183,9 +186,56 @@ const onZoom = debounce(function () {
   viewX = x;
   viewY = y;
 
-  handleZoom(isScaleChanged, isPositionChanged);
+  // Avoids possible state mixup where a more recent call of
+  // zoomRaf() could update these flags before earlier RAF
+  // calls had time to run.
+  pendingScaleChange = pendingScaleChange || isScaleChanged;
+  pendingPositionChange = pendingPositionChange || isPositionChanged;
+
+  if (rafId) return;
+  rafId = requestAnimationFrame(() => {
+    rafId = null;
+
+    // Safely clears these flags for future renders
+    const didScaleChange = pendingScaleChange;
+    const didPositionChange = pendingPositionChange;
+    pendingScaleChange = false;
+    pendingPositionChange = false;
+
+    // Uses global values, so each frame always draws using the latest positioning values
+    viewbox.attr("transform", `translate(${viewX} ${viewY}) scale(${scale})`);
+
+    if (didPositionChange) {
+      if (layerIsOn("toggleCoordinates")) drawCoordinates();
+    }
+
+    if (customization === 1) {
+      const canvas = byId("canvas");
+      if (canvas && canvas.style.opacity !== "0") {
+        const img = byId("imageToConvert");
+        if (img) {
+          const ctx = canvas.getContext("2d");
+          ctx.clearRect(0, 0, canvas.width, canvas.height);
+          ctx.setTransform(scale, 0, 0, scale, viewX, viewY);
+          ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+        }
+      }
+    }
+
+    if (didScaleChange) {
+      postZoom();
+    }
+  })
+}
+
+const postZoom = debounce(() => {
+  invokeActiveZooming();
+  drawScaleBar(scaleBar, scale);
+  fitScaleBar(scaleBar, svgWidth, svgHeight);
 }, 50);
-const zoom = d3.zoom().scaleExtent([1, 20]).on("zoom", onZoom);
+
+
+const zoom = d3.zoom().scaleExtent([1, 20]).on("zoom", zoomRaf);
 
 var mapCoordinates = {}; // map coordinates on globe
 let populationRate = +byId("populationRateInput").value;


### PR DESCRIPTION
# Description

Improve zoom/pan responsiveness by replacing the debounced zoom handler with an requestAnimationFrame(RAF)-coalesced transform path, while keeping expensive zoom side effects debounced.

The previous path deferred all zoom updates behind a 50ms debounce. I noticed in the browser devtools that this forced lots of forced pauses in rendering despite nothing being waited on. The new path applies viewbox transform once per paint frame from the latest zoom state, which reduces interaction latency and improves visual smoothness during pan/zoom. Expensive operations (invokeActiveZooming, scale bar sizing) remain debounced and are gated to scale changes, preserving performance under high input rates. I haven't looked fully into optimizing these, and overlays like Relief still show choppiness, but most map views now should be noticeably smoother when interacting.

Before/after metrics (manual profiling):

- Before updates were quantized to debounce windows (~50ms); after updates are paint-synced (typically next frame, ~8-16ms depending on refresh rate).
- Before max ~20 updates/sec under continuous input no matter what. After, can reach display refresh rate (60/120 Hz) with frame coalescing.
- Before could run on debounced zoom handler calls. After, remains debounced and scale-gated, reducing redundant work during pan-heavy interaction.
- Smoother panning/zooming with reduced jitter and faster perceived response, especially under rapid wheel/trackpad input.


Note: There were some extra global state flags added to prevent minor desyncs while zooming and panning. Now, coordinates redraw is aggregated across coalesced events in the same frame.

| Before | After |
| --- | --- |
| https://github.com/user-attachments/assets/46b13b01-bc61-4679-91c5-f99bcb47f2f9 | https://github.com/user-attachments/assets/e61d4ee9-7672-4e73-a0fb-f1ccc7e28814 |




