### PR TITLE
fix: The space between the start and end points of the Bézier curve i…

### DIFF
--- a/public/modules/io/save.js
+++ b/public/modules/io/save.js
@@ -86,6 +86,14 @@ function prepareMapData() {
   cloneEl.querySelector("#viewbox").removeAttribute("transform");
 
   cloneEl.querySelector("#ruler").innerHTML = ""; // always remove rulers
+  
+  cloneEl
+    .querySelectorAll("#routes > #roads path, #routes > #trails path, #routes > #searoutes path")
+    .forEach(path => path.setAttribute("fill", "none"));
+  
+  cloneEl
+    .querySelectorAll("#borders > #stateBorders path, #borders > #provinceBorders path")
+    .forEach(path => path.setAttribute("fill", "none"));
 
   const serializedSVG = new XMLSerializer().serializeToString(cloneEl);
 

--- a/public/modules/io/save.js
+++ b/public/modules/io/save.js
@@ -86,14 +86,6 @@ function prepareMapData() {
   cloneEl.querySelector("#viewbox").removeAttribute("transform");
 
   cloneEl.querySelector("#ruler").innerHTML = ""; // always remove rulers
-  
-  cloneEl
-    .querySelectorAll("#routes > #roads, #routes > #trails, #routes > #searoutes")
-    .forEach(path => path.setAttribute("fill", "none"));
-  
-  cloneEl
-    .querySelectorAll("#borders > #stateBorders, #borders > #provinceBorders")
-    .forEach(path => path.setAttribute("fill", "none"));
 
   const serializedSVG = new XMLSerializer().serializeToString(cloneEl);
 

--- a/public/modules/io/save.js
+++ b/public/modules/io/save.js
@@ -88,11 +88,11 @@ function prepareMapData() {
   cloneEl.querySelector("#ruler").innerHTML = ""; // always remove rulers
   
   cloneEl
-    .querySelectorAll("#routes > #roads path, #routes > #trails path, #routes > #searoutes path")
+    .querySelectorAll("#routes > #roads, #routes > #trails, #routes > #searoutes")
     .forEach(path => path.setAttribute("fill", "none"));
   
   cloneEl
-    .querySelectorAll("#borders > #stateBorders path, #borders > #provinceBorders path")
+    .querySelectorAll("#borders > #stateBorders, #borders > #provinceBorders")
     .forEach(path => path.setAttribute("fill", "none"));
 
   const serializedSVG = new XMLSerializer().serializeToString(cloneEl);

--- a/public/modules/ui/layers.js
+++ b/public/modules/ui/layers.js
@@ -813,7 +813,7 @@ function drawRoutes() {
     routePaths[group].push(`<path id="route${i}" d="${Routes.getPath(route)}"/>`);
   }
 
-  routes.selectAll("path").remove();
+  routes.attr("fill", "none").selectAll("path").remove();
   for (const group in routePaths) {
     routes.select("#" + group).html(routePaths[group].join(""));
   }

--- a/src/renderers/draw-borders.ts
+++ b/src/renderers/draw-borders.ts
@@ -79,7 +79,7 @@ const bordersRenderer = () => {
     }
   }
 
-  svg.select("#borders").selectAll("path").remove();
+  svg.select("#borders").attr("fill", "none").selectAll("path").remove();
   svg.select("#stateBorders").append("path").attr("d", statePath.join(" "));
   svg
     .select("#provinceBorders")


### PR DESCRIPTION
# Description

When extracting an .svg from a .map file, the map is filled in black because the fill attribute of the Bézier curves is not set to none.

This change will prevent filling caused by the line connecting the start and end points of the Bézier curve.

<img width="2480" height="1166" alt="left_before-right_after" src="https://github.com/user-attachments/assets/6babd6f1-d4df-49e7-bf0b-bfad0b0c2691" />

This change will be applied to newly saved .map files. Older .map files need to be re-saved with this new version.

## How to test

[export_map_elements.js](https://github.com/user-attachments/files/27321093/export_map_elements.js)

1. run `npm run dev`
2. open `http://localhost:5173/Fantasy-Map-Generator/`
3. save .map file.
4. run `node export_map_elements.js <mapfile>`
5. open `map_parts/05_map.svg`