### PR TITLE
Fixing menu corruption by UI Tour closure

### DIFF
--- a/src/modules/ui-tour.ts
+++ b/src/modules/ui-tour.ts
@@ -30,7 +30,8 @@ function showHeightmapCustomizationPanel() {
 function hideHeightmapCustomizationPanel() {
   const toolsContent = byId("toolsContent");
   const customizationMenu = byId("customizationMenu");
-  if (customizationMenu) customizationMenu.style.display = "none";
+  if (!customizationMenu || customizationMenu.style.display !== "block") return;
+  customizationMenu.style.display = "none";
   if (toolsContent) toolsContent.style.display = "block";
 }
 

--- a/tests/e2e/ui-tour.spec.ts
+++ b/tests/e2e/ui-tour.spec.ts
@@ -442,4 +442,72 @@ test.describe("UI Tour", () => {
     await expect(page.locator("#customizationMenu")).toBeHidden();
     await expect(page.locator("#options")).toBeHidden();
   });
+
+  // ── Regression: toolsContent must not leak when closing early (bug #1421) ──
+
+  test("closing tour on Layers tab step does not show toolsContent when menu is reopened", async ({
+    page,
+  }) => {
+    await page.evaluate(() => (window as any).UITour.start());
+    await page.waitForSelector(".driver-popover", { state: "visible" });
+
+    // Advance to Layers Tab step — options panel is open, Layers tab is active.
+    await advanceSteps(page, 4);
+    expect(await popoverTitle(page)).toBe(STEP_TITLES[4]);
+
+    await page.locator(".driver-popover-close-btn").click();
+    await page.waitForSelector(".driver-popover", { state: "hidden" });
+
+    // Reopen the options panel.
+    await page.locator("#optionsTrigger").click();
+    await expect(page.locator("#options")).toBeVisible();
+
+    // Only the Layers tab content should be visible — not toolsContent.
+    await expect(page.locator("#layersContent")).toBeVisible();
+    await expect(page.locator("#toolsContent")).toBeHidden();
+  });
+
+  test("closing tour on Style tab step does not show toolsContent when menu is reopened", async ({
+    page,
+  }) => {
+    await page.evaluate(() => (window as any).UITour.start());
+    await page.waitForSelector(".driver-popover", { state: "visible" });
+
+    // Advance to Style Tab step — options panel is open, Style tab is active.
+    await advanceSteps(page, 7);
+    expect(await popoverTitle(page)).toBe(STEP_TITLES[7]);
+
+    await page.locator(".driver-popover-close-btn").click();
+    await page.waitForSelector(".driver-popover", { state: "hidden" });
+
+    // Reopen the options panel.
+    await page.locator("#optionsTrigger").click();
+    await expect(page.locator("#options")).toBeVisible();
+
+    // Only the Style tab content should be visible — not toolsContent.
+    await expect(page.locator("#styleContent")).toBeVisible();
+    await expect(page.locator("#toolsContent")).toBeHidden();
+  });
+
+  test("closing tour on Options tab step does not show toolsContent when menu is reopened", async ({
+    page,
+  }) => {
+    await page.evaluate(() => (window as any).UITour.start());
+    await page.waitForSelector(".driver-popover", { state: "visible" });
+
+    // Advance to Options Tab step — options panel is open, Options tab is active.
+    await advanceSteps(page, 10);
+    expect(await popoverTitle(page)).toBe(STEP_TITLES[10]);
+
+    await page.locator(".driver-popover-close-btn").click();
+    await page.waitForSelector(".driver-popover", { state: "hidden" });
+
+    // Reopen the options panel.
+    await page.locator("#optionsTrigger").click();
+    await expect(page.locator("#options")).toBeVisible();
+
+    // Only the Options tab content should be visible — not toolsContent.
+    await expect(page.locator("#optionsContent")).toBeVisible();
+    await expect(page.locator("#toolsContent")).toBeHidden();
+  });
 });


### PR DESCRIPTION
# Description
The tour calls clickTab() during steps 7-10, which runs querySelectorAll() which hides #toolsContent. If the user closes tour via the X button, onDestroyStarted fires which calls hideHeightmapCustomizationPanel().  hideHeightmapCustomizationPanel() unconditionally sets toolsContent.style.display = "block" even if #customizationMenu was never shown and #toolsContent should stay hidden. Now the #toolsContent area is visible alongside whatever other tab content was already visible leading to corrupted layout when the panel is reopened.

Fix: only restore toolsContent when customizationMenu was actually shown

Addresses bug #1421 

Added three test cases to test for this use case.

