### PR TITLE
feat: add map height legend to Tools > Units > Altitude

### DIFF
--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -585,6 +585,7 @@ outlineLayers.on("change", function () {
 styleHeightmapScheme.on("change", function () {
   getEl().attr("scheme", this.value);
   drawHeightmap();
+  window.updateLegendIfVisible?.();
 });
 
 openCreateHeightmapSchemeButton.on("click", function () {

--- a/public/modules/ui/units-editor.js
+++ b/public/modules/ui/units-editor.js
@@ -179,17 +179,8 @@ function editUnits() {
     const bbox = legend.node().getBBox();
     legendLabel.attr("x", bbox.width / 2);
 
-    // Adjust legend position to ensure it's fully visible
-    const legendBox = legend.select("#legendBox");
-    const legendWidth = +legendBox.attr("width");
-    const legendHeight = +legendBox.attr("height");
-    const svgWidth = +d3.select("svg").attr("width");
-    const svgHeight = +d3.select("svg").attr("height");
-
-    const x = Math.max(10, Math.min(svgWidth - legendWidth - 10, (+legend.attr("data-x") / 100) * svgWidth));
-    const y = Math.max(10, Math.min(svgHeight - legendHeight - 10, (+legend.attr("data-y") / 100) * svgHeight));
-
-    legend.attr("transform", `translate(${x},${y})`);
+    // Use shared legend positioning logic (defaults near bottom-right when data-x/y are unset)
+    if (window.fitLegendBox) fitLegendBox();
   }
 
   function updateLegendIfVisible() {

--- a/public/modules/ui/units-editor.js
+++ b/public/modules/ui/units-editor.js
@@ -172,7 +172,6 @@ function editUnits() {
     const cache = getLegendHeightsCache();
     if (!cache) return;
 
-    const exponent = +heightExponentInput.value;
     const schemeName =
       terrs.select("#landHeights").attr("scheme") ||
       terrs.select("#oceanHeights").attr("scheme") ||
@@ -188,11 +187,10 @@ function editUnits() {
     const sampled = cache.sampledHeights.map(height => {
       const v = 1 - (height < 20 ? height - 5 : height) / 100;
       const sRGB = scheme(v);
-      const altitude = height < 20 ? 0 : Math.pow(height - 18, exponent);
-      return {height, altitude, color: sRGB};
+      return {height, color: sRGB};
     });
 
-    const data = sampled.map(c => [rn(c.height, 0), c.color, rn(c.altitude, 1)]);
+    const data = sampled.map(c => [rn(c.height, 0), c.color, getHeight(c.height)]);
 
     // Set the number of items per column
     styleLegendColItems.value = data.length;

--- a/public/modules/ui/units-editor.js
+++ b/public/modules/ui/units-editor.js
@@ -137,7 +137,11 @@ function editUnits() {
     for (const h of heights) countByHeight.set(h, (countByHeight.get(h) || 0) + 1);
 
     const exponent = +heightExponentInput.value;
-    const scheme = getColorScheme();
+    const schemeName =
+      terrs.select("#landHeights").attr("scheme") ||
+      terrs.select("#oceanHeights").attr("scheme") ||
+      "bright";
+    const scheme = getColorScheme(schemeName);
 
     const heightUnitSelect = ensureEl("heightUnit");
     const heightUnitName =

--- a/public/modules/ui/units-editor.js
+++ b/public/modules/ui/units-editor.js
@@ -57,12 +57,15 @@ function editUnits() {
   }
 
   function changeHeightUnit() {
-    if (this.value !== "custom_name") return;
-
-    prompt("Provide a custom name for a height unit", {default: ""}, custom => {
-      this.options.add(new Option(custom, custom, false, true));
-      lock("heightUnit");
-    });
+    if (this.value === "custom_name") {
+      prompt("Provide a custom name for a height unit", {default: ""}, custom => {
+        this.options.add(new Option(custom, custom, false, true));
+        lock("heightUnit");
+        updateLegendIfVisible();
+      });
+      return;
+    }
+    updateLegendIfVisible();
   }
 
   function changeHeightExponent() {
@@ -119,6 +122,8 @@ function editUnits() {
     localStorage.removeItem("populationRate");
     localStorage.removeItem("urbanization");
     localStorage.removeItem("urbanDensity");
+
+    updateLegendIfVisible();
   }
 
   function toggleLegend() {
@@ -179,10 +184,13 @@ function editUnits() {
     const scheme = getColorScheme(schemeName);
 
     const heightUnitSelect = ensureEl("heightUnit");
+    const selectedOpt = heightUnitSelect.selectedOptions[0];
+    const selectedText = selectedOpt?.text?.trim() ?? "";
+    const parenAbbrev = selectedText.match(/\(([^)]+)\)/)?.[1];
     const heightUnitName =
       heightUnitSelect.value === "custom_name"
-        ? heightUnitSelect.nextElementSibling?.value || ""
-        : (heightUnitSelect.selectedOptions[0]?.text.match(/\(([^)]+)\)/)?.[1] ?? "");
+        ? heightUnitSelect.nextElementSibling?.value || selectedText
+        : (parenAbbrev ?? selectedText) || heightUnitSelect.value;
 
     const sampled = cache.sampledHeights.map(height => {
       const v = 1 - (height < 20 ? height - 5 : height) / 100;
@@ -211,6 +219,7 @@ function editUnits() {
       updateAndDisplayLegend();
     }
   }
+  window.updateLegendIfVisible = updateLegendIfVisible;
 
   function addRuler() {
     if (!layerIsOn("toggleRulers")) toggleRulers();

--- a/public/modules/ui/units-editor.js
+++ b/public/modules/ui/units-editor.js
@@ -131,10 +131,46 @@ function editUnits() {
     }
   }
 
-  function updateAndDisplayLegend() {
-    const heights = pack.cells.h;
+  let legendHeightsCache = null;
+
+  function getLegendHeightsCache() {
+    const heights = pack?.cells?.h;
+    if (!heights) return null;
+
+    if (
+      legendHeightsCache &&
+      legendHeightsCache.heightsRef === heights &&
+      legendHeightsCache.heightsLen === heights.length
+    ) {
+      return legendHeightsCache;
+    }
+
     const countByHeight = new Map();
     for (const h of heights) countByHeight.set(h, (countByHeight.get(h) || 0) + 1);
+
+    const sortedHeights = Array.from(countByHeight.keys()).sort((a, b) => a - b);
+
+    // Select a representative sample of heights across the range
+    const totalSamples = 10;
+    const step = Math.max(1, Math.floor(sortedHeights.length / totalSamples));
+    const sampledHeights = sortedHeights.filter(
+      (_, index) => index % step === 0 || index === sortedHeights.length - 1
+    );
+
+    legendHeightsCache = {
+      heightsRef: heights,
+      heightsLen: heights.length,
+      countByHeight,
+      sortedHeights,
+      sampledHeights
+    };
+
+    return legendHeightsCache;
+  }
+
+  function updateAndDisplayLegend() {
+    const cache = getLegendHeightsCache();
+    if (!cache) return;
 
     const exponent = +heightExponentInput.value;
     const schemeName =
@@ -149,23 +185,12 @@ function editUnits() {
         ? heightUnitSelect.nextElementSibling?.value || ""
         : (heightUnitSelect.selectedOptions[0]?.text.match(/\(([^)]+)\)/)?.[1] ?? "");
 
-    const heightLevels = [];
-    countByHeight.forEach((count, height) => {
+    const sampled = cache.sampledHeights.map(height => {
       const v = 1 - (height < 20 ? height - 5 : height) / 100;
       const sRGB = scheme(v);
       const altitude = height < 20 ? 0 : Math.pow(height - 18, exponent);
-      heightLevels.push({height, count, altitude, color: sRGB});
+      return {height, altitude, color: sRGB};
     });
-
-    // Sort by height
-    heightLevels.sort((a, b) => a.height - b.height);
-
-    // Select a representative sample of heights across the range
-    const totalSamples = 10;
-    const step = Math.max(1, Math.floor(heightLevels.length / totalSamples));
-    const sampled = heightLevels.filter(
-      (_, index) => index % step === 0 || index === heightLevels.length - 1
-    );
 
     const data = sampled.map(c => [rn(c.height, 0), c.color, rn(c.altitude, 1)]);
 

--- a/public/modules/ui/units-editor.js
+++ b/public/modules/ui/units-editor.js
@@ -21,6 +21,7 @@ function editUnits() {
   ensureEl("distanceScaleInput").on("change", changeDistanceScale);
   ensureEl("heightUnit").on("change", changeHeightUnit);
   ensureEl("heightExponentInput").on("input", changeHeightExponent);
+  ensureEl("heightLegend").on("click", toggleLegend);
   ensureEl("temperatureScale").on("change", changeTemperatureScale);
 
   ensureEl("populationRateInput").on("change", changePopulationRate);
@@ -67,6 +68,14 @@ function editUnits() {
   function changeHeightExponent() {
     calculateTemperatures();
     if (layerIsOn("toggleTemperature")) drawTemperature();
+    updateLegendIfVisible();
+  }
+
+  function toggleLegend() {
+    if (legend.selectAll("*").size()) {
+      clearLegend();
+      return;
+    } // hide legend
   }
 
   function changeTemperatureScale() {
@@ -117,6 +126,79 @@ function editUnits() {
     localStorage.removeItem("populationRate");
     localStorage.removeItem("urbanization");
     localStorage.removeItem("urbanDensity");
+  }
+
+  function toggleLegend() {
+    const isVisible = legend.selectAll("*").size() > 0;
+
+    if (isVisible) {
+      clearLegend();
+    } else {
+      updateAndDisplayLegend();
+    }
+  }
+
+  function updateAndDisplayLegend() {
+    let arr = pack.cells.h;
+    let countMap = arr.reduce(
+      (map, value) => { map.set(value, (map.get(value) || 0) + 1); return map },
+      new Map()
+    );
+    const exponent = +heightExponentInput.value;
+    const scheme = getColorScheme();
+
+    // Get the selected height unit
+    const heightUnit = document.getElementById('heightUnit').value;
+    const heightUnitName = heightUnit === 'custom_name' 
+      ? document.getElementById('heightUnit').nextElementSibling.value 
+      : document.getElementById('heightUnit').selectedOptions[0].text.match(/\(([^)]+)\)/)[1];
+
+    const hmap = [];
+    countMap.forEach(function (mcount, mheight) {
+      const v = 1 - (mheight < 20 ? mheight - 5 : mheight) / 100;
+      const sRGB = scheme(v);
+      const a = mheight < 20 ? 0 : Math.pow(mheight - 18, exponent);
+      hmap.push({ height: mheight, count: mcount, altitude: a, color: sRGB });
+    });
+
+    // Sort hmap by height
+    hmap.sort((a, b) => a.height - b.height);
+
+    // Select a representative sample of heights across the range
+    const totalSamples = 10; // Adjust this number to change the number of legend items
+    const step = Math.max(1, Math.floor(hmap.length / totalSamples));
+    const sampledHmap = hmap.filter((_, index) => index % step === 0 || index === hmap.length - 1);
+
+    const data = sampledHmap
+      .map(c => [rn(c.height, 0), c.color, rn(c.altitude, 1)]);
+
+    // Set the number of items per column
+    styleLegendColItems.value = data.length;
+
+    drawLegend(`Heights (in ${heightUnitName})`, data);
+
+    // Center the legend label
+    const legendLabel = legend.select("#legendLabel");
+    const bbox = legend.node().getBBox();
+    legendLabel.attr("x", bbox.width / 2);
+
+    // Adjust legend position to ensure it's fully visible
+    const legendBox = legend.select("#legendBox");
+    const legendWidth = legendBox.attr("width");
+    const legendHeight = legendBox.attr("height");
+    const svgWidth = +d3.select("svg").attr("width");
+    const svgHeight = +d3.select("svg").attr("height");
+
+    let x = Math.max(10, Math.min(svgWidth - legendWidth - 10, +legend.attr("data-x") / 100 * svgWidth));
+    let y = Math.max(10, Math.min(svgHeight - legendHeight - 10, +legend.attr("data-y") / 100 * svgHeight));
+
+    legend.attr("transform", `translate(${x},${y})`);
+  }
+
+  function updateLegendIfVisible() {
+    if (legend.selectAll("*").size() > 0) {
+      updateAndDisplayLegend();
+    }
   }
 
   function addRuler() {

--- a/public/modules/ui/units-editor.js
+++ b/public/modules/ui/units-editor.js
@@ -21,7 +21,7 @@ function editUnits() {
   ensureEl("distanceScaleInput").on("change", changeDistanceScale);
   ensureEl("heightUnit").on("change", changeHeightUnit);
   ensureEl("heightExponentInput").on("input", changeHeightExponent);
-  ensureEl("heightLegend").on("click", toggleLegend);
+  ensureEl("altitudeLegend").on("click", toggleLegend);
   ensureEl("temperatureScale").on("change", changeTemperatureScale);
 
   ensureEl("populationRateInput").on("change", changePopulationRate);
@@ -69,13 +69,6 @@ function editUnits() {
     calculateTemperatures();
     if (layerIsOn("toggleTemperature")) drawTemperature();
     updateLegendIfVisible();
-  }
-
-  function toggleLegend() {
-    if (legend.selectAll("*").size()) {
-      clearLegend();
-      return;
-    } // hide legend
   }
 
   function changeTemperatureScale() {
@@ -139,38 +132,38 @@ function editUnits() {
   }
 
   function updateAndDisplayLegend() {
-    let arr = pack.cells.h;
-    let countMap = arr.reduce(
-      (map, value) => { map.set(value, (map.get(value) || 0) + 1); return map },
-      new Map()
-    );
+    const heights = pack.cells.h;
+    const countByHeight = new Map();
+    for (const h of heights) countByHeight.set(h, (countByHeight.get(h) || 0) + 1);
+
     const exponent = +heightExponentInput.value;
     const scheme = getColorScheme();
 
-    // Get the selected height unit
-    const heightUnit = document.getElementById('heightUnit').value;
-    const heightUnitName = heightUnit === 'custom_name' 
-      ? document.getElementById('heightUnit').nextElementSibling.value 
-      : document.getElementById('heightUnit').selectedOptions[0].text.match(/\(([^)]+)\)/)[1];
+    const heightUnitSelect = ensureEl("heightUnit");
+    const heightUnitName =
+      heightUnitSelect.value === "custom_name"
+        ? heightUnitSelect.nextElementSibling?.value || ""
+        : (heightUnitSelect.selectedOptions[0]?.text.match(/\(([^)]+)\)/)?.[1] ?? "");
 
-    const hmap = [];
-    countMap.forEach(function (mcount, mheight) {
-      const v = 1 - (mheight < 20 ? mheight - 5 : mheight) / 100;
+    const heightLevels = [];
+    countByHeight.forEach((count, height) => {
+      const v = 1 - (height < 20 ? height - 5 : height) / 100;
       const sRGB = scheme(v);
-      const a = mheight < 20 ? 0 : Math.pow(mheight - 18, exponent);
-      hmap.push({ height: mheight, count: mcount, altitude: a, color: sRGB });
+      const altitude = height < 20 ? 0 : Math.pow(height - 18, exponent);
+      heightLevels.push({height, count, altitude, color: sRGB});
     });
 
-    // Sort hmap by height
-    hmap.sort((a, b) => a.height - b.height);
+    // Sort by height
+    heightLevels.sort((a, b) => a.height - b.height);
 
     // Select a representative sample of heights across the range
-    const totalSamples = 10; // Adjust this number to change the number of legend items
-    const step = Math.max(1, Math.floor(hmap.length / totalSamples));
-    const sampledHmap = hmap.filter((_, index) => index % step === 0 || index === hmap.length - 1);
+    const totalSamples = 10;
+    const step = Math.max(1, Math.floor(heightLevels.length / totalSamples));
+    const sampled = heightLevels.filter(
+      (_, index) => index % step === 0 || index === heightLevels.length - 1
+    );
 
-    const data = sampledHmap
-      .map(c => [rn(c.height, 0), c.color, rn(c.altitude, 1)]);
+    const data = sampled.map(c => [rn(c.height, 0), c.color, rn(c.altitude, 1)]);
 
     // Set the number of items per column
     styleLegendColItems.value = data.length;
@@ -184,13 +177,13 @@ function editUnits() {
 
     // Adjust legend position to ensure it's fully visible
     const legendBox = legend.select("#legendBox");
-    const legendWidth = legendBox.attr("width");
-    const legendHeight = legendBox.attr("height");
+    const legendWidth = +legendBox.attr("width");
+    const legendHeight = +legendBox.attr("height");
     const svgWidth = +d3.select("svg").attr("width");
     const svgHeight = +d3.select("svg").attr("height");
 
-    let x = Math.max(10, Math.min(svgWidth - legendWidth - 10, +legend.attr("data-x") / 100 * svgWidth));
-    let y = Math.max(10, Math.min(svgHeight - legendHeight - 10, +legend.attr("data-y") / 100 * svgHeight));
+    const x = Math.max(10, Math.min(svgWidth - legendWidth - 10, (+legend.attr("data-x") / 100) * svgWidth));
+    const y = Math.max(10, Math.min(svgHeight - legendHeight - 10, (+legend.attr("data-y") / 100) * svgHeight));
 
     legend.attr("transform", `translate(${x},${y})`);
   }

--- a/src/index.html
+++ b/src/index.html
@@ -5340,6 +5340,11 @@
             </slider-input>
           </div>
 
+          <div data-tip="Toggle altitude legend. Granularity affects the amount of heights shown">
+            <span>Height legend:</span>
+            <button id="altitudeLegend" data-tip="Click to show the altitude legend" class="icon-list-bullet"></button>
+          </div>
+
           <div class="unitsHeader" data-tip="Select Temperature scale">
             <span class="icon-temperature-high"></span>
             <label>Temperature:</label>

--- a/src/index.html
+++ b/src/index.html
@@ -5340,11 +5340,6 @@
             </slider-input>
           </div>
 
-          <div data-tip="Toggle altitude legend. Granularity affects the amount of heights shown">
-            <span>Height legend:</span>
-            <button id="altitudeLegend" data-tip="Click to show the altitude legend" class="icon-list-bullet"></button>
-          </div>
-
           <div class="unitsHeader" data-tip="Select Temperature scale">
             <span class="icon-temperature-high"></span>
             <label>Temperature:</label>
@@ -5396,6 +5391,7 @@
         </div>
 
         <div id="unitsBottom">
+          <button id="altitudeLegend" data-tip="Click to show the altitude legend" class="icon-list-bullet"></button>
           <button id="addLinearRuler" data-tip="Click to place a linear measurer (ruler)" class="icon-ruler"></button>
           <button
             id="addOpisometer"


### PR DESCRIPTION
# Description

A new button has been added to the altitude settings section that displays a visual legend. This legend helps users interpret the different elevation levels represented on the map.

Changes:

UI: A "View Legend" button has been added to Tools > Units > Altitude.

Component: New map legend pop-up that displays the color scale and its corresponding altitude values.

Logic: The legend chooses some representative points. Also updates the unit system that is shown (meters/feet).

How to test:
Go to the side menu and select Tools. Enter Units and then Altitude. Click it and confirm that the legend matches the colors displayed on the map. Switch from meters to feet and verify that the legend values ​​update correctly.

Screenshot

FMG altitude legend 2026-05-07
<img width="1362" height="700" alt="FMG-altitude-legend-2026-05-07-01jpg" src="https://github.com/user-attachments/assets/2537fb87-7bc8-46e2-8fd8-8444fec12d08" />
