### PR TITLE
Add 'Locate province' button and handler

### DIFF
--- a/public/modules/dynamic/editors/cultures-editor.js
+++ b/public/modules/dynamic/editors/cultures-editor.js
@@ -49,7 +49,7 @@ function insertEditorHtml() {
       <button id="culturesEditStyle" data-tip="Edit cultures style in Style Editor" class="icon-adjust"></button>
       <button id="culturesLegend" data-tip="Toggle Legend box" class="icon-list-bullet"></button>
       <button id="culturesPercentage" data-tip="Toggle percentage / absolute values display mode" class="icon-percent"></button>
-      <button id="culturesLocate" data-tip="Locate selected culture territory on the map" class="icon-target"></button>
+      <button id="culturesLocate" data-tip="Click on the list first to select a culture, then click to locate it on the map" class="icon-target"></button>
       <button id="culturesHeirarchy" data-tip="Show cultures hierarchy tree" class="icon-sitemap"></button>
       <button id="culturesManually" data-tip="Manually re-assign cultures" class="icon-brush"></button>
       <div id="culturesManuallyButtons" style="display: none">

--- a/public/modules/dynamic/editors/cultures-editor.js
+++ b/public/modules/dynamic/editors/cultures-editor.js
@@ -49,6 +49,7 @@ function insertEditorHtml() {
       <button id="culturesEditStyle" data-tip="Edit cultures style in Style Editor" class="icon-adjust"></button>
       <button id="culturesLegend" data-tip="Toggle Legend box" class="icon-list-bullet"></button>
       <button id="culturesPercentage" data-tip="Toggle percentage / absolute values display mode" class="icon-percent"></button>
+      <button id="culturesLocate" data-tip="Locate selected culture territory on the map" class="icon-target"></button>
       <button id="culturesHeirarchy" data-tip="Show cultures hierarchy tree" class="icon-sitemap"></button>
       <button id="culturesManually" data-tip="Manually re-assign cultures" class="icon-brush"></button>
       <div id="culturesManuallyButtons" style="display: none">
@@ -82,6 +83,7 @@ function addListeners() {
   ensureEl("culturesEditStyle").on("click", () => editStyle("cults"));
   ensureEl("culturesLegend").on("click", toggleLegend);
   ensureEl("culturesPercentage").on("click", togglePercentageMode);
+  ensureEl("culturesLocate").on("click", locateSelectedCulture);
   ensureEl("culturesHeirarchy").on("click", showHierarchy);
   ensureEl("culturesRecalculate").on("click", () => recalculateCultures(true));
   ensureEl("culturesManually").on("click", enterCultureManualAssignent);
@@ -99,6 +101,27 @@ function refreshCulturesEditor() {
   culturesCollectStatistics();
   culturesEditorAddLines();
   drawCultureCenters();
+}
+
+function locateCulture(cultureId) {
+  if (!cults) return;
+  const cultureElement = cults.select("#culture" + cultureId).node();
+  if (!cultureElement) return;
+  highlightElement(cultureElement, 8);
+}
+
+function locateSelectedCulture() {
+  const selected = $body.querySelector("div.selected");
+  if (!selected) {
+    tip("Select a culture first", true);
+    return;
+  }
+  const cultureId = Number(selected.dataset.id);
+  if (Number.isNaN(cultureId)) {
+    tip("Select a culture first", true);
+    return;
+  }
+  locateCulture(cultureId);
 }
 
 function culturesCollectStatistics() {
@@ -697,8 +720,8 @@ function enterCultureManualAssignent() {
 }
 
 function selectCultureOnLineClick(i) {
-  if (customization !== 4) return;
-  $body.querySelector("div.selected").classList.remove("selected");
+  const previous = $body.querySelector("div.selected");
+  if (previous) previous.classList.remove("selected");
   this.classList.add("selected");
 }
 

--- a/public/modules/dynamic/editors/religions-editor.js
+++ b/public/modules/dynamic/editors/religions-editor.js
@@ -63,6 +63,7 @@ function insertEditorHtml() {
       <button id="religionsPercentage" data-tip="Toggle percentage / absolute values display mode" class="icon-percent"></button>
       <button id="religionsHeirarchy" data-tip="Show religions hierarchy tree" class="icon-sitemap"></button>
       <button id="religionsExtinct" data-tip="Show/hide extinct religions (religions without cells)" class="icon-eye-off"></button>
+      <button id="religionsLocate" data-tip="Click on the list first to select a religion, then click to locate it on the map" class="icon-target"></button>
 
       <button id="religionsManually" data-tip="Manually re-assign religions" class="icon-brush"></button>
       <div id="religionsManuallyButtons" style="display: none">
@@ -99,6 +100,7 @@ function addListeners() {
   ensureEl("religionsPercentage").on("click", togglePercentageMode);
   ensureEl("religionsHeirarchy").on("click", showHierarchy);
   ensureEl("religionsExtinct").on("click", toggleExtinct);
+  ensureEl("religionsLocate").on("click", locateSelectedReligion);
   ensureEl("religionsManually").on("click", enterReligionsManualAssignent);
   ensureEl("religionsManuallyApply").on("click", applyReligionsManualAssignent);
   ensureEl("religionsManuallyCancel").on("click", () => exitReligionsManualAssignment());
@@ -552,6 +554,22 @@ function drawReligionCenters() {
     .call(d3.drag().on("start", religionCenterDrag));
 }
 
+function locateReligion(religionId) {
+  if (religionId === undefined || religionId === null) return;
+  if (!relig) return;
+  const el = relig.select("#religion" + religionId).node();
+  if (!el) return;
+  highlightElement(el, 8);
+}
+
+function locateSelectedReligion() {
+  const selected = $body.querySelector("div.selected");
+  if (!selected) return tip("Select a religion first", true);
+  const religionId = Number(selected.dataset.id);
+  if (Number.isNaN(religionId)) return tip("Select a religion first", true);
+  locateReligion(religionId);
+}
+
 function religionCenterDrag() {
   const religionId = +this.dataset.id;
   const tr = parseTransform(this.getAttribute("transform"));
@@ -666,9 +684,9 @@ function enterReligionsManualAssignent() {
   $body.querySelector("div").classList.add("selected");
 }
 
-function selectReligionOnLineClick(i) {
-  if (customization !== 7) return;
-  $body.querySelector("div.selected").classList.remove("selected");
+function selectReligionOnLineClick() {
+  const prev = $body.querySelector("div.selected");
+  if (prev) prev.classList.remove("selected");
   this.classList.add("selected");
 }
 

--- a/public/modules/dynamic/editors/states-editor.js
+++ b/public/modules/dynamic/editors/states-editor.js
@@ -51,6 +51,7 @@ function insertEditorHtml() {
       <button id="statesLegend" data-tip="Toggle Legend box" class="icon-list-bullet"></button>
       <button id="statesPercentage" data-tip="Toggle percentage / absolute values views" class="icon-percent"></button>
       <button id="statesChart" data-tip="Show states bubble chart" class="icon-chart-area"></button>
+      <button id="statesLocate" data-tip="Click on the list first to select a state, then click to locate it on the map" class="icon-target"></button>
 
       <button id="statesRegenerate" data-tip="Show the regeneration menu and more data" class="icon-cog-alt"></button>
       <div id="statesRegenerateButtons" style="display: none">
@@ -102,6 +103,7 @@ function addListeners() {
   ensureEl("statesLegend").on("click", toggleLegend);
   ensureEl("statesPercentage").on("click", togglePercentageMode);
   ensureEl("statesChart").on("click", showStatesChart);
+  ensureEl("statesLocate").on("click", locateSelectedState);
   ensureEl("statesRegenerate").on("click", openRegenerationMenu);
   ensureEl("statesRegenerateBack").on("click", exitRegenerationMenu);
   ensureEl("statesRecalculate").on("click", () => recalculateStates(true));
@@ -837,6 +839,28 @@ function showStatesChart() {
     }
   });
 }
+
+function locateState(stateId) {
+  if (!regions) return;
+  const stateElement = regions.select("#state" + stateId).node();
+  if (!stateElement) return;
+  highlightElement(stateElement, 8);
+}
+
+function locateSelectedState() {
+  const selected = $body.querySelector("div.selected");
+  if (!selected) {
+    tip("Select a state first", true);
+    return;
+  }
+  const stateId = Number(selected.dataset.id);
+  if (Number.isNaN(stateId)) {
+    tip("Select a state first", true);
+    return;
+  }
+  locateState(stateId);
+}
+
 
 function openRegenerationMenu() {
   ensureEl("statesBottom")

--- a/public/modules/dynamic/editors/states-editor.js
+++ b/public/modules/dynamic/editors/states-editor.js
@@ -120,7 +120,8 @@ function addListeners() {
   $body.on("click", event => {
     const $element = event.target;
     const classList = $element.classList;
-    const stateId = +$element.parentNode?.dataset?.id;
+    const stateLine = $element.closest("#statesBodySection > div[data-id]");
+    const stateId = stateLine ? +stateLine.dataset.id : NaN;
     if ($element.tagName === "FILL-BOX") stateChangeFill($element);
     else if (classList.contains("name")) editStateName(stateId);
     else if (classList.contains("coaIcon")) editEmblem("state", "stateCOA" + stateId, pack.states[stateId]);
@@ -841,23 +842,21 @@ function showStatesChart() {
 }
 
 function locateState(stateId) {
-  if (!regions) return;
-  const stateElement = regions.select("#state" + stateId).node();
-  if (!stateElement) return;
+  if (!stateId && stateId !== 0) return;
+  const selector = '#statesBody #state' + stateId;
+  const stateElement = document.querySelector(selector);
+  if (!stateElement) {
+    tip("State path not found on the map", true);
+    return;
+  }
   highlightElement(stateElement, 8);
 }
 
 function locateSelectedState() {
   const selected = $body.querySelector("div.selected");
-  if (!selected) {
-    tip("Select a state first", true);
-    return;
-  }
+  if (!selected) return tip("Select a state line first", true);
   const stateId = Number(selected.dataset.id);
-  if (Number.isNaN(stateId)) {
-    tip("Select a state first", true);
-    return;
-  }
+  if (Number.isNaN(stateId)) return tip("Select a state line first", true);
   locateState(stateId);
 }
 
@@ -938,9 +937,8 @@ function enterStatesManualAssignent() {
 }
 
 function selectStateOnLineClick() {
-  if (customization !== 2) return;
   if (this.parentNode.id !== "statesBodySection") return;
-  $body.querySelector("div.selected").classList.remove("selected");
+  $body.querySelector("div.selected")?.classList.remove("selected");
   this.classList.add("selected");
 }
 

--- a/public/modules/ui/markers-overview.js
+++ b/public/modules/ui/markers-overview.js
@@ -62,7 +62,7 @@ function overviewMarkers() {
     const i = +el.parentNode.dataset.i;
 
     if (el.classList.contains("icon-pencil")) return openEditor(i);
-    if (el.classList.contains("icon-dot-circled")) return focusOnMarker(i);
+    if (el.classList.contains("icon-target")) return focusOnMarker(i);
     if (el.classList.contains("icon-pin")) return pinMarker(el, i);
     if (el.classList.contains("locks")) return toggleLockStatus(el, i);
     if (el.classList.contains("icon-trash-empty")) return triggerRemove(i);
@@ -90,7 +90,7 @@ function overviewMarkers() {
             }
             <div data-tip="Marker type" style="width:10em">${type}</div>
             <span style="padding-right:.1em" data-tip="Edit marker" class="icon-pencil"></span>
-            <span style="padding-right:.1em" data-tip="Focus on marker position" class="icon-dot-circled pointer"></span>
+            <span style="padding-right:.1em" data-tip="Focus on marker position" class="icon-target pointer"></span>
             <span style="padding-right:.1em" data-tip="Pin marker (display only pinned markers)" class="icon-pin ${
               pinned ? "" : "inactive"
             }" pointer"></span>

--- a/public/modules/ui/provinces-editor.js
+++ b/public/modules/ui/provinces-editor.js
@@ -51,7 +51,7 @@ function editProvinces() {
     else if (cl.contains("coaIcon")) editEmblem("province", "provinceCOA" + p, pack.provinces[p]);
     else if (cl.contains("icon-star-empty")) capitalZoomIn(p);
     else if (cl.contains("icon-flag-empty")) triggerIndependencePromps(p);
-    else if (cl.contains("icon-dot-circled")) overviewBurgs({stateId});
+    else if (cl.contains("icon-target")) overviewBurgs({stateId});
     else if (cl.contains("culturePopulation")) changePopulation(p);
     else if (cl.contains("icon-pin")) toggleFog(p, cl);
     else if (cl.contains("icon-trash-empty")) removeProvince(p);
@@ -168,7 +168,7 @@ function editProvinces() {
           ${p.burgs.length ? getCapitalOptions(p.burgs, p.burg) : ""}
         </select>
         <input data-tip="Province owner" class="provinceOwner" value="${stateName}" disabled">
-        <span data-tip="Click to overview province burgs" style="padding-right: 1px" class="icon-dot-circled pointer hide"></span>
+        <span data-tip="Click to overview province burgs" style="padding-right: 1px" class="icon-target pointer hide"></span>
         <div data-tip="Burgs count" class="provinceBurgs hide">${p.burgs.length}</div>
         <span data-tip="Province area" style="padding-right: 4px" class="icon-map-o hide"></span>
         <div data-tip="Province area" class="biomeArea hide">${si(area) + unit}</div>

--- a/public/modules/ui/provinces-editor.js
+++ b/public/modules/ui/provinces-editor.js
@@ -542,6 +542,7 @@ function editProvinces() {
     ensureEl("provinceNameEditorShortRandom").on("click", regenerateShortNameRandom);
     ensureEl("provinceNameEditorAddForm").on("click", addCustomForm);
     ensureEl("provinceNameEditorFullRegenerate").on("click", regenerateFullName);
+    ensureEl("provinceLocate").on("click", () => locateProvince(province));
 
     function regenerateShortNameCulture() {
       const province = +provinceNameEditor.dataset.province;
@@ -1156,6 +1157,13 @@ function editProvinces() {
     if (customization === 11) exitProvincesManualAssignment("close");
     if (customization === 12) exitAddProvinceMode();
   }
+}
+
+function locateProvince(p) {
+  if (!provs) return;
+  const provinceElement = provs.select("#province" + p).node();
+  if (!provinceElement) return;
+  highlightElement(provinceElement, 8);
 }
 
 function updateLockStatus(provinceId, classList) {

--- a/public/modules/ui/provinces-editor.js
+++ b/public/modules/ui/provinces-editor.js
@@ -52,7 +52,7 @@ function editProvinces() {
     else if (cl.contains("coaIcon")) editEmblem("province", "provinceCOA" + p, pack.provinces[p]);
     else if (cl.contains("icon-star-empty")) capitalZoomIn(p);
     else if (cl.contains("icon-flag-empty")) triggerIndependencePromps(p);
-    else if (cl.contains("icon-target")) overviewBurgs({stateId});
+    else if (cl.contains("icon-dot-circled")) overviewBurgs({stateId});
     else if (cl.contains("culturePopulation")) changePopulation(p);
     else if (cl.contains("icon-pin")) toggleFog(p, cl);
     else if (cl.contains("icon-trash-empty")) removeProvince(p);
@@ -169,7 +169,7 @@ function editProvinces() {
           ${p.burgs.length ? getCapitalOptions(p.burgs, p.burg) : ""}
         </select>
         <input data-tip="Province owner" class="provinceOwner" value="${stateName}" disabled">
-        <span data-tip="Click to overview province burgs" style="padding-right: 1px" class="icon-target pointer hide"></span>
+        <span data-tip="Click to overview province burgs" style="padding-right: 1px" class="icon-dot-circled pointer hide"></span>
         <div data-tip="Burgs count" class="provinceBurgs hide">${p.burgs.length}</div>
         <span data-tip="Province area" style="padding-right: 4px" class="icon-map-o hide"></span>
         <div data-tip="Province area" class="biomeArea hide">${si(area) + unit}</div>

--- a/public/modules/ui/provinces-editor.js
+++ b/public/modules/ui/provinces-editor.js
@@ -37,6 +37,7 @@ function editProvinces() {
   ensureEl("provincesRelease").on("click", triggerProvincesRelease);
   ensureEl("provincesAdd").on("click", enterAddProvinceMode);
   ensureEl("provincesRecolor").on("click", recolorProvinces);
+  ensureEl("provincesLocate").on("click", locateSelectedProvince);
 
   body.on("click", function (ev) {
     if (customization) return;
@@ -194,7 +195,7 @@ function editProvinces() {
     ensureEl("provincesFooterPopulation").dataset.population = totalPopulation;
 
     body.querySelectorAll("div.states").forEach(el => {
-      el.on("click", selectProvinceOnLineClick);
+      el.on("click", selectProvinceForLocate);
       el.on("mouseenter", ev => provinceHighlightOn(ev));
       el.on("mouseleave", ev => provinceHighlightOff(ev));
     });
@@ -257,6 +258,20 @@ function editProvinces() {
     };
 
     openPicker(currentFill, callback);
+  }
+
+  function selectProvinceForLocate() {
+    if (customization === 11) return; // skip if in manual assignment mode
+    if (this.parentNode.id !== "provincesBodySection") return;
+    body.querySelector("div.selected")?.classList.remove("selected");
+    this.classList.add("selected");
+  }
+
+  function locateSelectedProvince() {
+    const selected = body.querySelector("div.selected");
+    if (!selected) return tip("Select a province first", false, "warning");
+    const province = +selected.dataset.id;
+    locateProvince(province);
   }
 
   function capitalZoomIn(p) {
@@ -542,7 +557,6 @@ function editProvinces() {
     ensureEl("provinceNameEditorShortRandom").on("click", regenerateShortNameRandom);
     ensureEl("provinceNameEditorAddForm").on("click", addCustomForm);
     ensureEl("provinceNameEditorFullRegenerate").on("click", regenerateFullName);
-    ensureEl("provinceLocate").on("click", () => locateProvince(province));
 
     function regenerateShortNameCulture() {
       const province = +provinceNameEditor.dataset.province;

--- a/public/modules/ui/rivers-overview.js
+++ b/public/modules/ui/rivers-overview.js
@@ -65,7 +65,7 @@ function overviewRivers() {
         data-width="${r.width}"
         data-basin="${basin}"
       >
-        <span data-tip="Click to focus on river" class="icon-dot-circled pointer"></span>
+        <span data-tip="Click to focus on river" class="icon-target pointer"></span>
         <div data-tip="River name" style="margin-left: 0.4em;" class="riverName">${r.name}</div>
         <div data-tip="River type name" class="riverType">${r.type}</div>
         <div data-tip="River discharge (flux power)" class="biomeArea">${discharge}</div>
@@ -90,7 +90,7 @@ function overviewRivers() {
     // add listeners
     body.querySelectorAll("div.states").forEach(el => el.on("mouseenter", ev => riverHighlightOn(ev)));
     body.querySelectorAll("div.states").forEach(el => el.on("mouseleave", ev => riverHighlightOff(ev)));
-    body.querySelectorAll("div > span.icon-dot-circled").forEach(el => el.on("click", zoomToRiver));
+    body.querySelectorAll("div > span.icon-target").forEach(el => el.on("click", zoomToRiver));
     body.querySelectorAll("div > span.icon-pencil").forEach(el => el.on("click", openRiverEditor));
     body.querySelectorAll("div > span.icon-trash-empty").forEach(el => el.on("click", triggerRiverRemove));
 

--- a/public/modules/ui/routes-overview.js
+++ b/public/modules/ui/routes-overview.js
@@ -56,7 +56,7 @@ function overviewRoutes() {
         data-group="${route.group}"
         data-length="${route.length}"
       >
-        <span data-tip="Click to focus on route" class="icon-dot-circled pointer"></span>
+        <span data-tip="Click to focus on route" class="icon-target pointer"></span>
         <div data-tip="Route name" style="width: 15em; margin-left: 0.4em;">${route.name}</div>
         <div data-tip="Route group" style="width: 8em;">${route.group}</div>
         <div data-tip="Route length" style="width: 6em;">${length}</div>
@@ -77,7 +77,7 @@ function overviewRoutes() {
     // add listeners
     body.querySelectorAll("div.states").forEach(el => el.on("mouseenter", routeHighlightOn));
     body.querySelectorAll("div.states").forEach(el => el.on("mouseleave", routeHighlightOff));
-    body.querySelectorAll("div > span.icon-dot-circled").forEach(el => el.on("click", zoomToRoute));
+    body.querySelectorAll("div > span.icon-target").forEach(el => el.on("click", zoomToRoute));
     body.querySelectorAll("div > span.icon-pencil").forEach(el => el.on("click", openRouteEditor));
     body.querySelectorAll("div > span.locks").forEach(el => el.on("click", toggleLockStatus));
     body.querySelectorAll("div > span.icon-trash-empty").forEach(el => el.on("click", triggerRouteRemove));

--- a/src/index.html
+++ b/src/index.html
@@ -4671,7 +4671,7 @@
           <button id="provincesChart" data-tip="Show provinces chart" class="icon-chart-area"></button>
           <button
             id="provincesLocate"
-            data-tip="Locate selected province on map"
+            data-tip="Click to select on the list, then click to locate selected province on map"
             class="icon-target"
           ></button>
           <button

--- a/src/index.html
+++ b/src/index.html
@@ -4671,7 +4671,7 @@
           <button id="provincesChart" data-tip="Show provinces chart" class="icon-chart-area"></button>
           <button
             id="provincesLocate"
-            data-tip="Click to select on the list, then click to locate selected province on map"
+            data-tip="Click on the list first to select a province, then click to locate it on the map"
             class="icon-target"
           ></button>
           <button

--- a/src/index.html
+++ b/src/index.html
@@ -4670,6 +4670,11 @@
           ></button>
           <button id="provincesChart" data-tip="Show provinces chart" class="icon-chart-area"></button>
           <button
+            id="provincesLocate"
+            data-tip="Locate selected province on map"
+            class="icon-target"
+          ></button>
+          <button
             id="provincesToggleLabels"
             data-tip="Toggle province labels. Change size in Menu ⭢ Style ⭢ Provinces"
             class="icon-font"
@@ -4851,10 +4856,6 @@
           style="margin-top: 0.2em"
         >
           Dominant culture:&nbsp;<span id="provinceCultureDisplay"></span>
-        </div>
-
-        <div class="dialog-footer">
-          <span id="provinceLocate" data-tip="Locate province on map" class="icon-dot-circled pointer"></span>
         </div>
       </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -4852,6 +4852,10 @@
         >
           Dominant culture:&nbsp;<span id="provinceCultureDisplay"></span>
         </div>
+
+        <div class="dialog-footer">
+          <span id="provinceLocate" data-tip="Locate province on map" class="icon-dot-circled pointer"></span>
+        </div>
       </div>
 
       <div id="namesbaseEditor" class="dialog stable textual" style="display: none">


### PR DESCRIPTION
Add a Locate / zoom in feature to the province editor UI and implement a handler to highlight the corresponding province on the map.

<img width="1733" height="639" alt="FMG-1 122-Locate-Province-2026-05-14-1" src="https://github.com/user-attachments/assets/ba4f8754-bb4d-4670-8454-c78860e0e127" />


* The index.html change inserts a span (#provinceLocate) into the editor dialog.
* Provinces-editor.js wires its click to locateProvince(province) and adds the locateProvince(p) function, which finds the SVG element (#provinceN) via provs.select and calls highlightElement(..., 8). Guard clauses prevent errors if provs or the element are missing.

✅ Button appears in the footer inside the "change province name" dialog.
✅ Map zooms to the province location when clicked.
✅ Shows a highlight animation.
✅ Works with or without labels toggled. That prevents issue: #1435
✅ Function is globally accessible.

Image that shows the highlight:
<img width="305" height="388" alt="FMG 1 122 Locate Province 2026-05-14 03" src="https://github.com/user-attachments/assets/b67b04af-2226-4a46-8dab-0b866bd2a049" />
