### PR TITLE
Fix neighbor-of-neighbor false-positive diplomatic relationships

### DIFF
--- a/src/modules/states-generator.ts
+++ b/src/modules/states-generator.ts
@@ -400,10 +400,7 @@ class StatesModule {
         const neibOfNeib =
           naval || neib
             ? false
-            : states[f]
-                .neighbors!.map(n => states[n].neighbors)
-                .join("")
-                .includes(t.toString());
+            : states[f].neighbors!.some(n => states[n].neighbors!.includes(t));
 
         let status = naval ? rw(navals) : neib ? rw(neibs) : neibOfNeib ? rw(neibsOfNeibs) : rw(far);
 


### PR DESCRIPTION
## Bug Summary

In `src/modules/states-generator.ts` line ~400, the `generateDiplomacy()` function has a false-positive bug in neighbor-of-neighbor checking.

## The Problem

The original code used string matching to check if state `t` was a neighbor of any neighbor of state `f`:

```typescript
const neibOfNeib =
  naval || neib
    ? false
    : states[f]
        .neighbors!.map(n => states[n].neighbors)
        .join("")
        .includes(t.toString());
```

When `.join("")` flattens the neighbor arrays, a state with neighbors like `[12, 3, 456]` becomes the string `"12,3456"`. Then `.includes("2")` incorrectly matches because "2" appears as a substring of "12", causing false-positive diplomatic relationships.

## The Fix

Replace the string-based `.join("").includes()` with proper array membership checking:

```typescript
const neibOfNeib =
  naval || neib
    ? false
    : states[f].neighbors!.some(n => states[n].neighbors!.includes(t));
```

This correctly checks if state `t` is actually an element in any neighbor's neighbor array, avoiding substring false positives.

---

Fixes #1446