### PR TITLE
Urquhart Graph < 2 Points Edge Case - Fixes #1442

### DIFF
--- a/src/modules/routes-generator.ts
+++ b/src/modules/routes-generator.ts
@@ -223,6 +223,10 @@ class RoutesModule {
   // this gives us an aproximation of a desired road network, i.e. connections between burgs
   // code from https://observablehq.com/@mbostock/urquhart-graph
   private calculateUrquhartEdges(points: Point[]) {
+
+    if (points.length < 2) return []; // No connection for less than 2 points
+    if (points.length === 2) return [[0, 1]]; // Direct connection for exactly two points
+
     const score = (p0: number, p1: number) => distanceSquared(points[p0], points[p1]);
 
     const { halfedges, triangles } = Delaunator.from(points);


### PR DESCRIPTION
# Description

This is a bug-fix for the special case in the urquhart graph calculation for less than 3 points. The **Delaunator Library** for less than 3 points just returns an empty list of triangles/edges. This causes possible routes to be swallowed although they would be possible.

[Issue 1442](https://github.com/Azgaar/Fantasy-Map-Generator/issues/1442#issue-4484640597)

# Test setup

This bug can be provoked with the the following test setup, to test deterministically: 

http://localhost:5173/Fantasy-Map-Generator/?seed=42&width=1920&height=1080

# Observations

The FMG now correctly adds the routes between to burgs. As **Map Change 1** shows, this has an impact on border generation, since it changes the routes graph. This is visible in test case 2 where the burg Alorlarungalit is now contained within the border.

## Map Change 1

Before:
<img width="1211" height="758" alt="case1-before-fix" src="https://github.com/user-attachments/assets/b71012dd-fe02-4cb5-b2d4-8f723e1087e0" />

After:
<img width="1562" height="1012" alt="case1-with-fix" src="https://github.com/user-attachments/assets/ab745e9c-31ad-4428-856e-5115340dee65" />

## Map Change 2

Before:
<img width="1350" height="894" alt="case2-before-fix" src="https://github.com/user-attachments/assets/9f6ff403-23a2-4d22-9aa1-1167fb8571cb" />

After:
<img width="1798" height="1042" alt="case2-with-fix" src="https://github.com/user-attachments/assets/ed400632-fc43-4a85-ad5f-40f84b1683e4" />
