### PR TITLE
Replaced 2 cases of in-place sorting with none mutating reduce Fixes: #1445 Fixes: #1444

### DIFF
--- a/src/modules/lakes.ts
+++ b/src/modules/lakes.ts
@@ -66,7 +66,7 @@ export class LakesModule {
     };
 
     const getLowestShoreCell = (lake: PackedGraphFeature) => {
-      return lake.shoreline.sort((a, b) => heights[a] - heights[b])[0];
+      return lake.shoreline.reduce((minCell, c) => heights[c] < heights[minCell] ? c : minCell);
     };
 
     features.forEach(feature => {
@@ -99,7 +99,7 @@ export class LakesModule {
       }
 
       let isDeep = true;
-      const lowestShorelineCell = feature.shoreline.sort((a, b) => h[a] - h[b])[0];
+      const lowestShorelineCell = feature.shoreline.reduce((minCell, c) => h[c] < h[minCell] ? c : minCell);
       const queue = [lowestShorelineCell];
       const checked = [];
       checked[lowestShorelineCell] = true;

--- a/src/modules/river-generator.ts
+++ b/src/modules/river-generator.ts
@@ -118,7 +118,7 @@ class RiverModule {
         } else if (cells.haven[i]) {
           min = cells.haven[i];
         } else {
-          min = cells.c[i].sort((a: number, b: number) => h[a] - h[b])[0];
+          min = cells.c[i].reduce((minCell, c) => h[c] < h[minCell] ? c : minCell);
         }
 
         // cells is depressed


### PR DESCRIPTION
# Description

This PR solves the two issues: [Issue-1445](https://github.com/Azgaar/Fantasy-Map-Generator/issues/1445#issue-4484733147) and [Issue-1444](https://github.com/Azgaar/Fantasy-Map-Generator/issues/1444#issue-4484706235)

This PR removes a subtle unexpected side effect where the in-place sort mutates the pack data and leaves the cell arrays in an unexpected order after the module execution.

There is also a minor performance boost:

- sort -> O(n log n)
- reduce -> O(n)

# Verification

I used my deterministic test setup to verify that the change does not have a functional impact:

_http://localhost:5173/Fantasy-Map-Generator/?seed=42&width=1920&height=1080_

**The first 10 minima in the river-generator**

Rivers pre-fix: 9,156,40,155,45,152,159,38,160,37
Rivers post fix: 9,156,40,155,45,152,159,38,160,37

**The minima calculation in the lakes module triggers less often**

Lakes pre-fix 69: 885,4311
Lakes post-fix 69: 885,4311

Lakes pre-fix 102: 885,4311,5510
Lakes post-fix 102: 885,4311,5510

Also visual confirmation that this change does not have an impact of the generated map.