### PR TITLE
Compare source and target biom for culture biom expansion

### DIFF
--- a/src/modules/cultures-generator.ts
+++ b/src/modules/cultures-generator.ts
@@ -1296,6 +1296,7 @@ class CulturesModule {
     while (queue.length) {
       const { cellId, priority, cultureId } = queue.pop();
       const { type, expansionism } = cultures[cultureId];
+      const sourceBiome = cells.biome[cellId];
 
       cells.c[cellId].forEach(neibCellId => {
         if (hasLocked) {
@@ -1303,9 +1304,9 @@ class CulturesModule {
           if (neibCultureId && cultures[neibCultureId].lock) return; // do not overwrite cell of locked culture
         }
 
-        const biome = cells.biome[neibCellId];
-        const biomeCost = getBiomeCost(cultureId, biome, type as string);
-        const biomeChangeCost = biome === cells.biome[neibCellId] ? 0 : 20; // penalty on biome change
+        const targetBiome = cells.biome[neibCellId];
+        const biomeCost = getBiomeCost(cultureId, targetBiome, type as string);
+        const biomeChangeCost = sourceBiome === targetBiome ? 0 : 20; // penalty on biome change
         const heightCost = getHeightCost(neibCellId, cells.h[neibCellId], type as string);
         const riverCost = getRiverCost(cells.r[neibCellId], neibCellId, type as string);
         const typeCost = getTypeCost(cells.t[neibCellId], type as string);


### PR DESCRIPTION
# Description

This PR fixes [Issue-1440](https://github.com/Azgaar/Fantasy-Map-Generator/issues/1440#issue-4484559739) in order to correctly introduce a cost for biom change in expansion of cultures.

# Oberservations

The effect is subtle but visible at various locations. The change to the culture expansion also has an impact on the state generation, i noticed a whole state "The Proud Kingdom of Myth" that was completely gone after the change.

I used my usual test setup for the verification:
_http://localhost:5173/Fantasy-Map-Generator/?seed=42&width=1920&height=1080_

Cultures before the change:
<img width="2545" height="1294" alt="cultures-before-fix" src="https://github.com/user-attachments/assets/18988394-825a-41fb-b2db-914494c0bddb" />

Cultures after the change:
<img width="2545" height="1299" alt="cultures-after-fix" src="https://github.com/user-attachments/assets/9f243106-474a-4bd8-9c4c-3c31986e0532" />

Cultures/Bioms before the change:
<img width="2550" height="1298" alt="bioms-cultures-before-fix" src="https://github.com/user-attachments/assets/6e4811f1-7e02-4ae7-865d-26c11f8524de" />

Cultures/Bioms after the change:
<img width="2551" height="1294" alt="bioms-cultures-after-fix" src="https://github.com/user-attachments/assets/6f57be5b-8af3-4c67-8823-c35a071b9d21" />

Pure Biom Map as reference:
<img width="2548" height="1292" alt="bioms" src="https://github.com/user-attachments/assets/8ed28eb1-e489-4991-ba21-482bbef6f88a" />

