### PR TITLE
Fix: Manual paint, Customization === 11, Avoid duplicate listeners

### DIFF
--- a/public/modules/ui/provinces-editor.js
+++ b/public/modules/ui/provinces-editor.js
@@ -196,9 +196,19 @@ function editProvinces() {
     ensureEl("provincesFooterPopulation").dataset.population = totalPopulation;
 
     body.querySelectorAll("div.states").forEach(el => {
-      el.on("click", selectProvinceForLocate);
-      el.on("mouseenter", ev => provinceHighlightOn(ev));
-      el.on("mouseleave", ev => provinceHighlightOff(ev));
+      // Avoid attaching multiple listeners on refresh
+      if (el.dataset.provinceListener) return;
+
+      // Clicks should behave differently depending on mode:
+      // - normal mode: allow quick select for locate
+      // - manual assignment (customization === 11): allow selecting a province for painting
+      el.addEventListener("click", function (ev) {
+        if (customization === 11) selectProvinceOnLineClick.call(this, ev);
+        else selectProvinceForLocate.call(this, ev);
+      });
+      el.addEventListener("mouseenter", provinceHighlightOn);
+      el.addEventListener("mouseleave", provinceHighlightOff);
+      el.dataset.provinceListener = "1";
     });
 
     if (body.dataset.type === "percentage") {


### PR DESCRIPTION
Customization === 11 works for entering into "manual paint mode".

LocateProvince uses line selection to select a line on the Provinces editor.

Replace old el.on handlers with addEventListener and mark elements with a dataset flag to prevent attaching listeners repeatedly during refresh.

Add a click handler that dispatches to selectProvinceOnLineClick when customization === 11 (manual painting) or to selectProvinceForLocate otherwise.

Keep mouseenter/mouseleave wired to province highlight helpers.

# More information.

Perhaps we should consider the other times the "customization" has been modified in PR #1436.

```
function selectCultureOnLineClick(i) {
if (customization !== 4) return;
```

```
function selectReligionOnLineClick(i) {
if (customization !== 7) return;
```

```
function selectStateOnLineClick() {
if (customization !== 2) return;
```


