### PR TITLE
feat: add viewport renderer

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -183,10 +183,10 @@ let scale = 1;
 let viewX = 0;
 let viewY = 0;
 
-let rafId = null;
+let cameraFrameId = null;
 let pendingScaleChange = false;
 let pendingPositionChange = false;
-function zoomRaf() {
+function handleZoom() {
   const { k, x, y } = d3.event.transform;
 
   const isScaleChanged = Boolean(scale - k);
@@ -203,49 +203,51 @@ function zoomRaf() {
   pendingScaleChange = pendingScaleChange || isScaleChanged;
   pendingPositionChange = pendingPositionChange || isPositionChanged;
 
-  if (rafId) return;
-  rafId = requestAnimationFrame(() => {
-    rafId = null;
+  if (!cameraFrameId) {
+    cameraFrameId = requestAnimationFrame(() => {
+      cameraFrameId = null;
 
-    // Safely clears these flags for future renders
-    const didScaleChange = pendingScaleChange;
-    const didPositionChange = pendingPositionChange;
-    pendingScaleChange = false;
-    pendingPositionChange = false;
+      // Safely clears these flags for future renders
+      const didScaleChange = pendingScaleChange;
+      const didPositionChange = pendingPositionChange;
+      pendingScaleChange = false;
+      pendingPositionChange = false;
 
-    // Uses global values, so each frame always draws using the latest positioning values
-    viewbox.attr("transform", `translate(${viewX} ${viewY}) scale(${scale})`);
+      // Uses global values, so each frame always draws using the latest positioning values
+      viewbox.attr("transform", `translate(${viewX} ${viewY}) scale(${scale})`);
 
-    if (didPositionChange) {
-      if (layerIsOn("toggleCoordinates")) drawCoordinates();
-    }
+      if (didPositionChange) {
+        if (layerIsOn("toggleCoordinates")) drawCoordinates();
+      }
 
-    if (customization === 1) {
-      const canvas = ensureEl("canvas");
-      if (canvas && canvas.style.opacity !== "0") {
-        const img = ensureEl("imageToConvert");
-        if (img) {
-          const ctx = canvas.getContext("2d");
-          ctx.clearRect(0, 0, canvas.width, canvas.height);
-          ctx.setTransform(scale, 0, 0, scale, viewX, viewY);
-          ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      if (customization === 1) {
+        const canvas = ensureEl("canvas");
+        if (canvas && canvas.style.opacity !== "0") {
+          const img = ensureEl("imageToConvert");
+          if (img) {
+            const ctx = canvas.getContext("2d");
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            ctx.setTransform(scale, 0, 0, scale, viewX, viewY);
+            ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+          }
         }
       }
-    }
 
-    if (didScaleChange) {
-      invokeActiveZooming();
-      drawScaleBar(scaleBar, scale);
-      fitScaleBar(scaleBar, svgWidth, svgHeight);
-    }
+      if (didScaleChange) {
+        drawScaleBar(scaleBar, scale);
+        fitScaleBar(scaleBar, svgWidth, svgHeight);
+      }
 
-    if (didPositionChange || didScaleChange) {
-      window.updateMinimap && updateMinimap();
-    }
-  });
+      if (didPositionChange || didScaleChange) {
+        window.updateMinimap && updateMinimap();
+      }
+    });
+  }
+
+  scheduleViewportRender(getViewportBounds);
 }
 
-const zoom = d3.zoom().scaleExtent([1, 20]).on("zoom", zoomRaf);
+const zoom = d3.zoom().scaleExtent([1, 20]).on("zoom", handleZoom);
 
 var mapCoordinates = {}; // map coordinates on globe
 let populationRate = +ensureEl("populationRateInput").value;
@@ -262,6 +264,19 @@ var graphHeight = +mapHeightInput.value;
 // svg canvas resolution, can be changed
 let svgWidth = graphWidth;
 let svgHeight = graphHeight;
+
+function getViewportBounds() {
+  const padding = 80 / scale;
+  return {
+    scale,
+    x0: Math.max(-viewX / scale - padding, 0),
+    y0: Math.max(-viewY / scale - padding, 0),
+    x1: Math.min((svgWidth - viewX) / scale + padding, graphWidth),
+    y1: Math.min((svgHeight - viewY) / scale + padding, graphHeight)
+  };
+}
+
+window.getViewportBounds = getViewportBounds;
 
 landmass.append("rect").attr("x", 0).attr("y", 0).attr("width", graphWidth).attr("height", graphHeight);
 oceanPattern
@@ -521,7 +536,7 @@ function findBurgForMFCG(params) {
   }
 
   zoomTo(b.x, b.y, 8, 1600);
-  invokeActiveZooming();
+  renderViewport(getViewportBounds);
   tip("Here stands the glorious city of " + b.name, true, "success", 15000);
 }
 
@@ -534,70 +549,6 @@ function zoomTo(x, y, z = 8, d = 2000) {
 // Reset zoom to initial
 function resetZoom(d = 1000) {
   svg.transition().duration(d).call(zoom.transform, d3.zoomIdentity);
-}
-
-// active zooming feature
-function invokeActiveZooming() {
-  const isOptimized = shapeRendering.value === "optimizeSpeed";
-
-  if (coastline.select("#sea_island").size() && +coastline.select("#sea_island").attr("auto-filter")) {
-    // toggle shade/blur filter for coatline on zoom
-    const filter = scale > 1.5 && scale <= 2.6 ? null : scale > 2.6 ? "url(#blurFilter)" : "url(#dropShadow)";
-    coastline.select("#sea_island").attr("filter", filter);
-  }
-
-  // rescale labels on zoom
-  if (labels.style("display") !== "none") {
-    labels.selectAll("g").each(function () {
-      if (this.id === "burgLabels") return;
-      const desired = +this.dataset.size;
-      const relative = Math.max(rn((desired + desired / scale) / 2, 2), 1);
-      if (rescaleLabels.checked) this.setAttribute("font-size", relative);
-
-      const hidden = hideLabels.checked && (relative * scale < 6 || relative * scale > 60);
-      if (hidden) this.classList.add("hidden");
-      else this.classList.remove("hidden");
-    });
-  }
-
-  // rescale emblems on zoom
-  if (emblems.style("display") !== "none") {
-    emblems.selectAll("g").each(function () {
-      const size = this.getAttribute("font-size") * scale;
-      const hidden = hideEmblems.checked && (size < 25 || size > 300);
-      if (hidden) this.classList.add("hidden");
-      else this.classList.remove("hidden");
-      if (!hidden && window.COArenderer && this.children.length && !this.children[0].getAttribute("href"))
-        renderGroupCOAs(this);
-    });
-  }
-
-  // change states halo width
-  if (!customization && !isOptimized) {
-    const desired = +statesHalo.attr("data-width");
-    const haloSize = rn(desired / scale ** 0.8, 2);
-    statesHalo.attr("stroke-width", haloSize).style("display", haloSize > 0.1 ? "block" : "none");
-  }
-
-  // rescale map markers
-  +markers.attr("rescale") &&
-    pack.markers?.forEach(marker => {
-      const { i, x, y, size = 30, hidden } = marker;
-      const el = !hidden && document.getElementById(`marker${i}`);
-      if (!el) return;
-
-      const zoomedSize = Math.max(rn(size / 5 + 24 / scale, 2), 1);
-      el.setAttribute("width", zoomedSize);
-      el.setAttribute("height", zoomedSize);
-      el.setAttribute("x", rn(x - zoomedSize / 2, 1));
-      el.setAttribute("y", rn(y - zoomedSize, 1));
-    });
-
-  // rescale rulers to have always the same size
-  if (ruler.style("display") !== "none") {
-    const size = rn((10 / scale ** 0.3) * 2, 2);
-    ruler.selectAll("text").attr("font-size", size);
-  }
 }
 
 // add drag to upload logic, pull request from @evyatron
@@ -653,7 +604,7 @@ async function generate(options) {
     const timeStart = performance.now();
     const { seed: precreatedSeed, graph: precreatedGraph } = options || {};
 
-    invokeActiveZooming();
+    renderViewport(getViewportBounds);
     setSeed(precreatedSeed);
     INFO && console.group("Generated Map " + seed);
 

--- a/public/modules/ui/layers.js
+++ b/public/modules/ui/layers.js
@@ -258,6 +258,7 @@ function drawLayers() {
   if (layerIsOn("toggleRulers")) rulers.draw();
   // scale bar
   // vignette
+  renderViewport(getViewportBounds);
 }
 
 function toggleHeight(event) {
@@ -844,29 +845,14 @@ function toggleRoutes(event) {
 
 function drawRoutes() {
   TIME && console.time("drawRoutes");
-  const routePaths = {};
-
-  for (const route of pack.routes) {
-    const { i, group, points } = route;
-    if (!points || points.length < 2) continue;
-    if (!routePaths[group]) routePaths[group] = [];
-    routePaths[group].push(`<path id="route${i}" d="${Routes.getPath(route)}"/>`);
-  }
-
-  routes.attr("fill", "none").selectAll("path").remove();
-  for (const group in routePaths) {
-    routes.select("#" + group).html(routePaths[group].join(""));
-  }
-
+  syncRouteLayers();
+  renderViewport(getViewportBounds);
   TIME && console.timeEnd("drawRoutes");
 }
 
 function drawRoute(route) {
-  routes
-    .select("#" + route.group)
-    .append("path")
-    .attr("d", Routes.getPath(route))
-    .attr("id", "route" + route.i);
+  syncRouteLayers();
+  renderViewport(getViewportBounds);
 }
 
 function toggleMilitary(event) {
@@ -911,6 +897,7 @@ function toggleLabels(event) {
     $("#labels").fadeIn();
     // don't redraw labels as they are not stored in data yet
     if (labels.selectAll("text").size() === 0) drawLabels();
+    else renderViewport(getViewportBounds);
     if (event && isCtrlClick(event)) editStyle("labels");
   } else {
     if (event && isCtrlClick(event)) return editStyle("labels");
@@ -922,7 +909,7 @@ function toggleLabels(event) {
 function drawLabels() {
   drawStateLabels();
   drawBurgLabels();
-  invokeActiveZooming();
+  renderViewport(getViewportBounds);
 }
 
 function toggleBurgIcons(event) {
@@ -994,7 +981,7 @@ function toggleEmblems(event) {
     turnButtonOn("toggleEmblems");
     if (!emblems.selectAll("use").size()) drawEmblems();
     $("#emblems").fadeIn();
-    invokeActiveZooming();
+    renderViewport(getViewportBounds);
     if (event && isCtrlClick(event)) editStyle("emblems");
   } else {
     if (event && isCtrlClick(event)) return editStyle("emblems");

--- a/public/modules/ui/style-presets.js
+++ b/public/modules/ui/style-presets.js
@@ -155,7 +155,7 @@ function applyStyleWithUiRefresh(style) {
   updateMapFilter();
   stylePreset.dataset.old = stylePreset.value;
 
-  invokeActiveZooming();
+  renderViewport(getViewportBounds);
   setPresetRemoveButtonVisibiliy();
 
   drawScaleBar(scaleBar, scale);

--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -585,13 +585,13 @@ styleGridShiftY.on("input", function () {
 
 styleRescaleMarkers.on("change", function () {
   markers.attr("rescale", +this.checked);
-  invokeActiveZooming();
+  renderViewport(getViewportBounds);
 });
 
 styleCoastlineAuto.on("change", function () {
   coastline.select("#sea_island").attr("auto-filter", +this.checked);
   styleFilter.style.display = this.checked ? "none" : "block";
-  invokeActiveZooming();
+  renderViewport(getViewportBounds);
 });
 
 styleOceanFill.on("input", function () {
@@ -1185,7 +1185,7 @@ function updateElements() {
   if (legend.selectAll("*").size() && window.redrawLegend) redrawLegend();
   oceanLayers.selectAll("path").remove();
   OceanLayers();
-  invokeActiveZooming();
+  renderViewport(getViewportBounds);
 }
 
 // GLOBAL FILTERS

--- a/src/controllers/route-editor.ts
+++ b/src/controllers/route-editor.ts
@@ -41,7 +41,14 @@ function open(id: string): void {
   ensureEl("toggleCells").dataset.forced = String(+!layerIsOn("toggleCells"));
   if (!layerIsOn("toggleCells")) toggleCells();
 
+  const routeId = +id.slice(5);
+  forceViewportRoute(routeId);
+  renderViewport(getViewportBounds);
   elSelected = select<SVGElement, unknown>(`#${id}`).on("click", addControlPoint);
+  if (elSelected.empty()) {
+    releaseViewportRoute(routeId);
+    return;
+  }
 
   tip(
     "Drag control points to change the route. Click on point to remove it. Click on the route to add additional control point. For major changes please create a new route instead",
@@ -376,9 +383,13 @@ function changeName(this: HTMLInputElement): void {
 }
 
 function changeGroup(this: HTMLInputElement): void {
+  const routeId = +elSelected.attr("id").slice(5);
   const group = this.value;
   ensureEl(group).appendChild(elSelected.node()!);
   getRoute().group = group;
+  forceViewportRoute(routeId);
+  syncRouteLayers();
+  renderViewport(getViewportBounds);
 }
 
 function generateName(): void {
@@ -437,6 +448,9 @@ function removeRoute(): void {
 }
 
 function closeRouteEditor(): void {
+  const routeId = +elSelected.attr("id").slice(5);
+  releaseViewportRoute(routeId);
+
   select("#controlPoints").remove();
   select("#controlCells").remove();
 
@@ -449,6 +463,7 @@ function closeRouteEditor(): void {
   if (forced && layerIsOn("toggleCells")) toggleCells();
 
   ensureEl("routeEditor").innerHTML = "";
+  renderViewport(getViewportBounds);
 }
 
 export const RouteEditor = { open };

--- a/src/controllers/route-groups-editor.ts
+++ b/src/controllers/route-groups-editor.ts
@@ -49,7 +49,7 @@ function addLines(): void {
     .selectAll<SVGGElement, unknown>("g")
     .nodes()
     .map(el => {
-      const count = el.children.length;
+      const count = pack.routes.filter((route: Route) => route.group === el.id).length;
       return /* html */ `<div data-id="${el.id}" class="states" style="display: flex; justify-content: space-between;">
           <span>${el.id} (${count})</span>
           <div style="width: auto; display: flex; gap: 0.4em;">
@@ -83,6 +83,7 @@ function addGroup(): void {
       .attr("stroke-dasharray", "1 0.5")
       .attr("stroke-linecap", "butt");
     ensureEl<HTMLSelectElement>("routeGroup").options.add(new Option(group, group));
+    syncRouteLayers();
     addLines();
 
     ensureEl<HTMLSelectElement>("routeCreatorGroupSelect").options.add(new Option(group, group));
@@ -98,6 +99,8 @@ function removeGroup(group: string): void {
     onConfirm: () => {
       pack.routes.filter((r: Route) => r.group === group).forEach(Routes.remove);
       if (!DEFAULT_GROUPS.includes(group)) routes.select(`#${group}`).remove();
+      syncRouteLayers();
+      renderViewport(getViewportBounds);
       addLines();
     }
   });

--- a/src/controllers/routes-overview.ts
+++ b/src/controllers/routes-overview.ts
@@ -118,18 +118,38 @@ function routesOverviewAddLines(): void {
 function routeHighlightOn(event: Event): void {
   if (!layerIsOn("toggleRoutes")) toggleRoutes();
   const routeId = +(event.target as HTMLElement).dataset.id!;
-  routes.select(`#route${routeId}`).attr("stroke", "red").attr("stroke-width", 2).attr("stroke-dasharray", "none");
+  forceViewportRoute(routeId);
+  renderViewport(getViewportBounds);
+  const route = routes.select(`#route${routeId}`);
+  if (route.empty()) {
+    releaseViewportRoute(routeId);
+    return;
+  }
+
+  route.attr("stroke", "red").attr("stroke-width", 2).attr("stroke-dasharray", "none");
 }
 
 function routeHighlightOff(e: Event): void {
   const routeId = +(e.target as HTMLElement).dataset.id!;
-  routes.select(`#route${routeId}`).attr("stroke", null).attr("stroke-width", null).attr("stroke-dasharray", null);
+  const route = routes.select(`#route${routeId}`);
+  if (!route.empty()) route.attr("stroke", null).attr("stroke-width", null).attr("stroke-dasharray", null);
+  releaseViewportRoute(routeId);
+  renderViewport(getViewportBounds);
 }
 
 function zoomToRoute(this: HTMLElement): void {
   const routeId = +(this.parentNode as HTMLElement).dataset.id!;
-  const route = routes.select(`#route${routeId}`).node() as Element;
+  forceViewportRoute(routeId);
+  renderViewport(getViewportBounds);
+  const route = routes.select(`#route${routeId}`).node() as Element | null;
+  if (!route) {
+    releaseViewportRoute(routeId);
+    return;
+  }
+
   highlightElement(route, 3);
+  releaseViewportRoute(routeId);
+  renderViewport(getViewportBounds);
 }
 
 function downloadRoutesData(): void {

--- a/src/generators/routes-generator.ts
+++ b/src/generators/routes-generator.ts
@@ -811,6 +811,8 @@ class RoutesModule {
 
     pack.routes = pack.routes.filter(r => r.i !== route.i);
     viewbox.select(`#route${route.i}`).remove();
+    releaseViewportRoute(route.i);
+    syncRouteLayers();
   }
 
   getConnectivityRate(cellId: number): number {
@@ -874,7 +876,18 @@ class RoutesModule {
 
   getLength(routeId: number): number {
     const path = routes.select(`#route${routeId}`).node() as SVGPathElement;
-    return path.getTotalLength();
+    if (path) return path.getTotalLength();
+
+    const route = pack.routes.find(route => route.i === routeId);
+    if (!route) return 0;
+
+    const temporaryPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    temporaryPath.setAttribute("d", this.getPath(route));
+    temporaryPath.setAttribute("visibility", "hidden");
+    routes.node()?.appendChild(temporaryPath);
+    const length = temporaryPath.getTotalLength();
+    temporaryPath.remove();
+    return length;
   }
 
   // run on map load to restore connections based on routes data

--- a/src/index.html
+++ b/src/index.html
@@ -1370,7 +1370,13 @@
               </tr>
               <tr data-tip="Allow system to hide emblem groups if their size in too small or too big on that scale">
                 <td colspan="2">
-                  <input id="hideEmblems" class="checkbox" type="checkbox" onchange="invokeActiveZooming()" checked />
+                  <input
+                    id="hideEmblems"
+                    class="checkbox"
+                    type="checkbox"
+                    onchange="renderViewport(getViewportBounds)"
+                    checked
+                  />
                   <label for="hideEmblems" class="checkbox-label">Toggle visibility automatically</label>
                 </td>
               </tr>
@@ -1459,13 +1465,25 @@
 
               <tr data-tip="Allow system to hide labels if their size in too small or too big on that scale">
                 <td colspan="2">
-                  <input id="hideLabels" class="checkbox" type="checkbox" onchange="invokeActiveZooming()" checked />
+                  <input
+                    id="hideLabels"
+                    class="checkbox"
+                    type="checkbox"
+                    onchange="renderViewport(getViewportBounds)"
+                    checked
+                  />
                   <label for="hideLabels" class="checkbox-label">Toggle visibility automatically</label>
                 </td>
               </tr>
               <tr data-tip="Allow system to rescale labels on zoom">
                 <td colspan="2">
-                  <input id="rescaleLabels" class="checkbox" type="checkbox" onchange="invokeActiveZooming()" checked />
+                  <input
+                    id="rescaleLabels"
+                    class="checkbox"
+                    type="checkbox"
+                    onchange="renderViewport(getViewportBounds)"
+                    checked
+                  />
                   <label for="rescaleLabels" class="checkbox-label">Rescale on zoom</label>
                 </td>
               </tr>
@@ -5950,7 +5968,7 @@
               type="checkbox"
               onchange="
                 hideLabels.checked = !this.checked;
-                invokeActiveZooming();
+                renderViewport(getViewportBounds);
               "
               checked=""
             />

--- a/src/renderers/burg_icons_layers.ts
+++ b/src/renderers/burg_icons_layers.ts
@@ -1,0 +1,123 @@
+import type { Burg } from "../generators/burgs-generator";
+import { type Bounds, registerLayer, unregisterLayer } from "./layer_registry";
+
+type BurgGroup = { name: string; order: number };
+
+const svgNamespace = "http://www.w3.org/2000/svg";
+const registeredGroups = new Set<string>();
+
+export function syncBurgIconLayers(): void {
+  const definitions = [...(options.burgs.groups as BurgGroup[])].sort((a, b) => a.order - b.order);
+  const activeGroups = new Set(definitions.map(group => group.name));
+  const iconRoot = document.getElementById("burgIcons");
+  const anchorRoot = document.getElementById("anchors");
+  if (!(iconRoot instanceof SVGGElement) || !(anchorRoot instanceof SVGGElement)) return;
+
+  const defaultIconStyle = style.burgIcons.town || Object.values(style.burgIcons)[0] || {};
+  const defaultAnchorStyle = style.anchors.town || Object.values(style.anchors)[0] || {};
+
+  for (const { name } of definitions) {
+    iconRoot.appendChild(ensureStyledGroup(iconRoot, name, style.burgIcons[name] || defaultIconStyle));
+    anchorRoot.appendChild(ensureStyledGroup(anchorRoot, name, style.anchors[name] || defaultAnchorStyle));
+    registerBurgGroup(name);
+  }
+
+  removeInactiveGroups(iconRoot, activeGroups);
+  removeInactiveGroups(anchorRoot, activeGroups);
+
+  for (const groupName of registeredGroups) {
+    if (activeGroups.has(groupName)) continue;
+    unregisterLayer(`burg_icons.${groupName}`);
+    unregisterLayer(`anchors.${groupName}`);
+    registeredGroups.delete(groupName);
+  }
+}
+
+function registerBurgGroup(groupName: string): void {
+  registeredGroups.add(groupName);
+  const scaleMin = getScaleMin(groupName);
+
+  registerLayer<Burg>({
+    id: `burg_icons.${groupName}`,
+    rootId: "burgIcons",
+    groupId: groupName,
+    enabled: () => layerIsOn("toggleBurgIcons"),
+    scaleMin,
+    getItems: getBurgs,
+    filter: burg => burg.group === groupName,
+    inViewport: isBurgInViewport,
+    render: renderBurgIcons
+  });
+
+  registerLayer<Burg>({
+    id: `anchors.${groupName}`,
+    rootId: "anchors",
+    groupId: groupName,
+    enabled: () => layerIsOn("toggleBurgIcons"),
+    scaleMin,
+    getItems: getBurgs,
+    filter: burg => burg.group === groupName && Boolean(burg.port),
+    inViewport: isBurgInViewport,
+    render: renderAnchors
+  });
+}
+
+function getBurgs(): Burg[] {
+  return (pack.burgs || []).filter(burg => Boolean(burg.i) && !burg.removed);
+}
+
+function isBurgInViewport(burg: Burg, bounds: Bounds): boolean {
+  return burg.x >= bounds.x0 && burg.x <= bounds.x1 && burg.y >= bounds.y0 && burg.y <= bounds.y1;
+}
+
+function renderBurgIcons(group: SVGGElement, burgs: Burg[]): void {
+  const icon = group.dataset.icon || "#icon-circle";
+  group.replaceChildren(
+    ...burgs.map(burg => {
+      const use = document.createElementNS(svgNamespace, "use");
+      use.id = `burg${burg.i}`;
+      use.dataset.id = String(burg.i);
+      use.setAttribute("href", icon);
+      use.setAttribute("x", String(burg.x));
+      use.setAttribute("y", String(burg.y));
+      return use;
+    })
+  );
+}
+
+function renderAnchors(group: SVGGElement, burgs: Burg[]): void {
+  group.replaceChildren(
+    ...burgs.map(burg => {
+      const use = document.createElementNS(svgNamespace, "use");
+      use.id = `anchor${burg.i}`;
+      use.dataset.id = String(burg.i);
+      use.setAttribute("href", "#icon-anchor");
+      use.setAttribute("x", String(burg.x));
+      use.setAttribute("y", String(burg.y));
+      return use;
+    })
+  );
+}
+
+function ensureStyledGroup(root: SVGGElement, groupId: string, attributes: Record<string, string>): SVGGElement {
+  const existing = Array.from(root.children).find(child => child instanceof SVGGElement && child.id === groupId);
+  if (existing instanceof SVGGElement) return existing;
+
+  const group = document.createElementNS(svgNamespace, "g");
+  for (const [name, value] of Object.entries(attributes)) group.setAttribute(name, value);
+  group.id = groupId;
+  return group;
+}
+
+function removeInactiveGroups(root: SVGGElement, activeGroups: Set<string>): void {
+  for (const group of Array.from(root.children)) {
+    if (group instanceof SVGGElement && !activeGroups.has(group.id)) group.remove();
+  }
+}
+
+function getScaleMin(groupName: string): number {
+  if (groupName === "capital") return 1;
+  if (groupName === "city") return 1.5;
+  if (groupName === "town") return 2.5;
+  return 3;
+}

--- a/src/renderers/coastline_layers.ts
+++ b/src/renderers/coastline_layers.ts
@@ -1,0 +1,15 @@
+import { registerLayer } from "./layer_registry";
+
+registerLayer({
+  id: "coastline.sea_island",
+  rootId: "coastline",
+  groupId: "sea_island",
+  enabled: () => true,
+  update: (group, { scale }) => {
+    if (!Number(group.getAttribute("auto-filter"))) return;
+
+    const filter = scale > 1.5 && scale <= 2.6 ? null : scale > 2.6 ? "url(#blurFilter)" : "url(#dropShadow)";
+    if (filter) group.setAttribute("filter", filter);
+    else group.removeAttribute("filter");
+  }
+});

--- a/src/renderers/draw-burg-icons.ts
+++ b/src/renderers/draw-burg-icons.ts
@@ -1,4 +1,5 @@
 import type { Burg } from "../generators/burgs-generator";
+import { syncBurgIconLayers } from "./burg_icons_layers";
 
 declare global {
   var drawBurgIcons: () => void;
@@ -8,110 +9,21 @@ declare global {
 
 const burgIconsRenderer = (): void => {
   TIME && console.time("drawBurgIcons");
-  createIconGroups();
-
-  for (const { name } of options.burgs.groups) {
-    const burgsInGroup = pack.burgs.filter(b => b.group === name && !b.removed);
-    if (!burgsInGroup.length) continue;
-
-    const iconsGroup = document.querySelector<SVGGElement>(`#burgIcons > g#${name}`);
-    if (!iconsGroup) continue;
-
-    const icon = iconsGroup.dataset.icon || "#icon-circle";
-    iconsGroup.innerHTML = burgsInGroup
-      .map(b => `<use id="burg${b.i}" data-id="${b.i}" href="${icon}" x="${b.x}" y="${b.y}"></use>`)
-      .join("");
-
-    const portsInGroup = burgsInGroup.filter(b => b.port);
-    if (!portsInGroup.length) continue;
-
-    const portGroup = document.querySelector<SVGGElement>(`#anchors > g#${name}`);
-    if (!portGroup) continue;
-
-    portGroup.innerHTML = portsInGroup
-      .map(b => `<use id="anchor${b.i}" data-id="${b.i}" href="#icon-anchor" x="${b.x}" y="${b.y}"></use>`)
-      .join("");
-  }
-
+  syncBurgIconLayers();
+  renderViewport(getViewportBounds);
   TIME && console.timeEnd("drawBurgIcons");
 };
 
 const drawBurgIconRenderer = (burg: Burg): void => {
-  const iconGroup = burgIcons.select<SVGGElement>(`#${burg.group}`);
-  if (iconGroup.empty()) {
-    drawBurgIcons();
-    return; // redraw all icons if group is missing
-  }
-
-  removeBurgIconRenderer(burg.i!);
-  const icon = iconGroup.attr("data-icon") || "#icon-circle";
-  burgIcons
-    .select(`#${burg.group}`)
-    .append("use")
-    .attr("href", icon)
-    .attr("id", `burg${burg.i}`)
-    .attr("data-id", burg.i!)
-    .attr("x", burg.x)
-    .attr("y", burg.y);
-
-  if (burg.port) {
-    anchors
-      .select(`#${burg.group}`)
-      .append("use")
-      .attr("href", "#icon-anchor")
-      .attr("id", `anchor${burg.i}`)
-      .attr("data-id", burg.i!)
-      .attr("x", burg.x)
-      .attr("y", burg.y);
-  }
+  if (!burg.i) return;
+  syncBurgIconLayers();
+  renderViewport(getViewportBounds);
 };
 
 const removeBurgIconRenderer = (burgId: number): void => {
-  const existingIcon = document.getElementById(`burg${burgId}`);
-  if (existingIcon) existingIcon.remove();
-
-  const existingAnchor = document.getElementById(`anchor${burgId}`);
-  if (existingAnchor) existingAnchor.remove();
+  document.getElementById(`burg${burgId}`)?.remove();
+  document.getElementById(`anchor${burgId}`)?.remove();
 };
-
-function createIconGroups(): void {
-  // save existing styles and remove all groups
-  document.querySelectorAll("g#burgIcons > g").forEach(group => {
-    style.burgIcons[group.id] = Array.from(group.attributes).reduce((acc: { [key: string]: string }, attribute) => {
-      acc[attribute.name] = attribute.value;
-      return acc;
-    }, {});
-    group.remove();
-  });
-
-  document.querySelectorAll("g#anchors > g").forEach(group => {
-    style.anchors[group.id] = Array.from(group.attributes).reduce((acc: { [key: string]: string }, attribute) => {
-      acc[attribute.name] = attribute.value;
-      return acc;
-    }, {});
-    group.remove();
-  });
-
-  // create groups for each burg group and apply stored or default style
-  const defaultIconStyle = style.burgIcons.town || Object.values(style.burgIcons)[0] || {};
-  const defaultAnchorStyle = style.anchors.town || Object.values(style.anchors)[0] || {};
-  const sortedGroups = [...options.burgs.groups].sort((a, b) => a.order - b.order);
-  for (const { name } of sortedGroups) {
-    const burgGroup = burgIcons.append("g");
-    const iconStyles = style.burgIcons[name] || defaultIconStyle;
-    Object.entries(iconStyles).forEach(([key, value]) => {
-      burgGroup.attr(key, value);
-    });
-    burgGroup.attr("id", name);
-
-    const anchorGroup = anchors.append("g");
-    const anchorStyles = style.anchors[name] || defaultAnchorStyle;
-    Object.entries(anchorStyles).forEach(([key, value]) => {
-      anchorGroup.attr(key, value);
-    });
-    anchorGroup.attr("id", name);
-  }
-}
 
 window.drawBurgIcons = burgIconsRenderer;
 window.drawBurgIcon = drawBurgIconRenderer;

--- a/src/renderers/draw-emblems.ts
+++ b/src/renderers/draw-emblems.ts
@@ -149,7 +149,7 @@ const emblemsRenderer = (): void => {
       .join("");
     emblems.select("#stateEmblems").attr("font-size", sizeStates).html(stateString);
 
-    invokeActiveZooming();
+    renderViewport(getViewportBounds);
   });
 
   TIME && console.timeEnd("drawEmblems");

--- a/src/renderers/emblems_layers.ts
+++ b/src/renderers/emblems_layers.ts
@@ -1,0 +1,20 @@
+import { registerLayer } from "./layer_registry";
+
+for (const groupId of ["burgEmblems", "provinceEmblems", "stateEmblems"]) {
+  registerLayer({
+    id: `emblems.${groupId}`,
+    rootId: "emblems",
+    groupId,
+    enabled: () => layerIsOn("toggleEmblems"),
+    update: (group, { scale }) => {
+      const size = Number(group.getAttribute("font-size")) * scale;
+      const hidden = hideEmblems.checked && (size < 25 || size > 300);
+      group.classList.toggle("hidden", hidden);
+
+      const firstEmblem = group.firstElementChild;
+      if (!hidden && window.COArenderer && firstEmblem && !firstEmblem.getAttribute("href")) {
+        renderGroupCOAs(group);
+      }
+    }
+  });
+}

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -18,3 +18,4 @@ import "./draw-trade-animation";
 import "./ocean-layers";
 import "./trade-animation";
 import "./emblems";
+import "./viewport_layers";

--- a/src/renderers/labels_layers.ts
+++ b/src/renderers/labels_layers.ts
@@ -1,0 +1,61 @@
+import { rn } from "../utils";
+import { type RenderContext, registerLayer, unregisterLayer } from "./layer_registry";
+
+const registeredLabelLayers = new Set<string>();
+
+export function syncLabelLayers(): void {
+  const labelsRoot = document.getElementById("labels");
+  if (!(labelsRoot instanceof SVGGElement)) return;
+
+  const currentLayers = new Set<string>();
+  const labelGroups = Array.from(labelsRoot.children)
+    .filter((child): child is SVGGElement => child instanceof SVGGElement && child.id !== "burgLabels")
+    .map(group => group.id)
+    .filter(Boolean);
+
+  for (const groupId of labelGroups) {
+    const layerId = `labels.${groupId}`;
+    currentLayers.add(layerId);
+    registerLabelLayer(layerId, "labels", groupId);
+  }
+
+  const burgLabelsRoot = document.getElementById("burgLabels");
+  const burgLabelGroups = burgLabelsRoot
+    ? Array.from(burgLabelsRoot.children)
+        .filter((child): child is SVGGElement => child instanceof SVGGElement)
+        .map(group => group.id)
+        .filter(Boolean)
+    : [];
+
+  for (const groupId of burgLabelGroups) {
+    const layerId = `burg_labels.${groupId}`;
+    currentLayers.add(layerId);
+    registerLabelLayer(layerId, "burgLabels", groupId);
+  }
+
+  for (const layerId of registeredLabelLayers) {
+    if (currentLayers.has(layerId)) continue;
+    unregisterLayer(layerId);
+    registeredLabelLayers.delete(layerId);
+  }
+}
+
+function registerLabelLayer(layerId: string, rootId: string, groupId: string): void {
+  registeredLabelLayers.add(layerId);
+  registerLayer({
+    id: layerId,
+    rootId,
+    groupId,
+    enabled: () => layerIsOn("toggleLabels"),
+    update: updateLabelGroup
+  });
+}
+
+function updateLabelGroup(group: SVGGElement, { scale }: RenderContext): void {
+  const desired = Number(group.dataset.size);
+  const relative = Math.max(rn((desired + desired / scale) / 2, 2), 1);
+  if (rescaleLabels.checked) group.setAttribute("font-size", String(relative));
+
+  const hidden = hideLabels.checked && (relative * scale < 6 || relative * scale > 60);
+  group.classList.toggle("hidden", hidden);
+}

--- a/src/renderers/layer_registry.ts
+++ b/src/renderers/layer_registry.ts
@@ -1,0 +1,45 @@
+export type Bounds = {
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+  scale: number;
+};
+
+export type RenderContext = {
+  bounds: Bounds;
+  scale: number;
+};
+
+export type LayerEntry<T> = {
+  id: string;
+  rootId: string;
+  groupId: string;
+  enabled: () => boolean;
+  scaleMin?: number;
+  scaleMax?: number;
+  getItems?: () => T[];
+  filter?: (item: T) => boolean;
+  inViewport?: (item: T, bounds: Bounds) => boolean;
+  render?: (group: SVGGElement, items: T[], context: RenderContext) => void;
+  update?: (group: SVGGElement, context: RenderContext) => void;
+};
+
+const registry: LayerEntry<unknown>[] = [];
+
+export function registerLayer<T>(entry: LayerEntry<T>): void {
+  const index = registry.findIndex(layer => layer.id === entry.id);
+  const registeredEntry = entry as LayerEntry<unknown>;
+
+  if (index === -1) registry.push(registeredEntry);
+  else registry[index] = registeredEntry;
+}
+
+export function unregisterLayer(id: string): void {
+  const index = registry.findIndex(layer => layer.id === id);
+  if (index !== -1) registry.splice(index, 1);
+}
+
+export function getLayers(): readonly LayerEntry<unknown>[] {
+  return registry;
+}

--- a/src/renderers/markers_layers.ts
+++ b/src/renderers/markers_layers.ts
@@ -1,0 +1,24 @@
+import { rn } from "../utils";
+import { registerLayer } from "./layer_registry";
+
+type ZoomMarker = (typeof pack.markers)[number] & { size?: number; hidden?: boolean };
+
+registerLayer({
+  id: "markers.default",
+  rootId: "viewbox",
+  groupId: "markers",
+  enabled: () => layerIsOn("toggleMarkers") && Boolean(Number(markers.attr("rescale"))),
+  update: (group, { scale }) => {
+    for (const marker of (pack.markers || []) as ZoomMarker[]) {
+      const { i, x, y, size = 30, hidden } = marker;
+      const element = !hidden ? group.querySelector<SVGSVGElement>(`#marker${i}`) : null;
+      if (!element) continue;
+
+      const zoomedSize = Math.max(rn(size / 5 + 24 / scale, 2), 1);
+      element.setAttribute("width", String(zoomedSize));
+      element.setAttribute("height", String(zoomedSize));
+      element.setAttribute("x", String(rn(x - zoomedSize / 2, 1)));
+      element.setAttribute("y", String(rn(y - zoomedSize, 1)));
+    }
+  }
+});

--- a/src/renderers/routes_layers.ts
+++ b/src/renderers/routes_layers.ts
@@ -1,0 +1,107 @@
+import type { Route } from "../generators/routes-generator";
+import { type Bounds, registerLayer, unregisterLayer } from "./layer_registry";
+
+const svgNamespace = "http://www.w3.org/2000/svg";
+const forcedRoutes = new Set<number>();
+const forcedRouteGroups = new Map<number, string>();
+const registeredGroups = new Set<string>();
+
+export function syncRouteLayers(): void {
+  const root = document.getElementById("routes");
+  if (!(root instanceof SVGGElement)) return;
+  root.setAttribute("fill", "none");
+
+  const activeGroups = new Set([
+    ...Array.from(root.children)
+      .filter((child): child is SVGGElement => child instanceof SVGGElement)
+      .map(group => group.id)
+      .filter(Boolean),
+    ...(pack.routes || []).map(route => route.group).filter(Boolean)
+  ]);
+
+  for (const groupName of activeGroups) registerRouteGroup(groupName);
+
+  for (const groupName of registeredGroups) {
+    if (activeGroups.has(groupName)) continue;
+    unregisterLayer(`routes.${groupName}`);
+    registeredGroups.delete(groupName);
+  }
+}
+
+export function forceRoute(routeId: number): void {
+  const route = pack.routes?.find(route => route.i === routeId);
+  if (!route) return;
+
+  const previousGroup = forcedRouteGroups.get(routeId);
+  forcedRoutes.add(routeId);
+  forcedRouteGroups.set(routeId, route.group);
+  if (previousGroup && previousGroup !== route.group) registerRouteGroup(previousGroup);
+  registerRouteGroup(route.group);
+}
+
+export function releaseRoute(routeId: number): void {
+  const groupName = forcedRouteGroups.get(routeId);
+  forcedRoutes.delete(routeId);
+  forcedRouteGroups.delete(routeId);
+  if (groupName) registerRouteGroup(groupName);
+}
+
+function registerRouteGroup(groupName: string): void {
+  registeredGroups.add(groupName);
+  const defaultScaleMin = getScaleMin(groupName);
+  const hasForcedRoute = Array.from(forcedRouteGroups.values()).includes(groupName);
+
+  registerLayer<Route>({
+    id: `routes.${groupName}`,
+    rootId: "routes",
+    groupId: groupName,
+    enabled: () => layerIsOn("toggleRoutes"),
+    scaleMin: hasForcedRoute ? 1 : defaultScaleMin,
+    getItems: getRoutes,
+    filter: route => route.group === groupName,
+    inViewport: (route, bounds) => isRouteInViewport(route, bounds, defaultScaleMin),
+    render: renderRoutes
+  });
+}
+
+function getRoutes(): Route[] {
+  return (pack.routes || []).filter(route => route.points?.length >= 2);
+}
+
+function isRouteInViewport(route: Route, bounds: Bounds, defaultScaleMin: number): boolean {
+  if (forcedRoutes.has(route.i)) return true;
+  if (bounds.scale < defaultScaleMin) return false;
+
+  let x0 = Infinity;
+  let y0 = Infinity;
+  let x1 = -Infinity;
+  let y1 = -Infinity;
+  for (const [x, y] of route.points) {
+    x0 = Math.min(x0, x);
+    y0 = Math.min(y0, y);
+    x1 = Math.max(x1, x);
+    y1 = Math.max(y1, y);
+  }
+
+  return x1 >= bounds.x0 && x0 <= bounds.x1 && y1 >= bounds.y0 && y0 <= bounds.y1;
+}
+
+function getScaleMin(groupName: string): number {
+  return groupName === "trails" ? 3 : 1;
+}
+
+function renderRoutes(group: SVGGElement, routeList: Route[]): void {
+  group.replaceChildren(
+    ...routeList.map(route => {
+      const existingPath = forcedRoutes.has(route.i) ? group.querySelector<SVGPathElement>(`#route${route.i}`) : null;
+      const path = existingPath || document.createElementNS(svgNamespace, "path");
+      path.id = `route${route.i}`;
+      path.setAttribute("d", Routes.getPath(route));
+      return path;
+    })
+  );
+}
+
+window.syncRouteLayers = syncRouteLayers;
+window.forceViewportRoute = forceRoute;
+window.releaseViewportRoute = releaseRoute;

--- a/src/renderers/ruler_layers.ts
+++ b/src/renderers/ruler_layers.ts
@@ -1,0 +1,15 @@
+import { rn } from "../utils";
+import { registerLayer } from "./layer_registry";
+
+registerLayer({
+  id: "ruler.default",
+  rootId: "viewbox",
+  groupId: "ruler",
+  enabled: () => layerIsOn("toggleRulers"),
+  update: (group, { scale }) => {
+    const size = rn((10 / scale ** 0.3) * 2, 2);
+    group.querySelectorAll("text").forEach(text => {
+      text.setAttribute("font-size", String(size));
+    });
+  }
+});

--- a/src/renderers/states_halo_layers.ts
+++ b/src/renderers/states_halo_layers.ts
@@ -1,0 +1,15 @@
+import { rn } from "../utils";
+import { registerLayer } from "./layer_registry";
+
+registerLayer({
+  id: "states.halo",
+  rootId: "regions",
+  groupId: "statesHalo",
+  enabled: () => !customization && shapeRendering.value !== "optimizeSpeed",
+  update: (group, { scale }) => {
+    const desired = Number(group.dataset.width);
+    const haloSize = rn(desired / scale ** 0.8, 2);
+    group.setAttribute("stroke-width", String(haloSize));
+    group.style.display = haloSize > 0.1 ? "block" : "none";
+  }
+});

--- a/src/renderers/viewport_layers.ts
+++ b/src/renderers/viewport_layers.ts
@@ -1,0 +1,27 @@
+import "./coastline_layers";
+import "./emblems_layers";
+import "./markers_layers";
+import "./ruler_layers";
+import "./states_halo_layers";
+import { syncBurgIconLayers } from "./burg_icons_layers";
+import { syncLabelLayers } from "./labels_layers";
+import { syncRouteLayers } from "./routes_layers";
+import { renderAll, renderNow, scheduleRender } from "./viewport_renderer";
+
+function syncLayers(): void {
+  syncLabelLayers();
+  syncBurgIconLayers();
+  syncRouteLayers();
+}
+
+window.scheduleViewportRender = scheduleRender;
+
+window.renderViewport = getBounds => {
+  syncLayers();
+  renderNow(getBounds);
+};
+
+window.renderAllViewportLayers = (root, getBounds) => {
+  syncLayers();
+  renderAll(root, getBounds);
+};

--- a/src/renderers/viewport_renderer.test.ts
+++ b/src/renderers/viewport_renderer.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { type Bounds, registerLayer, unregisterLayer } from "./layer_registry";
+import { renderNow, scheduleRender } from "./viewport_renderer";
+
+const svgNamespace = "http://www.w3.org/2000/svg";
+const bounds: Bounds = { x0: 0, y0: 0, x1: 100, y1: 100, scale: 2 };
+const registeredIds: string[] = [];
+const hasSvgDom = typeof document !== "undefined" && typeof document.createElementNS === "function";
+
+afterEach(() => {
+  for (const id of registeredIds.splice(0)) unregisterLayer(id);
+  document.querySelectorAll("svg[data-viewport-renderer-test]").forEach(svg => {
+    svg.remove();
+  });
+});
+
+describe.runIf(hasSvgDom)("viewport renderer", () => {
+  it("isolates subgroups and filters items to the viewport", () => {
+    createRoot("features");
+    registerTestLayer({
+      id: "test.visible",
+      rootId: "features",
+      groupId: "visible",
+      enabled: () => true,
+      getItems: () => [25, 125],
+      inViewport: item => item <= bounds.x1,
+      render: (group, items) => renderValues(group, items)
+    });
+    registerTestLayer({
+      id: "test.sibling",
+      rootId: "features",
+      groupId: "sibling",
+      enabled: () => true,
+      getItems: () => [75],
+      render: (group, items) => renderValues(group, items)
+    });
+
+    renderNow(() => bounds);
+
+    expect(getValues("visible")).toEqual(["25"]);
+    expect(getValues("sibling")).toEqual(["75"]);
+  });
+
+  it("clears a materialized group when its toggle or scale range disables it", () => {
+    createRoot("scaled");
+    let enabled = true;
+    registerTestLayer({
+      id: "test.scaled",
+      rootId: "scaled",
+      groupId: "items",
+      enabled: () => enabled,
+      scaleMin: 2,
+      scaleMax: 4,
+      getItems: () => [1],
+      render: (group, items) => renderValues(group, items)
+    });
+
+    renderNow(() => bounds);
+    expect(getValues("items")).toEqual(["1"]);
+
+    enabled = false;
+    renderNow(() => bounds);
+    expect(getValues("items")).toEqual([]);
+
+    enabled = true;
+    renderNow(() => ({ ...bounds, scale: 1.99 }));
+    expect(getValues("items")).toEqual([]);
+  });
+
+  it("coalesces repeated camera updates into one animation frame", async () => {
+    createRoot("batched");
+    let renders = 0;
+    registerTestLayer({
+      id: "test.batched",
+      rootId: "batched",
+      groupId: "items",
+      enabled: () => true,
+      getItems: () => [1],
+      render: group => {
+        renders++;
+        group.dataset.scale = String(bounds.scale);
+      }
+    });
+
+    scheduleRender(() => ({ ...bounds, scale: 1 }));
+    scheduleRender(() => ({ ...bounds, scale: 1.5 }));
+    scheduleRender(() => bounds);
+    await nextPaint();
+
+    expect(renders).toBe(1);
+    expect(document.getElementById("items")?.dataset.scale).toBe("2");
+  });
+
+  it("skips missing roots without throwing", () => {
+    registerTestLayer({
+      id: "test.missing",
+      rootId: "missing",
+      groupId: "items",
+      enabled: () => true,
+      getItems: () => [1],
+      render: () => {
+        throw new Error("render should not run");
+      }
+    });
+
+    expect(() => renderNow(() => bounds)).not.toThrow();
+  });
+});
+
+function registerTestLayer<T>(entry: Parameters<typeof registerLayer<T>>[0]): void {
+  registeredIds.push(entry.id);
+  registerLayer(entry);
+}
+
+function createRoot(id: string): void {
+  const svg = document.createElementNS(svgNamespace, "svg");
+  svg.dataset.viewportRendererTest = "";
+  const root = document.createElementNS(svgNamespace, "g");
+  root.id = id;
+  svg.appendChild(root);
+  document.body.appendChild(svg);
+}
+
+function renderValues(group: SVGGElement, values: number[]): void {
+  group.replaceChildren(
+    ...values.map(value => {
+      const element = document.createElementNS(svgNamespace, "use");
+      element.dataset.value = String(value);
+      return element;
+    })
+  );
+}
+
+function getValues(groupId: string): string[] {
+  return Array.from(document.querySelectorAll(`#${groupId} > use`)).map(
+    element => (element as SVGUseElement).dataset.value!
+  );
+}
+
+function nextPaint(): Promise<void> {
+  return new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+}

--- a/src/renderers/viewport_renderer.ts
+++ b/src/renderers/viewport_renderer.ts
@@ -1,0 +1,78 @@
+import { type Bounds, getLayers, type LayerEntry, type RenderContext } from "./layer_registry";
+
+type BoundsProvider = () => Bounds;
+type RenderRoot = Document | SVGSVGElement;
+
+const svgNamespace = "http://www.w3.org/2000/svg";
+let rafId: number | null = null;
+let pendingBoundsProvider: BoundsProvider | null = null;
+
+export function scheduleRender(getBounds: BoundsProvider): void {
+  pendingBoundsProvider = getBounds;
+  if (rafId !== null) return;
+
+  rafId = requestAnimationFrame(() => {
+    rafId = null;
+    const getPendingBounds = pendingBoundsProvider;
+    pendingBoundsProvider = null;
+    if (getPendingBounds) renderLayers(getPendingBounds());
+  });
+}
+
+export function renderNow(getBounds: BoundsProvider): void {
+  if (rafId !== null) cancelAnimationFrame(rafId);
+  rafId = null;
+  pendingBoundsProvider = null;
+  renderLayers(getBounds());
+}
+
+export function renderAll(root: SVGSVGElement, getBounds: BoundsProvider): void {
+  renderLayers(getBounds(), root, true);
+}
+
+function renderLayers(bounds: Bounds, root: RenderRoot = document, renderAllItems = false): void {
+  const context: RenderContext = { bounds, scale: bounds.scale };
+
+  for (const layer of getLayers()) {
+    const rootGroup = findElement(root, layer.rootId);
+    if (!rootGroup) continue;
+
+    const group = ensureGroup(rootGroup, layer.groupId);
+    const active = layer.enabled() && (renderAllItems || isInScaleRange(bounds.scale, layer));
+
+    if (!active) {
+      if (layer.render) group.replaceChildren();
+      continue;
+    }
+
+    if (layer.render && layer.getItems) {
+      let items = layer.getItems();
+      if (layer.filter) items = items.filter(layer.filter);
+      if (!renderAllItems && layer.inViewport) items = items.filter(item => layer.inViewport!(item, bounds));
+      layer.render(group, items, context);
+    }
+
+    if (!renderAllItems) layer.update?.(group, context);
+  }
+}
+
+function findElement(root: RenderRoot, id: string): SVGGElement | null {
+  const element = root instanceof Document ? root.getElementById(id) : root.querySelector(`#${CSS.escape(id)}`);
+  return element instanceof SVGGElement ? element : null;
+}
+
+function ensureGroup(root: SVGGElement, groupId: string): SVGGElement {
+  const existing = Array.from(root.children).find(child => child instanceof SVGGElement && child.id === groupId);
+  if (existing instanceof SVGGElement) return existing;
+
+  const group = document.createElementNS(svgNamespace, "g");
+  group.id = groupId;
+  root.appendChild(group);
+  return group;
+}
+
+function isInScaleRange(scale: number, layer: LayerEntry<unknown>): boolean {
+  if (layer.scaleMin !== undefined && scale < layer.scaleMin) return false;
+  if (layer.scaleMax !== undefined && scale > layer.scaleMax) return false;
+  return true;
+}

--- a/src/services/io/export.ts
+++ b/src/services/io/export.ts
@@ -239,6 +239,7 @@ async function getMapURL(type: string, options: GetMapURLOptions = {}): Promise<
 
   const cloneEl = (document.getElementById("map") as unknown as SVGSVGElement).cloneNode(true) as SVGSVGElement; // clone svg
   cloneEl.id = "fantasyMap";
+  renderAllViewportLayers(cloneEl, getViewportBounds);
   document.body.appendChild(cloneEl);
   const clone: MapSelection = select(cloneEl);
   if (!debug) clone.select("#debug").remove();

--- a/src/services/io/load.ts
+++ b/src/services/io/load.ts
@@ -803,7 +803,7 @@ async function parseLoadedData(data: string[], mapVersion: string | null): Promi
     if (layerIsOn("toggleGrid")) drawGrid();
     if (typeof window.restoreDefaultEvents === "function") restoreDefaultEvents();
     focusOn(); // based on searchParams focus on point, cell or burg
-    invokeActiveZooming();
+    renderViewport(getViewportBounds);
     fitMapToScreen();
 
     WARN && console.warn(`TOTAL: ${rn((performance.now() - uploadTimeStart) / 1000, 2)}s`);

--- a/src/services/io/save.ts
+++ b/src/services/io/save.ts
@@ -82,6 +82,7 @@ function prepareMapData(): string {
 
   // save svg
   const cloneEl = ensureEl("map").cloneNode(true) as SVGSVGElement;
+  renderAllViewportLayers(cloneEl, getViewportBounds);
 
   // reset transform values to default
   cloneEl.setAttribute("width", String(graphWidth));

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -4,6 +4,7 @@ import type { GoodsModule } from "../generators/goods-generator";
 import type { MarketsModule } from "../generators/markets-generator";
 import type { NameBase } from "../generators/names-generator";
 import type { ProductionModule } from "../generators/production-generator";
+import type { Bounds } from "../renderers/layer_registry";
 import type { PackedGraph } from "./PackedGraph";
 
 declare global {
@@ -43,7 +44,9 @@ declare global {
   var latitudeOutput: HTMLInputElement;
   var longitudeOutput: HTMLInputElement;
   var precOutput: HTMLInputElement;
+  var shapeRendering: HTMLSelectElement;
   var hideLabels: HTMLInputElement;
+  var hideEmblems: HTMLInputElement;
   var stylePreset: HTMLSelectElement;
   var rescaleLabels: HTMLInputElement;
   var temperatureScale: HTMLSelectElement;
@@ -172,7 +175,13 @@ declare global {
 
   var layerIsOn: (layerId: string) => boolean;
   var drawRoute: (route: any) => void;
-  var invokeActiveZooming: () => void;
+  var getViewportBounds: () => Bounds;
+  var scheduleViewportRender: (getBounds: () => Bounds) => void;
+  var renderViewport: (getBounds: () => Bounds) => void;
+  var renderAllViewportLayers: (root: SVGSVGElement, getBounds: () => Bounds) => void;
+  var syncRouteLayers: () => void;
+  var forceViewportRoute: (routeId: number) => void;
+  var releaseViewportRoute: (routeId: number) => void;
   var FlatQueue: any;
 
   var THREE: any; // lazy-loaded


### PR DESCRIPTION
## Performance

Synthetic stress profile in headless Chromium at scale 5: 12,000 burgs, 4,000 routes, 24 camera moves. Values are one local run and should be treated as directional, not a cross-device guarantee.

| Metric | `master` | This branch | Change |
| --- | ---: | ---: | ---: |
| Live heavy-layer nodes | 17,200 | 654 | -96.2% |
| Total SVG nodes | 18,125 | 1,579 | -91.3% |
| Initial route + burg draw | 52.9 ms | 17.5 ms | -66.9% |
| Traced task time | 761.1 ms | 488.6 ms | -35.8% |
| Layout time | 26.1 ms | 13.4 ms | -48.5% |

On a generated 1,028-burg / 837-route map, scale 1 retained 10 burg icons and 191 route paths. A focused scale-5 viewport retained 19 icons and 27 route paths. A full export clone restored all 1,028 icons, 205 anchors, and 837 routes.