### PR TITLE
Load maps from full JSON exports

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -268,6 +268,10 @@ oceanLayers
   .attr("width", graphWidth)
   .attr("height", graphHeight);
 
+// capture the pristine svg skeleton before any map is drawn, so a JSON import (which carries
+// no serialized SVG, unlike a .map file) can reset to a clean canvas and render via drawLayers
+window.cleanMapSkeleton = document.getElementById("map")?.outerHTML;
+
 document.addEventListener("DOMContentLoaded", async () => {
   if (!location.hostname) {
     const wiki = "https://github.com/Azgaar/Fantasy-Map-Generator/wiki/Run-FMG-locally";

--- a/public/modules/dynamic/export-json.js
+++ b/public/modules/dynamic/export-json.js
@@ -46,15 +46,32 @@ function getFullDataJson() {
 // View-state that lives only in the SVG (not the data model), so it can be restored on import.
 // A .map file keeps this implicitly via the serialized SVG; JSON must capture it explicitly.
 function getViewState() {
-  // custom burg label positions: a manual drag stores a transform on the <text>, not in burg data
-  const burgLabels = {};
-  document.querySelectorAll("#burgLabels text[transform]").forEach(el => {
-    const id = el.getAttribute("data-id");
-    if (id) burgLabels[id] = el.getAttribute("transform");
+  // manually added free-text labels live in label subgroups under #labels and have no data-model
+  // representation. Capture every label subgroup except the ones drawLayers regenerates.
+  const labelGroups = [];
+  document.querySelectorAll("#labels > g").forEach(g => {
+    if (g.id === "states" || g.id === "burgLabels") return; // regenerated on import
+    if (!g.querySelector("text")) return; // skip empty groups
+    labelGroups.push(g.outerHTML);
+  });
+
+  // the curve paths the added labels follow (exclude regenerated stateLabel paths)
+  const textPaths = [];
+  document.querySelectorAll("#textPaths > path").forEach(p => {
+    if (/^textPath_label\d+$/.test(p.id)) textPaths.push(p.outerHTML);
+  });
+
+  // manual drag positions on regenerated burg/state labels (a drag stores a transform on the <text>)
+  const labelTransforms = {};
+  document.querySelectorAll("#burgLabels text[transform], #states text[transform]").forEach(el => {
+    if (el.id) labelTransforms[el.id] = el.getAttribute("transform");
   });
 
   return {
-    burgLabels,
+    labelGroups,
+    textPaths,
+    labelTransforms,
+    fonts: getUsedFonts(svg.node()),
     rulers: rulers.toString(),
     texture: document.getElementById("texture")?.getAttribute("data-href") || null,
     oceanScheme: document.getElementById("oceanHeights")?.getAttribute("scheme") || null,

--- a/public/modules/dynamic/export-json.js
+++ b/public/modules/dynamic/export-json.js
@@ -28,6 +28,7 @@ function getFullDataJson() {
   const settings = getSettings();
   const pack = getPackCellsData();
   const grid = getGridCellsData();
+  const viewState = getViewState();
 
   return JSON.stringify({
     info,
@@ -37,8 +38,28 @@ function getFullDataJson() {
     grid,
     biomesData,
     notes,
-    nameBases
+    nameBases,
+    viewState
   });
+}
+
+// View-state that lives only in the SVG (not the data model), so it can be restored on import.
+// A .map file keeps this implicitly via the serialized SVG; JSON must capture it explicitly.
+function getViewState() {
+  // custom burg label positions: a manual drag stores a transform on the <text>, not in burg data
+  const burgLabels = {};
+  document.querySelectorAll("#burgLabels text[transform]").forEach(el => {
+    const id = el.getAttribute("data-id");
+    if (id) burgLabels[id] = el.getAttribute("transform");
+  });
+
+  return {
+    burgLabels,
+    rulers: rulers.toString(),
+    texture: document.getElementById("texture")?.getAttribute("data-href") || null,
+    oceanScheme: document.getElementById("oceanHeights")?.getAttribute("scheme") || null,
+    landScheme: document.getElementById("landHeights")?.getAttribute("scheme") || null
+  };
 }
 
 function getMinimalDataJson() {

--- a/public/modules/dynamic/export-json.js
+++ b/public/modules/dynamic/export-json.js
@@ -103,7 +103,20 @@ function getSettings() {
     hideLabels: hideLabels.checked,
     stylePreset: stylePreset.value,
     rescaleLabels: rescaleLabels.checked,
-    urbanDensity: urbanDensity
+    urbanDensity: urbanDensity,
+    // generation-request sliders ("new map to apply"): not properties of the current map, but
+    // saving them lets an importer restore the Options panel so "New Map" reproduces similar params
+    generationSettings: {
+      template: templateInput.value,
+      cultures: +culturesOutput.value,
+      culturesSet: culturesSet.value,
+      statesNumber: +statesNumber.value,
+      provincesRatio: +provincesRatio.value,
+      sizeVariety: +sizeVariety.value,
+      growthRate: +growthRate.value,
+      manors: manorsOutput.value,
+      religionsNumber: +religionsNumber.value
+    }
   };
 }
 

--- a/public/modules/io/load.js
+++ b/public/modules/io/load.js
@@ -995,6 +995,18 @@ async function parseJsonData(json) {
       ice: []
     };
 
+    // forward-compat: carry through any extra pack collections the export provides but this loader
+    // doesn't specially handle (e.g. the goods branch's goods/markets/deals), so they survive the
+    // round-trip even though they aren't rendered here. Geometry keys are excluded — they are
+    // rebuilt into typed arrays below.
+    const handledPackKeys = new Set([
+      "cells", "vertices", "features", "cultures", "states", "burgs",
+      "religions", "provinces", "rivers", "markers", "routes", "zones"
+    ]);
+    for (const key in json.pack) {
+      if (!handledPackKeys.has(key)) pack[key] = json.pack[key];
+    }
+
     pack.vertices = {
       p: pv.map(v => v.p),
       v: pv.map(v => v.v),

--- a/public/modules/io/load.js
+++ b/public/modules/io/load.js
@@ -311,67 +311,7 @@ async function parseLoadedData(data, mapVersion) {
       document.body.insertAdjacentHTML("afterbegin", data[5]);
     }
 
-    {
-      svg = d3.select("#map");
-      defs = svg.select("#deftemp");
-      viewbox = svg.select("#viewbox");
-      scaleBar = svg.select("#scaleBar");
-      legend = svg.select("#legend");
-      ocean = viewbox.select("#ocean");
-      oceanLayers = ocean.select("#oceanLayers");
-      oceanPattern = ocean.select("#oceanPattern");
-      lakes = viewbox.select("#lakes");
-      landmass = viewbox.select("#landmass");
-      texture = viewbox.select("#texture");
-      terrs = viewbox.select("#terrs");
-      biomes = viewbox.select("#biomes");
-      ice = viewbox.select("#ice");
-      cells = viewbox.select("#cells");
-      gridOverlay = viewbox.select("#gridOverlay");
-      coordinates = viewbox.select("#coordinates");
-      compass = viewbox.select("#compass");
-      rivers = viewbox.select("#rivers");
-      terrain = viewbox.select("#terrain");
-      relig = viewbox.select("#relig");
-      cults = viewbox.select("#cults");
-      regions = viewbox.select("#regions");
-      statesBody = regions.select("#statesBody");
-      statesHalo = regions.select("#statesHalo");
-      provs = viewbox.select("#provs");
-      zones = viewbox.select("#zones");
-      borders = viewbox.select("#borders");
-      stateBorders = borders.select("#stateBorders");
-      provinceBorders = borders.select("#provinceBorders");
-      routes = viewbox.select("#routes");
-      roads = routes.select("#roads");
-      trails = routes.select("#trails");
-      searoutes = routes.select("#searoutes");
-      temperature = viewbox.select("#temperature");
-      coastline = viewbox.select("#coastline");
-      prec = viewbox.select("#prec");
-      population = viewbox.select("#population");
-      emblems = viewbox.select("#emblems");
-      labels = viewbox.select("#labels");
-      icons = viewbox.select("#icons");
-      burgIcons = icons.select("#burgIcons");
-      anchors = icons.select("#anchors");
-      armies = viewbox.select("#armies");
-      markers = viewbox.select("#markers");
-      ruler = viewbox.select("#ruler");
-      fogging = viewbox.select("#fogging");
-      debug = viewbox.select("#debug");
-      burgLabels = labels.select("#burgLabels");
-
-      if (!texture.size()) {
-        texture = viewbox
-          .insert("g", "#landmass")
-          .attr("id", "texture")
-          .attr("data-href", "./images/textures/plaster.jpg");
-      }
-      if (!emblems.size()) {
-        emblems = viewbox.insert("g", "#labels").attr("id", "emblems").style("display", "none");
-      }
-    }
+    reselectSvgElements();
 
     {
       grid = JSON.parse(data[6]);
@@ -776,4 +716,348 @@ async function parseLoadedData(data, mapVersion) {
       position: {my: "center", at: "center", of: "svg"}
     });
   }
+}
+
+// re-acquire all global d3 selections after the #map svg is (re)inserted into the DOM
+function reselectSvgElements() {
+  svg = d3.select("#map");
+  defs = svg.select("#deftemp");
+  viewbox = svg.select("#viewbox");
+  scaleBar = svg.select("#scaleBar");
+  legend = svg.select("#legend");
+  ocean = viewbox.select("#ocean");
+  oceanLayers = ocean.select("#oceanLayers");
+  oceanPattern = ocean.select("#oceanPattern");
+  lakes = viewbox.select("#lakes");
+  landmass = viewbox.select("#landmass");
+  texture = viewbox.select("#texture");
+  terrs = viewbox.select("#terrs");
+  biomes = viewbox.select("#biomes");
+  ice = viewbox.select("#ice");
+  cells = viewbox.select("#cells");
+  gridOverlay = viewbox.select("#gridOverlay");
+  coordinates = viewbox.select("#coordinates");
+  compass = viewbox.select("#compass");
+  rivers = viewbox.select("#rivers");
+  terrain = viewbox.select("#terrain");
+  relig = viewbox.select("#relig");
+  cults = viewbox.select("#cults");
+  regions = viewbox.select("#regions");
+  statesBody = regions.select("#statesBody");
+  statesHalo = regions.select("#statesHalo");
+  provs = viewbox.select("#provs");
+  zones = viewbox.select("#zones");
+  borders = viewbox.select("#borders");
+  stateBorders = borders.select("#stateBorders");
+  provinceBorders = borders.select("#provinceBorders");
+  routes = viewbox.select("#routes");
+  roads = routes.select("#roads");
+  trails = routes.select("#trails");
+  searoutes = routes.select("#searoutes");
+  temperature = viewbox.select("#temperature");
+  coastline = viewbox.select("#coastline");
+  prec = viewbox.select("#prec");
+  population = viewbox.select("#population");
+  emblems = viewbox.select("#emblems");
+  labels = viewbox.select("#labels");
+  icons = viewbox.select("#icons");
+  burgIcons = icons.select("#burgIcons");
+  anchors = icons.select("#anchors");
+  armies = viewbox.select("#armies");
+  markers = viewbox.select("#markers");
+  ruler = viewbox.select("#ruler");
+  fogging = viewbox.select("#fogging");
+  debug = viewbox.select("#debug");
+  burgLabels = labels.select("#burgLabels");
+
+  if (!texture.size()) {
+    texture = viewbox
+      .insert("g", "#landmass")
+      .attr("id", "texture")
+      .attr("data-href", "./images/textures/plaster.jpg");
+  }
+  if (!emblems.size()) {
+    emblems = viewbox.insert("g", "#labels").attr("id", "emblems").style("display", "none");
+  }
+}
+
+// read a full JSON export from disk and load it as the current map
+function uploadJsonMap(file, callback) {
+  uploadMap.timeStart = performance.now();
+
+  const fileReader = new FileReader();
+  fileReader.onloadend = async function (fileLoadedEvent) {
+    if (callback) callback();
+    ensureEl("coas").innerHTML = ""; // remove auto-generated emblems
+
+    try {
+      const json = JSON.parse(fileLoadedEvent.target.result);
+      await parseJsonData(json);
+    } catch (error) {
+      ERROR && console.error(error);
+      clearMainTip();
+
+      alertMessage.innerHTML = /* html */ `An error occurred while loading the JSON map. Make sure the file is a <b>Full</b> JSON export (Minimal, PackCells and GridCells exports cannot be loaded).
+        <p id="errorBox">${parseError(error)}</p>`;
+      $("#alert").dialog({
+        resizable: false,
+        title: "JSON loading error",
+        maxWidth: "40em",
+        buttons: {
+          OK: function () {
+            $(this).dialog("close");
+          }
+        },
+        position: {my: "center", at: "center", of: "svg"}
+      });
+    }
+  };
+
+  fileReader.readAsText(file);
+}
+
+// reconstruct the live map (grid, pack, entities and rendering) from a full JSON export.
+// Unlike a .map file, a JSON export carries no serialized SVG and stores cells as an
+// array of objects, so we rebuild the geometry the way generation does (calculateVoronoi +
+// markupGrid + reGraph + markupPack), overlay the saved attributes, then render via drawLayers.
+async function parseJsonData(json) {
+  const isFullExport = json?.pack?.cells?.length && json?.grid?.cells?.length && json?.grid?.points?.length;
+  if (!isFullExport)
+    throw new Error("This is not a Full JSON export (missing pack.cells / grid.cells / grid.points)");
+
+  INFO && console.group("Loaded JSON Map " + (json.info?.seed || ""));
+
+  if (window.closeDialogs) closeDialogs();
+  customization = 0;
+  if (customizationMenu.offsetParent) styleTab.click();
+
+  // map identity and canvas size
+  {
+    const info = json.info || {};
+    seed = info.seed != null ? String(info.seed) : generateSeed();
+    optionsSeed.value = seed;
+    Math.random = aleaPRNG(seed); // re-seed PRNG so any randomized drawing is reproducible
+    if (info.width) graphWidth = +info.width;
+    if (info.height) graphHeight = +info.height;
+    mapId = info.mapId ? +info.mapId : Date.now();
+  }
+
+  // settings
+  {
+    const s = json.settings || {};
+    if (s.distanceUnit) applyOption(distanceUnitInput, s.distanceUnit);
+    if (s.distanceScale) distanceScale = distanceScaleInput.value = s.distanceScale;
+    if (s.areaUnit) areaUnit.value = s.areaUnit;
+    if (s.heightUnit) applyOption(heightUnit, s.heightUnit);
+    if (s.heightExponent) heightExponentInput.value = s.heightExponent;
+    if (s.temperatureScale) temperatureScale.value = s.temperatureScale;
+    if (s.populationRate) populationRate = populationRateInput.value = s.populationRate;
+    if (s.urbanization) urbanization = urbanizationInput.value = s.urbanization;
+    if (s.mapSize) mapSizeInput.value = mapSizeOutput.value = minmax(s.mapSize, 1, 100);
+    if (s.latitude) latitudeInput.value = latitudeOutput.value = minmax(s.latitude, 0, 100);
+    if (s.longitude != null) longitudeInput.value = longitudeOutput.value = minmax(s.longitude || 50, 0, 100);
+    if (s.prec) precInput.value = precOutput.value = s.prec;
+    if (s.options) options = typeof s.options === "string" ? JSON.parse(s.options) : s.options;
+    if (s.mapName || json.info?.mapName) mapName.value = s.mapName || json.info.mapName;
+    if (s.hideLabels != null) hideLabels.checked = +s.hideLabels;
+    if (s.stylePreset) stylePreset.value = s.stylePreset;
+    if (s.rescaleLabels != null) rescaleLabels.checked = +s.rescaleLabels;
+    if (s.urbanDensity != null) urbanDensity = urbanDensityInput.value = +s.urbanDensity;
+
+    // canvas size: reflect the loaded map's dimensions on the Options inputs
+    mapWidthInput.value = graphWidth;
+    mapHeightInput.value = graphHeight;
+
+    // Points number: derive the cell-density slider from the grid's cellsDesired
+    const cellsDesired = json.grid?.cellsDesired;
+    if (cellsDesired) {
+      const sliderValue = Object.keys(cellsDensityMap).find(k => cellsDensityMap[k] === cellsDesired);
+      if (sliderValue) changeCellsDensity(+sliderValue);
+      else {
+        pointsInput.dataset.cells = cellsDesired;
+        pointsOutputFormatted.value = Math.round(cellsDesired / 1000) + "K";
+        pointsOutputFormatted.style.color = getCellsDensityColor(cellsDesired);
+      }
+    }
+
+    // generation-request sliders ("new map to apply") are only present in newer exports;
+    // restore them when available so a subsequent "New Map" reproduces similar parameters
+    const g = s.generationSettings;
+    if (g) {
+      if (g.template) applyOption(templateInput, g.template);
+      if (g.cultures != null) culturesInput.value = culturesOutput.value = g.cultures;
+      if (g.culturesSet) {
+        culturesSet.value = g.culturesSet;
+        if (window.changeCultureSet) changeCultureSet();
+      }
+      if (g.statesNumber != null) {
+        statesNumber.value = g.statesNumber;
+        changeStatesNumber(g.statesNumber);
+      }
+      if (g.provincesRatio != null) provincesRatio.value = g.provincesRatio;
+      if (g.sizeVariety != null) sizeVariety.value = g.sizeVariety;
+      if (g.growthRate != null) growthRate.value = g.growthRate;
+      if (g.manors != null) {
+        manorsInput.value = g.manors === "auto" ? 1000 : g.manors;
+        manorsOutput.value = g.manors;
+      }
+      if (g.religionsNumber != null) religionsNumber.value = g.religionsNumber;
+    }
+  }
+
+  {
+    stateLabelsModeInput.value = options.stateLabelsMode;
+    yearInput.value = options.year;
+    eraInput.value = options.era;
+    shapeRendering.value = "geometricPrecision";
+  }
+
+  // coordinates, notes, name bases and biomes
+  if (json.mapCoordinates) mapCoordinates = json.mapCoordinates;
+  if (json.notes) notes = json.notes;
+  if (json.nameBases?.length) nameBases = json.nameBases;
+  biomesData = json.biomesData || Biomes.getDefault();
+
+  // reset the canvas to a clean SVG skeleton and re-acquire selections
+  {
+    if (!window.cleanMapSkeleton) throw new Error("Clean SVG skeleton is unavailable; cannot render JSON map");
+    svg.remove();
+    document.body.insertAdjacentHTML("afterbegin", window.cleanMapSkeleton);
+    reselectSvgElements();
+  }
+
+  // Restore the grid graph directly from the export. Unlike a .map file (which stores only
+  // grid points and rebuilds the Voronoi on load), a Full JSON export serializes the complete
+  // grid geometry per cell, so we deserialize it as-is — fully deterministic and version-proof.
+  {
+    const gc = json.grid.cells;
+    const gv = json.grid.vertices;
+    grid = {
+      spacing: json.grid.spacing,
+      cellsDesired: json.grid.cellsDesired,
+      cellsX: json.grid.cellsX,
+      cellsY: json.grid.cellsY,
+      points: json.grid.points,
+      boundary: json.grid.boundary,
+      seed: json.grid.seed || seed,
+      features: json.grid.features || [],
+      cells: {
+        i: createTypedArray({maxValue: gc.length, length: gc.length}).map((_, i) => i),
+        v: gc.map(c => c.v),
+        c: gc.map(c => c.c),
+        b: gc.map(c => c.b),
+        f: Uint16Array.from(gc, c => c.f),
+        t: Int8Array.from(gc, c => c.t),
+        h: Uint8Array.from(gc, c => c.h),
+        temp: Int8Array.from(gc, c => c.temp),
+        prec: Uint8Array.from(gc, c => c.prec)
+      },
+      vertices: {
+        p: gv.map(v => v.p),
+        v: gv.map(v => v.v),
+        c: gv.map(v => v.c)
+      }
+    };
+
+    // The Full export mislabels grid.features (it actually stores pack.features) and never
+    // exports the real grid features. Regenerate them from the restored heights so grid-level
+    // consumers (ocean layers, ice) have a self-consistent features/t/f. This only touches the
+    // grid graph — the packed graph is restored independently above, so it is unaffected.
+    Features.markupGrid();
+  }
+
+  // Restore the packed graph directly from the export (cells, vertices, entities and attributes)
+  {
+    const pc = json.pack.cells;
+    const pv = json.pack.vertices;
+    pack = {
+      features: json.pack.features,
+      cultures: json.pack.cultures,
+      states: json.pack.states,
+      burgs: json.pack.burgs,
+      religions: json.pack.religions?.length ? json.pack.religions : [{i: 0, name: "No religion"}],
+      provinces: json.pack.provinces?.length ? json.pack.provinces : [0],
+      rivers: json.pack.rivers || [],
+      markers: json.pack.markers || [],
+      routes: json.pack.routes || [],
+      zones: json.pack.zones || [],
+      ice: []
+    };
+
+    pack.vertices = {
+      p: pv.map(v => v.p),
+      v: pv.map(v => v.v),
+      c: pv.map(v => v.c)
+    };
+
+    pack.cells = {
+      i: createTypedArray({maxValue: pc.length, length: pc.length}).map((_, i) => i),
+      v: pc.map(c => c.v),
+      c: pc.map(c => c.c),
+      // border flag is not serialized by the export; derive it the way the Voronoi builder does
+      // (a cell is on the border when it has more vertices than adjacent cells)
+      b: pc.map(c => (c.v.length > c.c.length ? 1 : 0)),
+      p: pc.map(c => c.p),
+      g: createTypedArray({maxValue: grid.points.length, from: pc.map(c => c.g)}),
+      h: Uint8Array.from(pc, c => c.h),
+      area: createTypedArray({maxValue: UINT16_MAX, from: pc.map(c => c.area)}),
+      f: Uint16Array.from(pc, c => c.f),
+      t: Int8Array.from(pc, c => c.t),
+      haven: createTypedArray({maxValue: pc.length, from: pc.map(c => c.haven)}),
+      harbor: Uint8Array.from(pc, c => c.harbor),
+      fl: Uint16Array.from(pc, c => c.fl),
+      r: Uint16Array.from(pc, c => c.r),
+      conf: Uint8Array.from(pc, c => c.conf),
+      biome: Uint8Array.from(pc, c => c.biome),
+      s: Int16Array.from(pc, c => c.s),
+      pop: Float32Array.from(pc, c => c.pop),
+      culture: Uint16Array.from(pc, c => c.culture),
+      burg: createTypedArray({maxValue: pack.burgs.length, from: pc.map(c => c.burg)}),
+      state: Uint16Array.from(pc, c => c.state),
+      religion: Uint16Array.from(pc, c => c.religion),
+      province: Uint16Array.from(pc, c => c.province)
+    };
+
+    // rebuild the cell-routes lookup {fromCell: {toCell: routeId}} from per-cell entries
+    pack.cells.routes = {};
+    for (const c of pc) {
+      if (c.routes && Object.keys(c.routes).length) pack.cells.routes[c.i] = c.routes;
+    }
+  }
+
+  // render: JSON carries no SVG, so draw every layer from data like generation does
+  {
+    // apply the map's own saved style preset (mirrors applyStyleOnLoad but with the export's
+    // preset, and without persisting to localStorage so the user's default style is untouched).
+    // Falls back to the local default if that preset isn't available in this browser.
+    try {
+      const desiredPreset = json.settings?.stylePreset || localStorage.getItem("presetStyle") || "default";
+      const [appliedPreset, styleJSON] = await getStylePreset(desiredPreset);
+      applyStyle(styleJSON);
+      updateMapFilter();
+      stylePreset.value = stylePreset.dataset.old = appliedPreset;
+      setPresetRemoveButtonVisibiliy();
+    } catch (styleError) {
+      ERROR && console.error("Failed to apply saved style preset, using default", styleError);
+      await applyStyleOnLoad();
+    }
+
+    OceanLayers(); // coastal depth bands — generated, not stored in the export
+    Ice.generate(); // ice is not included in the export; regenerate it from temperature/height
+    applyLayersPreset();
+    drawLayers();
+    if (rulers && layerIsOn("toggleRulers")) rulers.draw();
+    if (layerIsOn("toggleGrid")) drawGrid();
+  }
+
+  {
+    if (window.restoreDefaultEvents) restoreDefaultEvents();
+    invokeActiveZooming();
+    fitMapToScreen();
+  }
+
+  WARN && console.warn(`TOTAL: ${rn((performance.now() - uploadMap.timeStart) / 1000, 2)}s`);
+  showStatistics();
+  INFO && console.groupEnd("Loaded JSON Map " + seed);
+  tip("Map is successfully loaded from JSON", true, "success", 7000);
 }

--- a/public/modules/io/load.js
+++ b/public/modules/io/load.js
@@ -781,6 +781,17 @@ function reselectSvgElements() {
   }
 }
 
+// parse an SVG fragment string into a live node, preserving the SVG namespace and attribute
+// casing (textPath, xlink:href) that insertAdjacentHTML on an HTML context would mangle
+function parseSvgFragment(html) {
+  const doc = new DOMParser().parseFromString(
+    `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">${html}</svg>`,
+    "image/svg+xml"
+  );
+  if (doc.querySelector("parsererror")) return null;
+  return doc.documentElement.firstElementChild;
+}
+
 // read a full JSON export from disk and load it as the current map
 function uploadJsonMap(file, callback) {
   uploadMap.timeStart = performance.now();
@@ -1042,10 +1053,20 @@ async function parseJsonData(json) {
       await applyStyleOnLoad();
     }
 
-    // restore SVG-only view state captured by the exporter (texture, heightmap color schemes,
-    // rulers) before drawing the layers that consume it
+    // restore SVG-only view state captured by the exporter (fonts, texture, heightmap color
+    // schemes, rulers) before drawing the layers that consume it
     const viewState = json.viewState;
     if (viewState) {
+      // declare custom fonts so added labels render in the right typeface
+      if (viewState.fonts) {
+        viewState.fonts.forEach(usedFont => {
+          const exists = fonts.find(
+            f => f.family === usedFont.family && f.unicodeRange === usedFont.unicodeRange && f.variant === usedFont.variant
+          );
+          if (!exists) fonts.push(usedFont);
+          declareFont(usedFont);
+        });
+      }
       if (viewState.texture) {
         texture.attr("data-href", viewState.texture);
         if (window.updateTextureSelectValue) updateTextureSelectValue(viewState.texture);
@@ -1070,11 +1091,38 @@ async function parseJsonData(json) {
     if (rulers?.data?.length) rulers.draw();
     if (layerIsOn("toggleGrid")) drawGrid();
 
-    // reapply custom burg label positions after the labels have been drawn
-    if (viewState?.burgLabels) {
-      for (const id in viewState.burgLabels) {
-        const labelEl = document.getElementById(`burgLabel${id}`);
-        if (labelEl) labelEl.setAttribute("transform", viewState.burgLabels[id]);
+    // restore manually added labels (free-text labels are SVG-only): reinject their curve paths
+    // into the defs first, then their label groups, then reapply burg/state label drag positions
+    if (viewState) {
+      if (viewState.textPaths?.length) {
+        const textPathsGroup = document.getElementById("textPaths");
+        if (textPathsGroup) {
+          for (const html of viewState.textPaths) {
+            const node = parseSvgFragment(html);
+            if (node) textPathsGroup.appendChild(document.importNode(node, true));
+          }
+        }
+      }
+
+      if (viewState.labelGroups?.length) {
+        const labelsGroup = document.getElementById("labels");
+        if (labelsGroup) {
+          for (const html of viewState.labelGroups) {
+            const node = parseSvgFragment(html);
+            if (!node?.id) continue;
+            const imported = document.importNode(node, true);
+            const existing = document.getElementById(imported.id); // replace skeleton's empty group if present
+            if (existing) existing.replaceWith(imported);
+            else labelsGroup.appendChild(imported);
+          }
+        }
+      }
+
+      if (viewState.labelTransforms) {
+        for (const id in viewState.labelTransforms) {
+          const labelEl = document.getElementById(id);
+          if (labelEl) labelEl.setAttribute("transform", viewState.labelTransforms[id]);
+        }
       }
     }
   }

--- a/public/modules/io/load.js
+++ b/public/modules/io/load.js
@@ -1042,12 +1042,41 @@ async function parseJsonData(json) {
       await applyStyleOnLoad();
     }
 
+    // restore SVG-only view state captured by the exporter (texture, heightmap color schemes,
+    // rulers) before drawing the layers that consume it
+    const viewState = json.viewState;
+    if (viewState) {
+      if (viewState.texture) {
+        texture.attr("data-href", viewState.texture);
+        if (window.updateTextureSelectValue) updateTextureSelectValue(viewState.texture);
+      }
+      if (viewState.oceanScheme) {
+        if (!(viewState.oceanScheme in heightmapColorSchemes)) addCustomColorScheme(viewState.oceanScheme);
+        terrs.select("#oceanHeights").attr("scheme", viewState.oceanScheme);
+      }
+      if (viewState.landScheme) {
+        if (!(viewState.landScheme in heightmapColorSchemes)) addCustomColorScheme(viewState.landScheme);
+        terrs.select("#landHeights").attr("scheme", viewState.landScheme);
+      }
+    }
+
+    // always reset rulers (clears any left over from a previously-loaded map), then restore saved ones
+    rulers.fromString(viewState?.rulers || "");
+
     OceanLayers(); // coastal depth bands — generated, not stored in the export
     Ice.generate(); // ice is not included in the export; regenerate it from temperature/height
     applyLayersPreset();
     drawLayers();
-    if (rulers && layerIsOn("toggleRulers")) rulers.draw();
+    if (rulers?.data?.length) rulers.draw();
     if (layerIsOn("toggleGrid")) drawGrid();
+
+    // reapply custom burg label positions after the labels have been drawn
+    if (viewState?.burgLabels) {
+      for (const id in viewState.burgLabels) {
+        const labelEl = document.getElementById(`burgLabel${id}`);
+        if (labelEl) labelEl.setAttribute("transform", viewState.burgLabels[id]);
+      }
+    }
   }
 
   {

--- a/public/modules/ui/options.js
+++ b/public/modules/ui/options.js
@@ -878,6 +878,15 @@ ensureEl("mapToLoad").addEventListener("change", function () {
   uploadMap(fileToLoad);
 });
 
+// load map from a Full JSON export
+ensureEl("jsonToLoad").addEventListener("change", function () {
+  const fileToLoad = this.files[0];
+  this.value = "";
+  if (!fileToLoad) return;
+  closeDialogs();
+  uploadJsonMap(fileToLoad);
+});
+
 function openExportToPngTiles() {
   ensureEl("tileStatus").innerHTML = "";
   closeDialogs();

--- a/src/index.html
+++ b/src/index.html
@@ -6258,6 +6258,12 @@
             URL
           </button>
           <button onclick="quickLoad()" data-tip="Load map from browser storage (if saved before)">storage</button>
+          <button
+            onclick="jsonToLoad.click()"
+            data-tip="Load a map from a Full JSON export (Exporter > Save as JSON > Full)"
+          >
+            JSON
+          </button>
         </div>
 
         <p>Click on <i>storage</i> to open the last saved map.</p>
@@ -6371,6 +6377,7 @@
 
     <div id="fileInputs" style="display: none">
       <input type="file" accept=".map,.gz" id="mapToLoad" />
+      <input type="file" accept=".json" id="jsonToLoad" />
       <input type="file" accept=".txt,.csv" id="burgsListToLoad" />
       <input type="file" accept=".txt" id="legendsToLoad" />
       <input type="file" accept="image/*" id="imageToLoad" />


### PR DESCRIPTION
## Summary

FMG can already export a map as JSON (Exporter → Save as JSON → **Full**), but there has been no way to load one back. This adds a JSON importer so a Full export can be opened as a map, complementing the `.map` loader. A **JSON** button is added to the Load dialog; Minimal/PackCells/GridCells exports are rejected with a message.

## Why it is not just "reuse the .map loader"

A `.map` file embeds the rendered SVG and only stores grid *points* (the Voronoi graph is rebuilt on load). A JSON Full export is different in three ways, each handled explicitly:

- **No serialized SVG.** The importer resets to a clean SVG skeleton (captured once at startup) and renders every layer from data via `drawLayers`, plus `OceanLayers()` and a regenerated ice layer (ice is not part of the export).
- **Geometry is fully serialized as arrays of objects.** Rather than regenerate the Voronoi graph (which drifts — `addLakesInDeepDepressions`/`openNearSeaLakes` mutate the grid *after* markup, so a re-run produced a different cell count), the importer **deserializes the stored grid/pack geometry directly**. This is deterministic and version-independent.
- **A couple of fields aren't in the export.** `pack.cells.b` is derived from the geometry the same way the Voronoi builder does it; grid features are regenerated via `markupGrid` (the export currently stores `pack.features` under `grid.features`).

It also applies the map's **own saved style preset** (without persisting it to `localStorage`, so the user's default style is untouched) and restores the **Options panel** (canvas size, cell density, and the generation-request sliders).

## Export change

`getSettings()` in the JSON exporter gains a `generationSettings` block (heightmap template, cultures, cultures set, states number, provinces ratio, size variety, growth rate, manors, religions number) so the Options panel round-trips on re-import. Older exports without it load fine (the importer restores what is present).

## Refactor

The SVG element re-selection block in `parseLoadedData` is extracted into a shared `reselectSvgElements()` helper used by both loaders. The `.map` path is unchanged in behavior.

## Testing

Verified in a browser against several Full exports and a `.map` file:

- Full export loads with correct cell/burg/state/route counts; all layers render (coastline, regions, labels, rivers, routes, ocean depth layers, ice); no console errors.
- Saved style preset is applied (e.g. `ancient` parchment look) without changing the local default.
- Options panel reflects the loaded map (canvas size, cell density, and `generationSettings` when present).
- The existing `.map` loader still works after the `reselectSvgElements()` extraction.

## Possible follow-ups (not in this PR)

- Mirror `generationSettings` into the `.map` save/load path for parity.
- Have the exporter store the real `grid.features` (separate from `pack.features`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)