### PR TITLE
Paginate burgs, states, cultures, religions, rivers & routes editors

### DIFF
--- a/src/components/dialog/sorting.test.ts
+++ b/src/components/dialog/sorting.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { sortData } from "./sorting";
+
+const rows = () => [
+  { name: "Bree", pop: 300 },
+  { name: "Anor", pop: 1000 },
+  { name: "Cair", pop: 50 }
+];
+
+describe("sortData", () => {
+  it("sorts alphabetically ascending and descending", () => {
+    const accessors = { name: (r: { name: string }) => r.name };
+    expect(sortData(rows(), { sortby: "name", alphabetically: true, direction: 1 }, accessors).map(r => r.name)) //
+      .toEqual(["Anor", "Bree", "Cair"]);
+    expect(sortData(rows(), { sortby: "name", alphabetically: true, direction: -1 }, accessors).map(r => r.name)) //
+      .toEqual(["Cair", "Bree", "Anor"]);
+  });
+
+  it("sorts numerically", () => {
+    const accessors = { pop: (r: { pop: number }) => r.pop };
+    expect(sortData(rows(), { sortby: "pop", alphabetically: false, direction: 1 }, accessors).map(r => r.pop)) //
+      .toEqual([50, 300, 1000]);
+  });
+
+  it("returns data untouched for an unknown sort key", () => {
+    const data = rows();
+    expect(sortData(data, { sortby: "nope", alphabetically: true, direction: 1 }, {})).toBe(data);
+  });
+});

--- a/src/components/dialog/sorting.ts
+++ b/src/components/dialog/sorting.ts
@@ -51,3 +51,42 @@ export function applySorting(headers: HTMLElement): void {
       list.appendChild(line);
     });
 }
+
+export type SortState = { sortby: string; alphabetically: boolean; direction: -1 | 1 };
+export type SortAccessors<T> = Record<string, (item: T) => string | number>;
+
+export function getActiveSort(headers: HTMLElement): SortState | null {
+  const header = headers.querySelector<HTMLElement>("div[class*='icon-sort']");
+  if (!header) return null;
+  return {
+    sortby: header.dataset.sortby as string,
+    alphabetically: header.classList.contains("alphabetically"),
+    direction: header.className.includes("-down") ? -1 : 1
+  };
+}
+
+export function sortData<T>(data: T[], sort: SortState, accessors: SortAccessors<T>): T[] {
+  const get = accessors[sort.sortby];
+  if (!get) return data;
+  return data.sort((a, b) => {
+    const aValue = get(a);
+    const bValue = get(b);
+    if (sort.alphabetically) {
+      const aString = String(aValue);
+      const bString = String(bValue);
+      return (aString > bString ? 1 : aString < bString ? -1 : 0) * sort.direction;
+    }
+    return (Number(aValue) - Number(bValue)) * sort.direction;
+  });
+}
+
+export function sortDataByActiveHeader<T>(headers: HTMLElement, data: T[], accessors: SortAccessors<T>): T[] {
+  const sort = getActiveSort(headers);
+  return sort ? sortData(data, sort, accessors) : data;
+}
+
+export function bindEditorSortReset(headers: HTMLElement, onSort: () => void): void {
+  for (const el of Array.from(headers.querySelectorAll<HTMLElement>(".sortable"))) {
+    el.addEventListener("click", () => onSort());
+  }
+}

--- a/src/components/dialog/table.test.ts
+++ b/src/components/dialog/table.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { initEditorTable } from "./table";
+
+const items = (n: number) => Array.from({ length: n }, (_, i) => i + 1);
+
+describe("initEditorTable", () => {
+  it("slices the first page and reports counts", () => {
+    const onUpdate = vi.fn();
+    const table = initEditorTable({ getData: () => items(250), onUpdate, pageSize: 100 });
+    table.refresh();
+    const view = onUpdate.mock.calls[0][0];
+    expect(view.rows).toHaveLength(100);
+    expect(view.rows[0]).toBe(1);
+    expect(view).toMatchObject({ page: 1, totalPages: 3, total: 250 });
+    expect(view.all).toHaveLength(250);
+  });
+
+  it("goto clamps to the valid page range", () => {
+    const onUpdate = vi.fn();
+    const table = initEditorTable({ getData: () => items(250), onUpdate, pageSize: 100 });
+    table.goto(99);
+    expect(table.view().page).toBe(3);
+    expect(table.view().rows).toHaveLength(50);
+    table.goto(0);
+    expect(table.view().page).toBe(1);
+  });
+
+  it("keeps the clamped page when the data shrinks on refresh", () => {
+    let data = items(250);
+    const table = initEditorTable({ getData: () => data, onUpdate: () => {}, pageSize: 100 });
+    table.goto(3);
+    data = items(120);
+    table.refresh();
+    expect(table.view().page).toBe(2);
+  });
+
+  it("reset returns to page 1", () => {
+    const table = initEditorTable({ getData: () => items(250), onUpdate: () => {}, pageSize: 100 });
+    table.goto(3);
+    table.reset();
+    expect(table.view().page).toBe(1);
+  });
+
+  it("renders a single page for small datasets", () => {
+    const table = initEditorTable({ getData: () => items(5), onUpdate: () => {} });
+    table.refresh();
+    expect(table.view()).toMatchObject({ page: 1, totalPages: 1, total: 5 });
+  });
+});

--- a/src/components/dialog/table.ts
+++ b/src/components/dialog/table.ts
@@ -1,0 +1,78 @@
+export const EDITOR_PAGE_SIZE = 100;
+
+export type TableView<T> = { rows: T[]; all: T[]; page: number; totalPages: number; total: number };
+
+export type EditorTable<T> = {
+  view: () => TableView<T>;
+  goto: (page: number) => void;
+  refresh: () => void;
+  reset: () => void;
+};
+
+export function initEditorTable<T>(options: {
+  getData: () => T[];
+  onUpdate: (view: TableView<T>) => void;
+  pageSize?: number;
+}): EditorTable<T> {
+  const { getData, onUpdate, pageSize = EDITOR_PAGE_SIZE } = options;
+  let page = 1;
+  let current: TableView<T> = { rows: [], all: [], page: 1, totalPages: 1, total: 0 };
+
+  const refresh = () => {
+    const all = getData();
+    const total = all.length;
+    const totalPages = Math.max(1, Math.ceil(total / pageSize));
+    page = Math.min(Math.max(1, page), totalPages);
+    const start = (page - 1) * pageSize;
+    current = { rows: all.slice(start, start + pageSize), all, page, totalPages, total };
+    onUpdate(current);
+  };
+
+  return {
+    view: () => current,
+    goto: (p: number) => {
+      page = p;
+      refresh();
+    },
+    refresh,
+    reset: () => {
+      page = 1;
+      refresh();
+    }
+  };
+}
+
+export function renderEditorPagination(
+  footer: HTMLElement,
+  view: { page: number; totalPages: number },
+  onGoto: (page: number) => void
+): void {
+  let nav = footer.querySelector<HTMLElement>(":scope > .editorPagination");
+  if (!nav) {
+    // width:0 + min-width:100% fills fit-content dialog footers without widening them
+    footer.style.display = "flex";
+    footer.style.flexWrap = "wrap";
+    footer.style.alignItems = "center";
+    footer.style.width = "0";
+    footer.style.minWidth = "100%";
+    nav = document.createElement("div");
+    nav.className = "editorPagination";
+    nav.style.cssText = "margin-left: auto; display: inline-flex; gap: 0.3em; align-items: center;";
+    footer.appendChild(nav);
+  }
+  if (view.totalPages <= 1) {
+    nav.style.display = "none";
+    nav.innerHTML = "";
+    return;
+  }
+  nav.style.display = "inline-flex";
+  nav.innerHTML = /* html */ `
+    <button class="icon-left-open editorPagePrev" data-tip="Previous page" style="padding: 0 4px;" ${view.page <= 1 ? "disabled" : ""}></button>
+    <span>Page&nbsp;<input class="editorPageInput" type="number" min="1" max="${view.totalPages}" value="${view.page}" style="width: 3.5em" data-tip="Jump to page" />&nbsp;of&nbsp;${view.totalPages}</span>
+    <button class="icon-right-open editorPageNext" data-tip="Next page" style="padding: 0 4px;" ${view.page >= view.totalPages ? "disabled" : ""}></button>`;
+  nav.querySelector<HTMLElement>(".editorPagePrev")?.addEventListener("click", () => onGoto(view.page - 1));
+  nav.querySelector<HTMLElement>(".editorPageNext")?.addEventListener("click", () => onGoto(view.page + 1));
+  nav.querySelector<HTMLInputElement>(".editorPageInput")?.addEventListener("change", event => {
+    onGoto(Number((event.target as HTMLInputElement).value));
+  });
+}

--- a/src/controllers/burgs-overview.ts
+++ b/src/controllers/burgs-overview.ts
@@ -1,14 +1,37 @@
 import { pack as packLayout, select, stratify } from "d3";
 import { closeDialogs, confirmationDialog } from "@/components/dialog/dialog-helpers";
 import { applyLineHighlighting } from "@/components/dialog/highlighting";
-import { applySorting, applySortingByHeader } from "@/components/dialog/sorting";
+import { applySortingByHeader, bindEditorSortReset, sortDataByActiveHeader } from "@/components/dialog/sorting";
+import { initEditorTable, renderEditorPagination, type TableView } from "@/components/dialog/table";
 import { tip } from "@/components/tooltips";
 import { Controllers } from "@/controllers";
+import type { Burg } from "@/generators/burgs-generator";
 import { drawBurgLabels } from "@/renderers/draw-burg-labels";
 import { downloadFile, getFileName, getHeight, getLatitude, getLongitude, uploadFile } from "@/utils";
 import { convertTemperature, ensureEl, getTemperatureLikeness, rn, si } from "../utils";
 
 type Filters = { stateId?: number | null; cultureId?: number | null };
+
+const BURGS_SORT_ACCESSORS: Record<string, (b: Burg) => string | number> = {
+  name: b => b.name || "",
+  province: b => {
+    const p = pack.cells.province[b.cell];
+    return p ? pack.provinces[p]?.name || "" : "";
+  },
+  state: b => pack.states[b.state!]?.name || "",
+  culture: b => pack.cultures[b.culture!]?.name || "",
+  group: b => b.group || "",
+  population: b => b.population! * populationRate * urbanization,
+  grossproduct: b => rn(b.product || 0, 2),
+  productpercapita: b => rn(b.population! > 0 ? (b.product || 0) / b.population! : 0, 2),
+  treasury: b => rn(b.treasury || 0, 2),
+  features: b => (b.capital && b.port ? "a-capital-port" : b.capital ? "c-capital" : b.port ? "p-port" : "z-burg")
+};
+
+const burgsTable = initEditorTable<Burg>({
+  getData: () => sortDataByActiveHeader(ensureEl("burgsHeader"), getFilteredBurgs(), BURGS_SORT_ACCESSORS),
+  onUpdate: renderBurgsPage
+});
 
 function open(filters: Filters = { stateId: null, cultureId: null }): void {
   if (customization) return;
@@ -19,7 +42,7 @@ function open(filters: Filters = { stateId: null, cultureId: null }): void {
   renderDialog();
   updateFilter(filters);
   updateLockAllIcon();
-  burgsOverviewAddLines();
+  burgsTable.reset();
 
   $("#burgsOverview").dialog({
     title: "Burgs Overview",
@@ -123,6 +146,8 @@ function renderDialog(): void {
     </div>`;
   ensureEl("dialogs").insertAdjacentHTML("beforeend", HTML);
   applySortingByHeader("burgsHeader");
+  // header is recreated on every open(), so re-register the sort-triggered page reset here too
+  bindEditorSortReset(ensureEl("burgsHeader"), burgsTable.reset);
   applyLineHighlighting("burgsOverview", ({ target, cellId }) => {
     const burgId = pack.cells.burg[cellId];
     if (burgId) return burgId;
@@ -133,9 +158,9 @@ function renderDialog(): void {
   ensureEl("burgsOverviewRefresh").addEventListener("click", refreshBurgsEditor);
   ensureEl("burgsGroupsEditorButton").addEventListener("click", () => Controllers.BurgGroupEditor.open());
   ensureEl("burgsChart").addEventListener("click", showBurgsChart);
-  ensureEl("burgsFilterState").addEventListener("change", burgsOverviewAddLines);
-  ensureEl("burgsFilterCulture").addEventListener("change", burgsOverviewAddLines);
-  ensureEl("burgsSearch").addEventListener("input", burgsOverviewAddLines);
+  ensureEl("burgsFilterState").addEventListener("change", burgsTable.reset);
+  ensureEl("burgsFilterCulture").addEventListener("change", burgsTable.reset);
+  ensureEl("burgsSearch").addEventListener("input", burgsTable.reset);
   ensureEl("regenerateBurgNames").addEventListener("click", regenerateNames);
   ensureEl("addNewBurg").addEventListener("click", () => void Controllers.BurgCreator.toggle());
   ensureEl("burgsExport").addEventListener("click", downloadBurgsData);
@@ -155,7 +180,7 @@ function closeBurgsOverview(): void {
 
 function refreshBurgsEditor(): void {
   updateFilter();
-  burgsOverviewAddLines();
+  burgsTable.reset();
 }
 
 function updateFilter(filters: { stateId?: number | null; cultureId?: number | null } = {}): void {
@@ -180,15 +205,12 @@ function updateFilter(filters: { stateId?: number | null; cultureId?: number | n
   );
 }
 
-// add line for each burg
-function burgsOverviewAddLines(): void {
-  const body = ensureEl("burgsBody");
+function getFilteredBurgs(): Burg[] {
   const searchText = ensureEl<HTMLInputElement>("burgsSearch").value.toLowerCase().trim();
   const selectedStateId = +ensureEl<HTMLSelectElement>("burgsFilterState").value;
   const selectedCultureId = +ensureEl<HTMLSelectElement>("burgsFilterCulture").value;
 
-  const validBurgs = pack.burgs.filter(b => b.i && !b.removed);
-  let filtered = validBurgs;
+  let filtered = pack.burgs.filter(b => b.i && !b.removed);
 
   if (searchText) {
     // filter by search text
@@ -209,6 +231,13 @@ function burgsOverviewAddLines(): void {
   }
   if (selectedStateId !== -1) filtered = filtered.filter(b => b.state === selectedStateId); // filtered by state
   if (selectedCultureId !== -1) filtered = filtered.filter(b => b.culture === selectedCultureId); // filtered by culture
+  return filtered;
+}
+
+// totals and footer span the full filtered set, not just the current page
+function renderBurgsPage(view: TableView<Burg>): void {
+  const body = ensureEl("burgsBody");
+  const validCount = pack.burgs.filter(b => b.i && !b.removed).length;
 
   body.innerHTML = "";
   let lines = "";
@@ -217,7 +246,7 @@ function burgsOverviewAddLines(): void {
   let totalProductPerCapita = 0;
   let totalTreasury = 0;
 
-  for (const b of filtered) {
+  for (const b of view.all) {
     const population = b.population! * populationRate * urbanization;
     const grossProduct = rn(b.product || 0, 2);
     const productPerCapita = rn(b.population! > 0 ? (b.product || 0) / b.population! : 0, 2);
@@ -226,6 +255,13 @@ function burgsOverviewAddLines(): void {
     totalProduct += grossProduct;
     totalProductPerCapita += productPerCapita;
     totalTreasury += treasury;
+  }
+
+  for (const b of view.rows) {
+    const population = b.population! * populationRate * urbanization;
+    const grossProduct = rn(b.product || 0, 2);
+    const productPerCapita = rn(b.population! > 0 ? (b.product || 0) / b.population! : 0, 2);
+    const treasury = rn(b.treasury || 0, 2);
     const features = b.capital && b.port ? "a-capital-port" : b.capital ? "c-capital" : b.port ? "p-port" : "z-burg";
     const state = pack.states[b.state!].name;
     const prov = pack.cells.province[b.cell];
@@ -274,17 +310,18 @@ function burgsOverviewAddLines(): void {
         <span data-tip="Remove burg" class="icon-trash-empty"></span>
       </div>`;
   }
-  if (!filtered.length) body.innerHTML = /* html */ `<div style="padding-block: 0.3em;">No burgs found</div>`;
+  if (!view.all.length) body.innerHTML = /* html */ `<div style="padding-block: 0.3em;">No burgs found</div>`;
   body.insertAdjacentHTML("beforeend", lines);
 
-  // update footer
-  ensureEl("burgsFooterBurgs").innerHTML = `${filtered.length} of ${validBurgs.length}`;
-  ensureEl("burgsFooterPopulation").innerHTML = filtered.length ? si(totalPopulation / filtered.length) : "0";
-  ensureEl("burgsFooterGrossProduct").innerHTML = filtered.length ? String(rn(totalProduct / filtered.length, 2)) : "0";
-  ensureEl("burgsFooterProductPerCapita").innerHTML = filtered.length
-    ? String(rn(totalProductPerCapita / filtered.length, 2))
+  ensureEl("burgsFooterBurgs").innerHTML = `${view.all.length} of ${validCount}`;
+  ensureEl("burgsFooterPopulation").innerHTML = view.all.length ? si(totalPopulation / view.all.length) : "0";
+  ensureEl("burgsFooterGrossProduct").innerHTML = view.all.length ? String(rn(totalProduct / view.all.length, 2)) : "0";
+  ensureEl("burgsFooterProductPerCapita").innerHTML = view.all.length
+    ? String(rn(totalProductPerCapita / view.all.length, 2))
     : "0";
-  ensureEl("burgsFooterTreasury").innerHTML = filtered.length ? String(rn(totalTreasury / filtered.length, 2)) : "0";
+  ensureEl("burgsFooterTreasury").innerHTML = view.all.length ? String(rn(totalTreasury / view.all.length, 2)) : "0";
+
+  renderEditorPagination(ensureEl("burgsFooter"), view, burgsTable.goto);
 
   // add listeners
   body.querySelectorAll("div.states").forEach(el => void el.addEventListener("mouseenter", ev => burgHighlightOn(ev)));
@@ -295,8 +332,6 @@ function burgsOverviewAddLines(): void {
   body
     .querySelectorAll("div > span.icon-trash-empty")
     .forEach(el => void el.addEventListener("click", triggerBurgRemove));
-
-  applySorting(ensureEl("burgsHeader"));
 }
 
 function burgHighlightOn(event: Event): void {
@@ -352,26 +387,20 @@ function triggerBurgRemove(this: HTMLElement): void {
     confirm: "Remove",
     onConfirm: () => {
       Burgs.remove(burgId);
-      burgsOverviewAddLines();
+      burgsTable.refresh();
     }
   });
 }
 
 function regenerateNames(): void {
-  ensureEl("burgsBody")
-    .querySelectorAll<HTMLElement>(":scope > div")
-    .forEach(el => {
-      const burg = +el.dataset.id!;
-      if (pack.burgs[burg].lock) return;
-
-      const culture = pack.burgs[burg].culture!;
-      const name = Names.getCulture(culture);
-
-      el.querySelector<HTMLInputElement>(".burgName")!.value = name;
-      pack.burgs[burg].name = el.dataset.name = name;
-    });
+  // regenerate across the full filtered set (all pages), not just the visible page
+  for (const b of getFilteredBurgs()) {
+    if (b.lock) continue;
+    b.name = Names.getCulture(b.culture!);
+  }
 
   if (layerIsOn("toggleLabels")) drawBurgLabels();
+  burgsTable.refresh();
 }
 
 function showBurgsChart(): void {
@@ -661,7 +690,7 @@ function importBurgNames(dataLoaded: string): void {
       pack.burgs[id].name = change[i].name;
       select("#burgLabels").select(`[data-id='${id}']`).text(change[i].name);
     }
-    burgsOverviewAddLines();
+    burgsTable.refresh();
   };
 
   confirmationDialog({
@@ -682,7 +711,7 @@ function triggerAllBurgsRemove(): void {
     confirm: "Remove",
     onConfirm: () => {
       pack.burgs.filter(b => b.i && !(b.capital || b.lock)).forEach(b => void Burgs.remove(b.i));
-      burgsOverviewAddLines();
+      burgsTable.refresh();
     }
   });
 }
@@ -695,7 +724,7 @@ function toggleLockAll(): void {
     burg.lock = !allLocked;
   });
 
-  burgsOverviewAddLines();
+  burgsTable.refresh();
   ensureEl("burgsLockAll").className = allLocked ? "icon-lock" : "icon-lock-open";
 }
 

--- a/src/controllers/cultures-editor.ts
+++ b/src/controllers/cultures-editor.ts
@@ -1,12 +1,13 @@
 import { csvParse, drag, easeSinIn, select, transition } from "d3";
 import { closeDialogs, confirmationDialog } from "@/components/dialog/dialog-helpers";
 import { applyLineHighlighting } from "@/components/dialog/highlighting";
-import { applySorting, applySortingByHeader } from "@/components/dialog/sorting";
+import { applySortingByHeader, bindEditorSortReset, sortDataByActiveHeader } from "@/components/dialog/sorting";
+import { initEditorTable, renderEditorPagination, type TableView } from "@/components/dialog/table";
 import type { FillBoxElement } from "@/components/fill-box";
 import { clearMainTip, showMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
-import { CULTURE_TYPES } from "@/generators/cultures-generator";
+import { CULTURE_TYPES, type Culture } from "@/generators/cultures-generator";
 import { drawBurgLabels } from "@/renderers/draw-burg-labels";
 import { clearLegend, drawLegend } from "@/renderers/draw-legend";
 import { moveCircle, removeCircle } from "@/renderers/overlays/brush-circle";
@@ -29,6 +30,28 @@ import {
 } from "../utils";
 
 let culturesManualHistory: string[] = [];
+// brush-selected culture during manual assignment; tracked off-DOM since the selected row may be on another page
+let selectedCultureId: number | null = null;
+
+const CULTURES_SORT_ACCESSORS: Record<string, (c: Culture) => string | number> = {
+  name: c => c.name || "",
+  type: c => c.type || "",
+  base: c => c.base,
+  cells: c => c.cells || 0,
+  expansionism: c => c.expansionism || 0,
+  area: c => c.area || 0,
+  population: c => (c.rural || 0) * populationRate + (c.urban || 0) * populationRate * urbanization,
+  emblems: c => c.shield
+};
+
+function getFilteredCultures(): Culture[] {
+  return pack.cultures.filter(c => !c.removed);
+}
+
+const culturesTable = initEditorTable<Culture>({
+  getData: () => sortDataByActiveHeader(ensureEl("culturesHeader"), getFilteredCultures(), CULTURES_SORT_ACCESSORS),
+  onUpdate: culturesEditorAddLines
+});
 
 function open(): void {
   if (customization) return;
@@ -40,7 +63,9 @@ function open(): void {
   if (layerIsOn("toggleProvinces")) toggleProvinces();
 
   renderDialog();
-  refreshCulturesEditor();
+  culturesCollectStatistics();
+  drawCultureCenters();
+  culturesTable.reset();
 
   $("#culturesEditor").dialog({
     title: "Cultures Editor",
@@ -101,6 +126,8 @@ function renderDialog(): void {
 
   ensureEl("dialogs").insertAdjacentHTML("beforeend", editorHtml);
   applySortingByHeader("culturesHeader");
+  // header is recreated on every open(), so re-register the sort-triggered page reset here too
+  bindEditorSortReset(ensureEl("culturesHeader"), culturesTable.reset);
   applyLineHighlighting("culturesEditor", ({ cellId }) => pack.cells.culture[cellId]);
 
   ensureEl("culturesEditorRefresh").on("click", refreshCulturesEditor);
@@ -122,7 +149,7 @@ function renderDialog(): void {
 
 function refreshCulturesEditor(): void {
   culturesCollectStatistics();
-  culturesEditorAddLines();
+  culturesTable.refresh();
   drawCultureCenters();
 }
 
@@ -143,7 +170,7 @@ function culturesCollectStatistics(): void {
   }
 }
 
-function culturesEditorAddLines(): void {
+function culturesEditorAddLines(view: TableView<Culture>): void {
   const unit = getAreaUnit();
   let lines = "";
   let totalArea = 0;
@@ -153,8 +180,13 @@ function culturesEditorAddLines(): void {
     ensureEl<HTMLSelectElement>("emblemShape").selectedOptions[0]?.parentElement?.getAttribute("label");
   const selectShape = emblemShapeGroup === "Diversiform";
 
-  for (const c of pack.cultures) {
-    if (c.removed) continue;
+  // totals span the full filtered set, not just the current page
+  for (const c of view.all) {
+    totalArea += getArea(c.area ?? 0);
+    totalPopulation += rn((c.rural ?? 0) * populationRate + (c.urban ?? 0) * populationRate * urbanization);
+  }
+
+  for (const c of view.rows) {
     const area = getArea(c.area ?? 0);
     const rural = (c.rural ?? 0) * populationRate;
     const urban = (c.urban ?? 0) * populationRate * urbanization;
@@ -162,8 +194,6 @@ function culturesEditorAddLines(): void {
     const populationTip = `Total population: ${si(population)}. Rural population: ${si(rural)}. Urban population: ${si(
       urban
     )}. Click to edit`;
-    totalArea += area;
-    totalPopulation += population;
 
     if (!c.i) {
       // Uncultured (neutral) line
@@ -248,6 +278,9 @@ function culturesEditorAddLines(): void {
       </div>`;
   }
   ensureEl("culturesBody").innerHTML = lines;
+  if (customization === 4 && selectedCultureId !== null) {
+    ensureEl("culturesBody").querySelector(`div[data-id='${selectedCultureId}']`)?.classList.add("selected");
+  }
 
   // update footer
   ensureEl("culturesFooterCultures").innerHTML = String(pack.cultures.filter(c => c.i && !c.removed).length);
@@ -256,6 +289,8 @@ function culturesEditorAddLines(): void {
   ensureEl("culturesFooterPopulation").innerHTML = si(totalPopulation);
   ensureEl("culturesFooterArea").dataset.area = String(totalArea);
   ensureEl("culturesFooterPopulation").dataset.population = String(totalPopulation);
+
+  renderEditorPagination(ensureEl("culturesFooter"), view, culturesTable.goto);
 
   // add listeners
   ensureEl("culturesBody")
@@ -314,7 +349,6 @@ function culturesEditorAddLines(): void {
     ensureEl("culturesBody").dataset.type = "absolute";
     togglePercentageMode();
   }
-  applySorting($culturesHeader);
   $("#culturesEditor").dialog({ width: "fit-content" });
 }
 
@@ -725,7 +759,7 @@ function togglePercentageMode(): void {
       });
   } else {
     ensureEl("culturesBody").dataset.type = "absolute";
-    culturesEditorAddLines();
+    culturesTable.refresh();
   }
 }
 
@@ -802,7 +836,11 @@ function enterCultureManualAssignent(): void {
     .call(drag<SVGElement, unknown>().on("start", dragCultureBrush))
     .on("touchmove mousemove", moveCultureBrush);
 
-  ensureEl("culturesBody").querySelector("div")?.classList.add("selected");
+  const firstLine = ensureEl("culturesBody").querySelector<HTMLElement>("div");
+  if (firstLine) {
+    firstLine.classList.add("selected");
+    selectedCultureId = +firstLine.dataset.id!;
+  }
   culturesManualHistory = [];
 }
 
@@ -811,6 +849,7 @@ function selectCultureOnLineClick(this: HTMLElement): void {
   const previous = ensureEl("culturesBody").querySelector("div.selected");
   if (previous) previous.classList.remove("selected");
   this.classList.add("selected");
+  selectedCultureId = +this.dataset.id!;
 }
 
 function selectCultureOnMapClick(this: any, event: any): void {
@@ -822,6 +861,8 @@ function selectCultureOnMapClick(this: any, event: any): void {
   const culture = assigned.size() ? +assigned.attr("data-culture") : pack.cells.culture[i!];
 
   ensureEl("culturesBody").querySelector("div.selected")?.classList.remove("selected");
+  selectedCultureId = culture;
+  // row may be on another page; the class re-applies on render if/when that page is shown
   ensureEl("culturesBody").querySelector(`div[data-id='${culture}']`)?.classList.add("selected");
 }
 
@@ -841,10 +882,10 @@ function dragCultureBrush(this: any, event: any): void {
 }
 
 function changeCultureForSelection(selection: number[]): void {
-  const temp = select("#cults").select("#temp");
-  const selected = ensureEl("culturesBody").querySelector<HTMLElement>("div.selected")!;
+  if (selectedCultureId === null) return;
 
-  const cultureNew = +selected.dataset.id!;
+  const temp = select("#cults").select("#temp");
+  const cultureNew = selectedCultureId;
   const color = pack.cultures[cultureNew].color || "#ffffff";
 
   selection.forEach(i => {
@@ -916,6 +957,7 @@ function exitCulturesManualAssignment(close?: string): void {
   clearMainTip();
   const selected = ensureEl("culturesBody").querySelector("div.selected");
   if (selected) selected.classList.remove("selected");
+  selectedCultureId = null;
 }
 
 function saveCulturesManualSnapshot(): void {
@@ -982,22 +1024,34 @@ function addCulture(this: SVGElement, event: MouseEvent): void {
   Cultures.add(center);
 
   drawCultureCenters();
-  culturesEditorAddLines();
+  culturesTable.refresh();
 }
 
 function downloadCulturesCsv(): void {
   const unit = getAreaUnit("2");
   const headers = `Id,Name,Color,Cells,Expansionism,Type,Area ${unit},Population,Namesbase,Emblems Shape,Origins`;
-  const lines = Array.from(ensureEl("culturesBody").querySelectorAll<HTMLElement>(":scope > div"));
-  const data = lines.map($line => {
-    const { id, name, color, cells, expansionism, type, area, population, emblems, base } = $line.dataset;
-    const namesbase = Names.nameBases[+base!].name;
-    const { origins } = pack.cultures[+id!];
-    const originList = (origins ?? [])
-      .filter((origin: number | null): origin is number => Boolean(origin))
-      .map((origin: number) => pack.cultures[origin].name);
+  // export the full filtered set (all pages), not just the visible page
+  const data = culturesTable.view().all.map(c => {
+    const area = getArea(c.area ?? 0);
+    const population = rn((c.rural ?? 0) * populationRate + (c.urban ?? 0) * populationRate * urbanization);
+    const namesbase = Names.nameBases[c.base].name;
+    const originList = (c.origins ?? [])
+      .filter((origin): origin is number => Boolean(origin))
+      .map(origin => pack.cultures[origin].name);
     const originText = `"${originList.join(", ")}"`;
-    return [id, name, color, cells, expansionism, type, area, population, namesbase, emblems, originText].join(",");
+    return [
+      c.i,
+      c.name,
+      c.i ? c.color || "" : "",
+      c.cells || 0,
+      c.i ? c.expansionism || 0 : "",
+      c.i ? c.type : "",
+      area,
+      population,
+      namesbase,
+      c.shield,
+      originText
+    ].join(",");
   });
   const csvData = [headers].concat(data).join("\n");
 

--- a/src/controllers/religions-editor.ts
+++ b/src/controllers/religions-editor.ts
@@ -1,10 +1,12 @@
 import { drag, easeSinIn, select, transition } from "d3";
 import { closeDialogs, confirmationDialog } from "@/components/dialog/dialog-helpers";
 import { applyLineHighlighting } from "@/components/dialog/highlighting";
-import { applySorting, applySortingByHeader } from "@/components/dialog/sorting";
+import { applySortingByHeader, bindEditorSortReset, sortDataByActiveHeader } from "@/components/dialog/sorting";
+import { initEditorTable, renderEditorPagination, type TableView } from "@/components/dialog/table";
 import { clearMainTip, showMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
+import type { Religion } from "@/generators/religions-generator";
 import { clearLegend, drawLegend } from "@/renderers/draw-legend";
 import { moveCircle, removeCircle } from "@/renderers/overlays/brush-circle";
 import { highlightElement } from "@/renderers/overlays/highlight";
@@ -23,6 +25,31 @@ import {
   si
 } from "../utils";
 
+// brush-selected religion during manual assignment; tracked off-DOM since the selected row may be on another page
+let selectedReligionId: number | null = null;
+
+const RELIGIONS_SORT_ACCESSORS: Record<string, (r: Religion) => string | number> = {
+  name: r => r.name || "",
+  type: r => r.type || "",
+  form: r => r.form || "",
+  deity: r => r.deity || "",
+  area: r => r.area || 0,
+  population: r => (r.rural || 0) * populationRate + (r.urban || 0) * populationRate * urbanization,
+  expansion: r => r.expansion || "",
+  expansionism: r => r.expansionism || 0
+};
+
+function getFilteredReligions(): Religion[] {
+  return pack.religions.filter(
+    r => !r.removed && !(r.i && !r.cells && ensureEl("religionsBody").dataset.extinct !== "show")
+  );
+}
+
+const religionsTable = initEditorTable<Religion>({
+  getData: () => sortDataByActiveHeader(ensureEl("religionsHeader"), getFilteredReligions(), RELIGIONS_SORT_ACCESSORS),
+  onUpdate: religionsEditorAddLines
+});
+
 function open(): void {
   if (customization) return;
   closeDialogs("#religionsEditor, .stable");
@@ -33,8 +60,9 @@ function open(): void {
   if (layerIsOn("toggleProvinces")) toggleProvinces();
 
   renderDialog();
-  refreshReligionsEditor();
+  religionsCollectStatistics();
   drawReligionCenters();
+  religionsTable.reset();
 
   $("#religionsEditor").dialog({
     title: "Religions Editor",
@@ -112,6 +140,8 @@ function renderDialog(): void {
 
   ensureEl("dialogs").insertAdjacentHTML("beforeend", editorHtml);
   applySortingByHeader("religionsHeader");
+  // header is recreated on every open(), so re-register the sort-triggered page reset here too
+  bindEditorSortReset(ensureEl("religionsHeader"), religionsTable.reset);
   applyLineHighlighting("religionsEditor", ({ cellId }) => pack.cells.religion[cellId]);
 
   ensureEl("religionsEditorRefresh").on("click", refreshReligionsEditor);
@@ -130,7 +160,7 @@ function renderDialog(): void {
 
 function refreshReligionsEditor(): void {
   religionsCollectStatistics();
-  religionsEditorAddLines();
+  religionsTable.refresh();
 }
 
 function religionsCollectStatistics(): void {
@@ -151,16 +181,19 @@ function religionsCollectStatistics(): void {
 }
 
 // add line for each religion
-function religionsEditorAddLines(): void {
+function religionsEditorAddLines(view: TableView<Religion>): void {
   const unit = ` ${getAreaUnit()}`;
   let lines = "";
   let totalArea = 0;
   let totalPopulation = 0;
 
-  for (const r of pack.religions) {
-    if (r.removed) continue;
-    if (r.i && !r.cells && ensureEl("religionsBody").dataset.extinct !== "show") continue; // hide extinct religions
+  // totals span the full filtered set, not just the current page
+  for (const r of view.all) {
+    totalArea += getArea(r.area ?? 0);
+    totalPopulation += rn((r.rural ?? 0) * populationRate + (r.urban ?? 0) * populationRate * urbanization);
+  }
 
+  for (const r of view.rows) {
     const area = getArea(r.area ?? 0);
     const rural = (r.rural ?? 0) * populationRate;
     const urban = (r.urban ?? 0) * populationRate * urbanization;
@@ -168,8 +201,6 @@ function religionsEditorAddLines(): void {
     const populationTip = `Believers: ${si(population)}; Rural areas: ${si(rural)}; Urban areas: ${si(
       urban
     )}. Click to change`;
-    totalArea += area;
-    totalPopulation += population;
 
     if (!r.i) {
       // No religion (neutral) line
@@ -242,6 +273,9 @@ function religionsEditorAddLines(): void {
     </div>`;
   }
   ensureEl("religionsBody").innerHTML = lines;
+  if (customization === 7 && selectedReligionId !== null) {
+    ensureEl("religionsBody").querySelector(`div[data-id='${selectedReligionId}']`)?.classList.add("selected");
+  }
 
   // update footer
   const validReligions = pack.religions.filter(r => r.i && !r.removed);
@@ -253,6 +287,8 @@ function religionsEditorAddLines(): void {
   ensureEl("religionsFooterPopulation").innerHTML = si(totalPopulation);
   ensureEl("religionsFooterArea").dataset.area = String(totalArea);
   ensureEl("religionsFooterPopulation").dataset.population = String(totalPopulation);
+
+  renderEditorPagination(ensureEl("religionsFooter"), view, religionsTable.goto);
 
   // add listeners
   ensureEl("religionsBody")
@@ -307,7 +343,6 @@ function religionsEditorAddLines(): void {
     togglePercentageMode();
   }
 
-  applySorting(ensureEl("religionsHeader"));
   $("#religionsEditor").dialog({ width: "fit-content" });
 }
 
@@ -666,7 +701,7 @@ function togglePercentageMode(): void {
       });
   } else {
     ensureEl("religionsBody").dataset.type = "absolute";
-    religionsEditorAddLines();
+    religionsTable.refresh();
   }
 }
 
@@ -709,7 +744,7 @@ async function showHierarchy(): Promise<void> {
 
 function toggleExtinct(): void {
   ensureEl("religionsBody").dataset.extinct = ensureEl("religionsBody").dataset.extinct !== "show" ? "show" : "hide";
-  religionsEditorAddLines();
+  religionsTable.reset();
   drawReligionCenters();
 }
 
@@ -743,7 +778,11 @@ function enterReligionsManualAssignent(): void {
     .call(drag<SVGElement, unknown>().on("start", dragReligionBrush))
     .on("touchmove mousemove", moveReligionBrush);
 
-  ensureEl("religionsBody").querySelector("div")?.classList.add("selected");
+  const firstLine = ensureEl("religionsBody").querySelector<HTMLElement>("div");
+  if (firstLine) {
+    firstLine.classList.add("selected");
+    selectedReligionId = +firstLine.dataset.id!;
+  }
 }
 
 function selectReligionOnLineClick(this: HTMLElement): void {
@@ -751,6 +790,7 @@ function selectReligionOnLineClick(this: HTMLElement): void {
   const prev = ensureEl("religionsBody").querySelector("div.selected");
   if (prev) prev.classList.remove("selected");
   this.classList.add("selected");
+  selectedReligionId = +this.dataset.id!;
 }
 
 function selectReligionOnMapClick(this: any, event: any): void {
@@ -762,6 +802,8 @@ function selectReligionOnMapClick(this: any, event: any): void {
   const religion = assigned.size() ? +assigned.attr("data-religion") : pack.cells.religion[i!];
 
   ensureEl("religionsBody").querySelector("div.selected")?.classList.remove("selected");
+  selectedReligionId = religion;
+  // row may be on another page; the class re-applies on render if/when that page is shown
   ensureEl("religionsBody").querySelector(`div[data-id='${religion}']`)?.classList.add("selected");
 }
 
@@ -781,9 +823,10 @@ function dragReligionBrush(this: any, event: any): void {
 
 // change religion within selection
 function changeReligionForSelection(selection: number[]): void {
+  if (selectedReligionId === null) return;
+
   const temp = select("#relig").select("#temp");
-  const selected = ensureEl("religionsBody").querySelector<HTMLElement>("div.selected")!;
-  const religionNew = +selected.dataset.id!;
+  const religionNew = selectedReligionId;
   const color = pack.religions[religionNew].color || "#ffffff";
   const preventOverwrite = (document.getElementById("religionsManuallyProtect") as HTMLInputElement | null)?.checked;
 
@@ -855,6 +898,7 @@ function exitReligionsManualAssignment(close?: string): void {
   clearMainTip();
   const $selected = ensureEl("religionsBody").querySelector("div.selected");
   if ($selected) $selected.classList.remove("selected");
+  selectedReligionId = null;
 }
 
 function enterAddReligionMode(this: HTMLElement): void {
@@ -912,16 +956,28 @@ function addReligion(this: SVGElement, event: MouseEvent): void {
 function downloadReligionsCsv(): void {
   const unit = getAreaUnit("2");
   const headers = `Id,Name,Color,Type,Form,Supreme Deity,Area ${unit},Believers,Origins,Potential,Expansionism`;
-  const lines = Array.from(ensureEl("religionsBody").querySelectorAll<HTMLElement>(":scope > div"));
-  const data = lines.map($line => {
-    const { id, name, color, type, form, deity, area, population, expansion, expansionism } = $line.dataset;
-    const deityText = `"${deity}"`;
-    const { origins } = pack.religions[+id!];
-    const originList = (origins || [])
-      .filter((origin: number) => origin)
-      .map((origin: number) => pack.religions[origin].name);
+  // export the full filtered set (all pages), not just the visible page
+  const data = religionsTable.view().all.map(r => {
+    const area = getArea(r.area ?? 0);
+    const population = rn((r.rural ?? 0) * populationRate + (r.urban ?? 0) * populationRate * urbanization);
+    const deityText = `"${r.deity || ""}"`;
+    const originList = (r.origins ?? [])
+      .filter((origin): origin is number => Boolean(origin))
+      .map(origin => pack.religions[origin].name);
     const originText = `"${originList.join(", ")}"`;
-    return [id, name, color, type, form, deityText, area, population, originText, expansion, expansionism].join(",");
+    return [
+      r.i,
+      r.name,
+      r.color ?? "",
+      r.type ?? "",
+      r.form ?? "",
+      deityText,
+      area,
+      population,
+      originText,
+      r.expansion ?? "",
+      r.i ? (r.expansionism ?? "") : ""
+    ].join(",");
   });
   const csvData = [headers].concat(data).join("\n");
 

--- a/src/controllers/rivers-overview.ts
+++ b/src/controllers/rivers-overview.ts
@@ -1,12 +1,46 @@
 import { mean, select } from "d3";
 import { closeDialogs } from "@/components/dialog/dialog-helpers";
 import { applyLineHighlighting } from "@/components/dialog/highlighting";
-import { applySorting, applySortingByHeader } from "@/components/dialog/sorting";
+import { applySortingByHeader, bindEditorSortReset, sortDataByActiveHeader } from "@/components/dialog/sorting";
+import { initEditorTable, renderEditorPagination, type TableView } from "@/components/dialog/table";
 import { Controllers } from "@/controllers";
 import type { River } from "@/generators/river-generator";
 import { highlightElement } from "@/renderers/overlays/highlight";
 import { downloadFile, getFileName } from "@/utils";
 import { destroyDialogIfExists, ensureEl, rn } from "../utils";
+
+function getRiversById(): Map<number, River> {
+  return new Map<number, River>(pack.rivers.map((river: River) => [river.i, river]));
+}
+
+function getFilteredRivers(riversById: Map<number, River>): River[] {
+  const searchText = ensureEl<HTMLInputElement>("riversSearch").value.toLowerCase().trim();
+  if (!searchText) return pack.rivers.slice();
+
+  return pack.rivers.filter((r: River) => {
+    const name = (r.name || "").toLowerCase();
+    const type = (r.type || "").toLowerCase();
+    const basin = riversById.get(r.basin);
+    const basinName = basin ? (basin.name || "").toLowerCase() : "";
+    return name.includes(searchText) || type.includes(searchText) || basinName.includes(searchText);
+  });
+}
+
+const riversTable = initEditorTable<River>({
+  getData: () => {
+    const riversById = getRiversById();
+    const filtered = getFilteredRivers(riversById);
+    return sortDataByActiveHeader(ensureEl("riversHeader"), filtered, {
+      name: (r: River) => r.name || "",
+      type: (r: River) => r.type || "",
+      discharge: (r: River) => r.discharge,
+      length: (r: River) => r.length,
+      width: (r: River) => r.width,
+      basin: (r: River) => riversById.get(r.basin)?.name || ""
+    });
+  },
+  onUpdate: renderRiversPage
+});
 
 function open(): void {
   if (customization) return;
@@ -14,7 +48,7 @@ function open(): void {
   if (!layerIsOn("toggleRivers")) toggleRivers();
 
   renderDialog();
-  riversOverviewAddLines();
+  riversTable.reset();
 
   $("#riversOverview").dialog({
     title: "Rivers Overview",
@@ -56,6 +90,8 @@ function renderDialog(): void {
   </div>`;
   ensureEl("dialogs").insertAdjacentHTML("beforeend", html);
   applySortingByHeader("riversHeader");
+  // header is recreated on every open(), so re-register the sort-triggered page reset here too
+  bindEditorSortReset(ensureEl("riversHeader"), riversTable.reset);
   applyLineHighlighting("riversOverview", ({ target, cellId }) => {
     const riverId = pack.cells.r[cellId];
     if (riverId) return riverId;
@@ -64,13 +100,13 @@ function renderDialog(): void {
   });
 
   // add listeners — dropped together with the dialog HTML on close
-  ensureEl("riversOverviewRefresh").on("click", riversOverviewAddLines);
+  ensureEl("riversOverviewRefresh").on("click", riversTable.refresh);
   ensureEl("addNewRiver").on("click", () => void Controllers.RiverAutoCreator.toggle());
   ensureEl("riverCreateNew").on("click", createNewRiver);
   ensureEl("riversBasinHighlight").on("click", toggleBasinsHightlight);
   ensureEl("riversExport").on("click", downloadRiversData);
   ensureEl("riversRemoveAll").on("click", triggerAllRiversRemove);
-  ensureEl("riversSearch").on("input", riversOverviewAddLines);
+  ensureEl("riversSearch").on("input", riversTable.reset);
 }
 
 function closeRiversOverview(): void {
@@ -81,29 +117,15 @@ function createNewRiver(): void {
   void Controllers.RiverCreator.open();
 }
 
-// add line for each river
-function riversOverviewAddLines(): void {
+// totals span the full filtered set, not just the current page
+function renderRiversPage(view: TableView<River>): void {
   const body = ensureEl("riversBody");
   body.innerHTML = "";
   let lines = "";
   const unit = distanceUnitInput.value;
+  const riversById = getRiversById();
 
-  // Precompute a lookup map from river id to river for efficient basin lookup
-  const riversById = new Map<number, River>(pack.rivers.map((river: River) => [river.i, river]));
-
-  let filteredRivers: River[] = pack.rivers;
-  const searchText = ensureEl<HTMLInputElement>("riversSearch").value.toLowerCase().trim();
-  if (searchText) {
-    filteredRivers = filteredRivers.filter(r => {
-      const name = (r.name || "").toLowerCase();
-      const type = (r.type || "").toLowerCase();
-      const basin = riversById.get(r.basin);
-      const basinName = basin ? (basin.name || "").toLowerCase() : "";
-      return name.includes(searchText) || type.includes(searchText) || basinName.includes(searchText);
-    });
-  }
-
-  for (const r of filteredRivers) {
+  for (const r of view.rows) {
     const discharge = `${r.discharge} m³/s`;
     const length = `${rn(r.length * distanceScale)} ${unit}`;
     const width = `${rn(r.width * distanceScale, 3)} ${unit}`;
@@ -132,13 +154,12 @@ function riversOverviewAddLines(): void {
   }
   body.insertAdjacentHTML("beforeend", lines);
 
-  // update footer
-  ensureEl("riversFooterNumber").innerHTML = `${filteredRivers.length} of ${pack.rivers.length}`;
-  const averageDischarge = rn(mean(filteredRivers.map(r => r.discharge))!) || 0;
+  ensureEl("riversFooterNumber").innerHTML = `${view.all.length} of ${pack.rivers.length}`;
+  const averageDischarge = rn(mean(view.all.map(r => r.discharge))!) || 0;
   ensureEl("riversFooterDischarge").innerHTML = `${averageDischarge} m³/s`;
-  const averageLength = rn(mean(filteredRivers.map(r => r.length))!) || 0;
+  const averageLength = rn(mean(view.all.map(r => r.length))!) || 0;
   ensureEl("riversFooterLength").innerHTML = `${averageLength * distanceScale} ${unit}`;
-  const averageWidth = rn(mean(filteredRivers.map(r => r.width))!, 3) || 0;
+  const averageWidth = rn(mean(view.all.map(r => r.width))!, 3) || 0;
   ensureEl("riversFooterWidth").innerHTML = `${rn(averageWidth * distanceScale, 3)} ${unit}`;
 
   // add listeners
@@ -148,7 +169,7 @@ function riversOverviewAddLines(): void {
   body.querySelectorAll("div > span.icon-pencil").forEach(el => void el.on("click", openRiverEditor));
   body.querySelectorAll("div > span.icon-trash-empty").forEach(el => void el.on("click", triggerRiverRemove));
 
-  applySorting(ensureEl("riversHeader"));
+  renderEditorPagination(ensureEl("riversFooter"), view, riversTable.goto);
 }
 
 function riverHighlightOn(event: Event): void {
@@ -202,15 +223,17 @@ function toggleBasinsHightlight(): void {
 function downloadRiversData(): void {
   let data = "Id,River,Type,Discharge,Length,Width,Basin\n"; // headers
 
-  ensureEl("riversBody")
-    .querySelectorAll<HTMLElement>(":scope > div")
-    .forEach(el => {
-      const d = el.dataset;
-      const discharge = `${d.discharge} m³/s`;
-      const length = `${rn(+d.length! * distanceScale)} ${distanceUnitInput.value}`;
-      const width = `${rn(+d.width! * distanceScale, 3)} ${distanceUnitInput.value}`;
-      data += `${[d.id, d.name, d.type, discharge, length, width, d.basin].join(",")}\n`;
-    });
+  // export the full sorted+filtered set (all pages), not the DOM (which only holds the current page)
+  const riversById = getRiversById();
+  const exported = riversTable.view().all;
+
+  exported.forEach((r: River) => {
+    const discharge = `${r.discharge} m³/s`;
+    const length = `${rn(r.length * distanceScale)} ${distanceUnitInput.value}`;
+    const width = `${rn(r.width * distanceScale, 3)} ${distanceUnitInput.value}`;
+    const basin = riversById.get(r.basin)?.name || "";
+    data += `${[r.i, r.name, r.type, discharge, length, width, basin].join(",")}\n`;
+  });
 
   const name = `${getFileName("Rivers")}.csv`;
   downloadFile(data, name);
@@ -232,7 +255,7 @@ function triggerRiverRemove(this: HTMLElement): void {
     buttons: {
       Remove: function (this: any) {
         Rivers.remove(river);
-        riversOverviewAddLines();
+        riversTable.refresh();
         $(this).dialog("close");
       },
       Cancel: function (this: any) {
@@ -263,7 +286,7 @@ function removeAllRivers(): void {
   pack.rivers = [];
   pack.cells.r = new Uint16Array(pack.cells.i.length);
   select("#rivers").selectAll("*").remove();
-  riversOverviewAddLines();
+  riversTable.refresh();
 }
 
 export const RiversOverview = { open };

--- a/src/controllers/routes-overview.ts
+++ b/src/controllers/routes-overview.ts
@@ -1,6 +1,7 @@
 import { mean, select } from "d3";
 import { closeDialogs, confirmationDialog } from "@/components/dialog/dialog-helpers";
-import { applySorting, applySortingByHeader } from "@/components/dialog/sorting";
+import { applySortingByHeader, bindEditorSortReset, sortDataByActiveHeader } from "@/components/dialog/sorting";
+import { initEditorTable, renderEditorPagination, type TableView } from "@/components/dialog/table";
 import { tip } from "@/components/tooltips";
 import { Controllers } from "@/controllers";
 import type { Route } from "@/generators/routes-generator";
@@ -8,13 +9,42 @@ import { highlightElement } from "@/renderers/overlays/highlight";
 import { downloadFile, getFileName } from "@/utils";
 import { destroyDialogIfExists, ensureEl, rn } from "../utils";
 
+const ROUTES_SORT_ACCESSORS = {
+  name: (route: Route) => route.name || "",
+  group: (route: Route) => route.group || "",
+  length: (route: Route) => route.length || 0
+};
+
+function getFilteredRoutes(): Route[] {
+  const searchText = ensureEl<HTMLInputElement>("routesSearch").value.toLowerCase().trim();
+  const routes = pack.routes.filter((route: Route) => Boolean(route.points) && route.points.length >= 2);
+
+  for (const route of routes) {
+    route.name = route.name || Routes.generateName(route);
+    route.length = route.length || Routes.getLength(route.i);
+  }
+
+  if (!searchText) return routes;
+
+  return routes.filter((route: Route) => {
+    const name = (route.name || "").toLowerCase();
+    const group = (route.group || "").toLowerCase();
+    return name.includes(searchText) || group.includes(searchText);
+  });
+}
+
+const routesTable = initEditorTable<Route>({
+  getData: () => sortDataByActiveHeader(ensureEl("routesHeader"), getFilteredRoutes(), ROUTES_SORT_ACCESSORS),
+  onUpdate: renderRoutesPage
+});
+
 function open(): void {
   if (customization) return;
   closeDialogs("#routesOverview, .stable");
   if (!layerIsOn("toggleRoutes")) toggleRoutes();
 
   renderDialog();
-  routesOverviewAddLines();
+  routesTable.reset();
 
   $("#routesOverview").dialog({
     title: "Routes Overview",
@@ -50,14 +80,16 @@ function renderDialog(): void {
   </div>`;
   ensureEl("dialogs").insertAdjacentHTML("beforeend", html);
   applySortingByHeader("routesHeader");
+  // header is recreated on every open(), so re-register the sort-triggered page reset here too
+  bindEditorSortReset(ensureEl("routesHeader"), routesTable.reset);
 
   // add listeners — dropped together with the dialog HTML on close
-  ensureEl("routesOverviewRefresh").on("click", routesOverviewAddLines);
+  ensureEl("routesOverviewRefresh").on("click", routesTable.refresh);
   ensureEl("routesCreateNew").on("click", createNewRoute);
   ensureEl("routesExport").on("click", downloadRoutesData);
   ensureEl("routesLockAll").on("click", toggleLockAll);
   ensureEl("routesRemoveAll").on("click", triggerAllRoutesRemove);
-  ensureEl("routesSearch").on("input", routesOverviewAddLines);
+  ensureEl("routesSearch").on("input", routesTable.reset);
 }
 
 function closeRoutesOverview(): void {
@@ -68,28 +100,14 @@ function createNewRoute(): void {
   Controllers.RouteCreator.open();
 }
 
-// add line for each route
-function routesOverviewAddLines(): void {
+// totals span the full filtered set, not just the current page
+function renderRoutesPage(view: TableView<Route>): void {
   const body = ensureEl("routesBody");
   body.innerHTML = "";
   let lines = "";
 
-  let filteredRoutes: Route[] = pack.routes;
-
-  const searchText = ensureEl<HTMLInputElement>("routesSearch").value.toLowerCase().trim();
-  if (searchText) {
-    filteredRoutes = filteredRoutes.filter(route => {
-      const name = (route.name || "").toLowerCase();
-      const group = (route.group || "").toLowerCase();
-      return name.includes(searchText) || group.includes(searchText);
-    });
-  }
-
-  for (const route of filteredRoutes) {
-    if (!route.points || route.points.length < 2) continue;
-    route.name = route.name || Routes.generateName(route);
-    route.length = route.length || Routes.getLength(route.i);
-    const length = `${rn(route.length * distanceScale)} ${distanceUnitInput.value}`;
+  for (const route of view.rows) {
+    const length = `${rn((route.length || 0) * distanceScale)} ${distanceUnitInput.value}`;
 
     lines += /* html */ `<div
         class="states"
@@ -111,9 +129,8 @@ function routesOverviewAddLines(): void {
   }
   body.insertAdjacentHTML("beforeend", lines);
 
-  // update footer
-  ensureEl("routesFooterNumber").innerHTML = `${filteredRoutes.length} of ${pack.routes.length}`;
-  const averageLength = rn(mean(filteredRoutes.map(r => r.length)) || 0) || 0;
+  ensureEl("routesFooterNumber").innerHTML = `${view.all.length} of ${pack.routes.length}`;
+  const averageLength = rn(mean(view.all.map(r => r.length)) || 0) || 0;
   ensureEl("routesFooterLength").innerHTML = `${averageLength * distanceScale} ${distanceUnitInput.value}`;
 
   // add listeners
@@ -124,7 +141,7 @@ function routesOverviewAddLines(): void {
   body.querySelectorAll("div > span.locks").forEach(el => void el.on("click", toggleLockStatus));
   body.querySelectorAll("div > span.icon-trash-empty").forEach(el => void el.on("click", triggerRouteRemove));
 
-  applySorting(ensureEl("routesHeader"));
+  renderEditorPagination(ensureEl("routesFooter"), view, routesTable.goto);
 }
 
 function routeHighlightOn(event: Event): void {
@@ -155,13 +172,12 @@ function zoomToRoute(this: HTMLElement): void {
 function downloadRoutesData(): void {
   let data = "Id,Route,Group,Length\n"; // headers
 
-  ensureEl("routesBody")
-    .querySelectorAll<HTMLElement>(":scope > div")
-    .forEach(el => {
-      const d = el.dataset;
-      const length = `${rn(+d.length! * distanceScale)} ${distanceUnitInput.value}`;
-      data += `${[d.id, d.name, d.group, length].join(",")}\n`;
-    });
+  // export the full sorted+filtered set (all pages), not the DOM (which only holds the current page)
+  const exported = routesTable.view().all;
+  exported.forEach((route: Route) => {
+    const length = `${rn((route.length || 0) * distanceScale)} ${distanceUnitInput.value}`;
+    data += `${[route.i, route.name, route.group, length].join(",")}\n`;
+  });
 
   const name = `${getFileName("Routes")}.csv`;
   downloadFile(data, name);
@@ -196,7 +212,7 @@ function toggleLockAll(): void {
     route.lock = !allLocked;
   });
 
-  routesOverviewAddLines();
+  routesTable.refresh();
   ensureEl("routesLockAll").className = allLocked ? "icon-lock" : "icon-lock-open";
 }
 
@@ -209,7 +225,7 @@ function triggerRouteRemove(this: HTMLElement): void {
     onConfirm: () => {
       const route = pack.routes.find((r: Route) => r.i === routeId) as Route;
       Routes.remove(route);
-      routesOverviewAddLines();
+      routesTable.refresh();
     }
   });
 }
@@ -250,7 +266,7 @@ function triggerAllRoutesRemove(): void {
           Routes.remove(route);
         }
         pack.cells.routes = Routes.buildLinks(pack.routes);
-        routesOverviewAddLines();
+        routesTable.refresh();
         $(this).dialog("close");
       },
       Cancel: function (this: any) {

--- a/src/controllers/states-editor.ts
+++ b/src/controllers/states-editor.ts
@@ -1,7 +1,8 @@
 import { drag, interpolateString, max, pack as packLayout, select, stratify } from "d3";
 import { closeDialogs, confirmationDialog } from "@/components/dialog/dialog-helpers";
 import { applyLineHighlighting } from "@/components/dialog/highlighting";
-import { applySorting, applySortingByHeader } from "@/components/dialog/sorting";
+import { applySortingByHeader, bindEditorSortReset, sortDataByActiveHeader } from "@/components/dialog/sorting";
+import { initEditorTable, renderEditorPagination, type TableView } from "@/components/dialog/table";
 import type { FillBoxElement } from "@/components/fill-box";
 import { clearMainTip, showMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
@@ -37,6 +38,29 @@ import {
 
 let statesManualHistory: string[] = [];
 
+const STATES_SORT_ACCESSORS: Record<string, (s: State) => string | number> = {
+  name: s => s.name || "",
+  form: s => (s.i ? s.formName || "" : ""),
+  capital: s => (s.i ? pack.burgs[s.capital]?.name || "" : ""),
+  culture: s => (s.i ? pack.cultures[s.culture]?.name || "" : ""),
+  burgs: s => s.burgs || 0,
+  cells: s => s.cells || 0,
+  area: s => getArea(s.area || 0),
+  population: s => rn((s.rural || 0) * populationRate + (s.urban || 0) * populationRate * urbanization),
+  treasury: s => s.treasury || 0,
+  type: s => (s.i ? s.type || "" : ""),
+  expansionism: s => (s.i ? s.expansionism || 0 : 0)
+};
+
+function getFilteredStatesData(): State[] {
+  return pack.states.filter(s => !s.removed);
+}
+
+const statesTable = initEditorTable<State>({
+  getData: () => sortDataByActiveHeader(ensureEl("statesHeader"), getFilteredStatesData(), STATES_SORT_ACCESSORS),
+  onUpdate: renderStatesPage
+});
+
 function open(): void {
   if (customization) return;
 
@@ -48,7 +72,8 @@ function open(): void {
   if (layerIsOn("toggleReligions")) toggleReligions();
 
   renderDialog();
-  refreshStatesEditor();
+  States.collectStatistics();
+  statesTable.reset();
 
   $("#statesEditor").dialog({
     title: "States Editor",
@@ -130,6 +155,7 @@ function renderDialog(): void {
   </div>`;
   ensureEl("dialogs").insertAdjacentHTML("beforeend", editorHtml);
   applySortingByHeader("statesHeader");
+  bindEditorSortReset(ensureEl("statesHeader"), statesTable.reset);
   applyLineHighlighting("statesEditor", ({ cellId }) =>
     pack.cells.h[cellId] < 20 ? undefined : pack.cells.state[cellId]
   );
@@ -201,20 +227,27 @@ function closeStatesEditor(): void {
 
 function refreshStatesEditor(): void {
   States.collectStatistics();
-  statesEditorAddLines();
+  statesTable.refresh();
 }
 
-// add line for each state
-function statesEditorAddLines(): void {
+// totals and footer span the full filtered set, not just the current page
+function renderStatesPage(view: TableView<State>): void {
   const unit = getAreaUnit();
   const hidden = ensureEl("statesRegenerateButtons").style.display === "block" ? "" : "hidden"; // toggle regenerate columns
-  let lines = "";
+
   let totalArea = 0;
   let totalPopulation = 0;
   let totalBurgs = 0;
+  for (const s of view.all) {
+    totalArea += getArea(s.area || 0);
+    const rural = (s.rural || 0) * populationRate;
+    const urban = (s.urban || 0) * populationRate * urbanization;
+    totalPopulation += rn(rural + urban);
+    totalBurgs += s.burgs || 0;
+  }
 
-  for (const s of pack.states) {
-    if (s.removed) continue;
+  let lines = "";
+  for (const s of view.rows) {
     const area = getArea(s.area || 0);
     const rural = (s.rural || 0) * populationRate;
     const urban = (s.urban || 0) * populationRate * urbanization;
@@ -222,9 +255,6 @@ function statesEditorAddLines(): void {
     const populationTip = `Total population: ${si(population)}; Rural population: ${si(rural)}; Urban population: ${si(
       urban
     )}. Click to change`;
-    totalArea += area;
-    totalPopulation += population;
-    totalBurgs += s.burgs || 0;
     const focused = select("#deftemp").select(`#fog #focusState${s.i}`).size();
     const treasuryTip = `Current treasury: 🟡 ${si(s.treasury)}. Sales Tax: ${rn((s.salesTax || 0) * 100, 1)}%. Poll Tax: ${rn((s.pollTax || 0) * 100, 1)}%. Click to view and edit taxes`;
 
@@ -335,6 +365,8 @@ function statesEditorAddLines(): void {
   ensureEl("statesFooterPopulation").innerHTML = si(totalPopulation);
   ensureEl("statesFooterPopulation").dataset.population = String(totalPopulation);
 
+  renderEditorPagination(ensureEl("statesFooter"), view, statesTable.goto);
+
   // add listeners
   ensureEl("statesBodySection")
     .querySelectorAll(":scope > div")
@@ -348,7 +380,6 @@ function statesEditorAddLines(): void {
     ensureEl("statesBodySection").dataset.type = "absolute";
     togglePercentageMode();
   }
-  applySorting(ensureEl("statesHeader"));
   $("#statesEditor").dialog({ width: "fit-content" });
 }
 
@@ -970,7 +1001,7 @@ function togglePercentageMode(): void {
       });
   } else {
     ensureEl("statesBodySection").dataset.type = "absolute";
-    statesEditorAddLines();
+    statesTable.refresh();
   }
 }
 
@@ -1623,7 +1654,7 @@ function addState(this: SVGElement, event: MouseEvent): void {
   layerIsOn("toggleStates") ? drawStates() : toggleStates();
   layerIsOn("toggleBorders") ? drawBorders() : toggleBorders();
 
-  statesEditorAddLines();
+  statesTable.refresh();
 }
 
 function exitAddStateMode(): void {
@@ -1826,29 +1857,26 @@ function openStateMergeDialog(): void {
 function downloadStatesCsv(): void {
   const unit = getAreaUnit("2");
   const headers = `Id,State,Full Name,Form,Color,Capital,Culture,Type,Expansionism,Cells,Burgs,Area ${unit},Total Population,Rural Population,Urban Population`;
-  const lines = Array.from(ensureEl("statesBodySection").querySelectorAll<HTMLElement>(":scope > div"));
-  const data = lines.map($line => {
-    const { id, name, form, color, capital, culture, type, expansionism, cells, burgs, area, population } =
-      $line.dataset;
-    const { fullName = "", rural, urban } = pack.states[+id!];
-    const ruralPopulation = Math.round((rural ?? 0) * populationRate);
-    const urbanPopulation = Math.round((urban ?? 0) * populationRate * urbanization);
+  const data = statesTable.view().all.map(s => {
+    const rural = s.rural || 0;
+    const urban = s.urban || 0;
+    const population = rn(rural * populationRate + urban * populationRate * urbanization);
     return [
-      id,
-      name,
-      fullName,
-      form,
-      color,
-      capital,
-      culture,
-      type,
-      expansionism,
-      cells,
-      burgs,
-      area,
+      s.i,
+      s.name,
+      s.fullName || "",
+      s.i ? s.formName : "",
+      s.i ? s.color : "",
+      s.i ? pack.burgs[s.capital].name : "",
+      s.i ? pack.cultures[s.culture].name : "",
+      s.i ? s.type : "",
+      s.i ? s.expansionism : "",
+      s.cells,
+      s.burgs,
+      getArea(s.area || 0),
       population,
-      ruralPopulation,
-      urbanPopulation
+      Math.round(rural * populationRate),
+      Math.round(urban * populationRate * urbanization)
     ].join(",");
   });
   const csvData = [headers].concat(data).join("\n");


### PR DESCRIPTION
Renders large editor lists 200 rows at a time so they stay responsive on big maps. The States editor in particular was effectively unusable at 1k+ states because it renders a coat-of-arms per row; it now renders the COA only for the current page.

### What changed
- Shared pagination/sort helpers in `editors.js`: `getActiveSort`, `sortDataByActiveHeader`, `getEditorPage`, `renderEditorPagination`, `bindEditorSortReset`.
- Pagination added to the **Burgs**, **States**, **Cultures**, **Religions**, **Rivers**, and **Routes** overviews/editors.
- Each one sorts the **full** filtered set (so sorting spans all pages, an upgrade over the old DOM-only `applySorting`), computes footer totals/averages over the full set, then renders only the current page and draws `Page n of N` controls in the footer.
- CSV exports operate over the full set (some previously read the rendered DOM, which would now be only the visible page).
- Search and state/culture filters (burgs) and column sort reset to page 1 and filter/sort across all pages; lazily-computed route name/length are populated for the full set so sort/footer/CSV stay correct.
- Manual re-assignment map-clicks, the culture-center hover, and `randomizeStatesExpansion` are guarded against rows that aren't on the current page.
- The footer pager fills the table-driven width without contributing to the dialog's `fit-content` width, so narrow dialogs (e.g. Rivers) don't get an empty gutter.

### Notes
- No new HTML or CSS — the pager UI is created entirely in JS (page size 200).
- Seven files touched; all were identical to current `master` before this change.

### Test plan
- Open each editor on a 1k+ map: paginates at 200; prev/next/jump/clamp work; pager hidden when the list fits one page.
- Column sort resets to page 1 and orders the full set (top of page 1 is the global max/min).
- Footer totals/averages stable across pages; percentage mode (states/cultures/religions) correct on a later page.
- Burgs: state/culture filters + search reset to page 1 and apply across all pages; "regenerate names" applies to the full filtered set.
- CSV export from a non-first page contains all rows.
- States manual re-assignment + randomize produce no console errors.
