### PR TITLE
Add toggleable provinces legend

### DIFF
--- a/public/modules/ui/provinces-editor.js
+++ b/public/modules/ui/provinces-editor.js
@@ -29,6 +29,7 @@ function editProvinces() {
   ensureEl("provincesFilterState").on("change", provincesEditorAddLines);
   ensureEl("provincesPercentage").on("click", togglePercentageMode);
   ensureEl("provincesChart").on("click", showChart);
+  ensureEl("provincesLegend").on("click", toggleProvincesLegend);
   ensureEl("provincesToggleLabels").on("click", toggleLabels);
   ensureEl("provincesExport").on("click", downloadProvincesData);
   ensureEl("provincesRemoveAll").on("click", removeAllProvinces);
@@ -795,6 +796,25 @@ function editProvinces() {
     provs.select("#provinceLabels").style("display", `${hidden ? "block" : "none"}`);
     provs.attr("data-labels", +hidden);
     provs.selectAll("text").call(d3.drag().on("drag", dragLabel)).classed("draggable", true);
+  }
+
+  function toggleProvincesLegend() {
+    // Toggle legend on/off
+    if (legend.selectAll("*").size()) {
+      legend.selectAll("*").remove();
+      return;
+    }
+
+    // Get filtered provinces based on current editor state
+    const selectedState = +ensureEl("provincesFilterState").value;
+    let filtered = pack.provinces.filter(p => p.i && !p.removed);
+    if (selectedState != -1) filtered = filtered.filter(p => p.state === selectedState);
+
+    // Map to [id, color, name] format for legend
+    const data = filtered.map(p => [p.i, p.color, p.name]);
+
+    // Draw legend
+    drawLegend("Provinces", data);
   }
 
   function triggerProvincesRelease() {

--- a/src/index.html
+++ b/src/index.html
@@ -4669,6 +4669,7 @@
             class="icon-percent"
           ></button>
           <button id="provincesChart" data-tip="Show provinces chart" class="icon-chart-area"></button>
+          <button id="provincesLegend" data-tip="Toggle Legend box" class="icon-list-bullet"></button>
           <button
             id="provincesToggleLabels"
             data-tip="Toggle province labels. Change size in Menu ⭢ Style ⭢ Provinces"


### PR DESCRIPTION
This PR adds a new Provinces Legend toggle. A new button (#provincesLegend) in the provinces toolbar between [chart] and [provincelabels]. This button calls function toggleProvincesLegend handler.

This function has some things set up.
* clears the legend if present or builds it from pack.provinces (only entries with p.i and not removed),
* applies the current state filter (provincesFilterState),
* maps provinces to [id, color, name],
* and calls drawLegend("Provinces", data) to render it.
