### PR TITLE
Renamed "europe-north" to "north sea region".

### DIFF
--- a/public/config/precreated-heightmaps.js
+++ b/public/config/precreated-heightmaps.js
@@ -12,7 +12,7 @@ const precreatedHeightmaps = {
   "europe-accented": {id: 8, name: "Europe Accented"},
   "europe-and-central-asia": {id: 9, name: "Europe and Central Asia"},
   "europe-central": {id: 10, name: "Europe Central"},
-  "europe-north": {id: 11, name: "Europe North"},
+  "north-sea-region": {id: 11, name: "North Sea Region"},
   greenland: {id: 12, name: "Greenland"},
   hellenica: {id: 13, name: "Hellenica"},
   iceland: {id: 14, name: "Iceland"},

--- a/public/main.js
+++ b/public/main.js
@@ -886,7 +886,7 @@ function defineMapSize() {
     if (template === "europe-accented") return [14, 22, 44.8];
     if (template === "europe-and-central-asia") return [25, 10, 39.5];
     if (template === "europe-central") return [11, 22, 46.4];
-    if (template === "europe-north") return [7, 18, 48.9];
+    if (template === "north-sea-region") return [7, 18, 48.9];
     if (template === "greenland") return [22, 7, 55.8];
     if (template === "hellenica") return [8, 27, 43.5];
     if (template === "iceland") return [2, 15, 55.3];


### PR DESCRIPTION
Renamed "europe-north" to "north sea region".

In precreated-heightmaps.js and main.js

Planned to add one precreated heightmap more to the north.
