### PR TITLE
Feat battle phases record

### DIFF
--- a/public/modules/ui/battle-screen.js
+++ b/public/modules/ui/battle-screen.js
@@ -12,6 +12,7 @@ class Battle {
     this.cell = findCell(this.x, this.y);
     this.attackers = {regiments: [], distances: [], morale: 100, casualties: 0, power: 0};
     this.defenders = {regiments: [], distances: [], morale: 100, casualties: 0, power: 0};
+    this.phasesRecord = [];
 
     this.addHeaders();
     this.addRegiment("attackers", attacker);
@@ -680,6 +681,12 @@ class Battle {
       return;
     }
 
+    // record phase
+    const currentPhase = `Attackers: ${capitalize(this.attackers.phase)}, Defenders: ${capitalize(this.defenders.phase)}`;
+    const lastRecord = this.phasesRecord.length ? this.phasesRecord[this.phasesRecord.length - 1] : null;
+    if (lastRecord && lastRecord.phase === currentPhase) lastRecord.count += 1;
+    else this.phasesRecord.push({phase: currentPhase, count: 1});
+
     // calculate casualties
     const attack = this.attackers.power * (this.attackers.die / 10 + 0.4);
     const defense = this.defenders.power * (this.defenders.die / 10 + 0.4);
@@ -882,13 +889,19 @@ class Battle {
 
     const status = battleStatus[+P(0.7)];
     const result = `The ${this.getTypeName(this.type)} ended in ${status}`;
-    const legend = `${this.name} took place in ${options.year} ${options.eraShort}. It was fought between ${getSide(
+    let legend = `${this.name} took place in ${options.year} ${options.eraShort}. It was fought between ${getSide(
       this.attackers.regiments,
       1
     )} and ${getSide(this.defenders.regiments, 0)}. ${result}.
-      \r\nAttackers losses: ${getLosses(this.attackers.casualties)}%, defenders losses: ${getLosses(
+      <br>Attackers losses: ${getLosses(this.attackers.casualties)}%, defenders losses: ${getLosses(
       this.defenders.casualties
     )}%`;
+
+    if (this.phasesRecord && this.phasesRecord.length) {
+      const phasesText = this.phasesRecord.map(r => (r.count > 1 ? `${r.phase} (x${r.count})` : r.phase)).join("<br>");
+      legend += `<br><br>Engagement progression:<br>${phasesText}`;
+    }
+
     notes.push({id: `marker${i}`, name: this.name, legend});
 
     tip(`${this.name} is over. ${result}`, true, "success", 4000);

--- a/src/generators/resample.ts
+++ b/src/generators/resample.ts
@@ -271,8 +271,6 @@ class Resampler {
     });
 
     States.getPoles();
-    const regimentCellsMap: Record<number, number> = {};
-    const VERTICAL_GAP = 8;
 
     pack.states = pack.states.map(state => {
       if (!state.i || state.removed) return state;
@@ -281,30 +279,31 @@ class Resampler {
       const [poleX, poleY] = state.pole as Point;
       state.center = !capital || capital.removed ? findClosestCell(poleX, poleY, Infinity, pack)! : capital.cell;
 
-      const military = state.military!.map(regiment => {
-        const cellCoords = projection(...parentMap.pack.cells.p[regiment.cell]);
-        const cell = this.isInMap(...cellCoords) ? findClosestCell(...cellCoords, Infinity, pack)! : state.center;
+      const military = state.military!.reduce(
+        (acc, regiment) => {
+          const [xPos, yPos] = projection(regiment.x, regiment.y);
 
-        const [xPos, yPos] = projection(regiment.x, regiment.y);
-        const [xBase, yBase] = projection(regiment.bx, regiment.by);
-        const [xCell, yCell] = pack.cells.p[cell];
+          if (!this.isInMap(xPos, yPos)) {
+            const noteIndex = notes.findIndex(n => n.id === `regiment${state.i}-${regiment.i}`);
+            if (noteIndex !== -1) notes.splice(noteIndex, 1);
+            return acc;
+          }
 
-        const regsOnCell = regimentCellsMap[cell] || 0;
-        regimentCellsMap[cell] = regsOnCell + 1;
+          const cellCoords = projection(...parentMap.pack.cells.p[regiment.cell]);
+          const cell = this.isInMap(...cellCoords) ? findClosestCell(...cellCoords, Infinity, pack)! : state.center;
 
-        const name =
-          this.isInMap(xPos, yPos) || regiment.name.includes("[relocated]")
-            ? regiment.name
-            : `[relocated] ${regiment.name}`;
+          const [xBase, yBase] = projection(regiment.bx, regiment.by);
+          const [xCell, yCell] = pack.cells.p[cell];
 
-        const pos = this.isInMap(xPos, yPos)
-          ? { x: rn(xPos, 2), y: rn(yPos, 2) }
-          : { x: xCell, y: yCell + regsOnCell * VERTICAL_GAP };
+          const name = regiment.name.replace("[relocated] ", "");
+          const pos = { x: rn(xPos, 2), y: rn(yPos, 2) };
+          const base = this.isInMap(xBase, yBase) ? { bx: rn(xBase, 2), by: rn(yBase, 2) } : { bx: xCell, by: yCell };
 
-        const base = this.isInMap(xBase, yBase) ? { bx: rn(xBase, 2), by: rn(yBase, 2) } : { bx: xCell, by: yCell };
-
-        return { ...regiment, cell, name, ...base, ...pos };
-      });
+          acc.push({ ...regiment, cell, name, ...base, ...pos });
+          return acc;
+        },
+        [] as NonNullable<typeof state.military>
+      );
 
       const neighbors = state.neighbors!.filter(stateId => validStates.has(stateId));
       return { ...state, neighbors, military };


### PR DESCRIPTION
## Description

enhancement addresses a community request to include a loose record of battle phase progression in the generated map marker note to write a narrative about the engagement after it concludes.

### Changes

* Created a **phasesRecord** array inside the **Battle** class constructor.
* Updated the **run()** method to push the active **attackers** and **defenders** phases to the array at the start of every iteration.
* Updated **applyResults()** to append the phase history to the legend string.