### PR TITLE
Choose save location and filename when saving a map to machine

### DIFF
--- a/src/io/save-to-file.test.ts
+++ b/src/io/save-to-file.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { saveToFileSystem } from "./save-to-file";
+
+// A fake FileSystemFileHandle: records what was written.
+function makeHandle(name: string) {
+  const writes: string[] = [];
+  const handle = {
+    name,
+    writes,
+    createWritable: vi.fn(async () => ({
+      write: async (data: string) => {
+        writes.push(data);
+      },
+      close: async () => {}
+    }))
+  };
+  return handle;
+}
+
+describe("saveToFileSystem", () => {
+  afterEach(() => {
+    delete (globalThis as any).showSaveFilePicker;
+    delete (globalThis as any).downloadFile;
+    vi.restoreAllMocks();
+  });
+
+  it("opens the picker and reports saved with the chosen filename", async () => {
+    const handle = makeHandle("Chosen.map");
+    const picker = vi.fn(async () => handle);
+    (globalThis as any).showSaveFilePicker = picker;
+
+    const outcome = await saveToFileSystem("map-data", "Suggested.map");
+
+    expect(picker).toHaveBeenCalledTimes(1);
+    expect(handle.writes).toEqual(["map-data"]);
+    expect(outcome).toEqual({ type: "saved", filename: "Chosen.map" });
+  });
+
+  it("offers the suggested name and constrains the picker to .map files", async () => {
+    const picker = vi.fn(async (_options?: any) => makeHandle("Chosen.map"));
+    (globalThis as any).showSaveFilePicker = picker;
+
+    await saveToFileSystem("map-data", "Suggested.map");
+
+    const options = picker.mock.calls[0][0];
+    expect(options.suggestedName).toBe("Suggested.map");
+    const acceptedExtensions = options.types.flatMap((t: any) => Object.values(t.accept).flat());
+    expect(acceptedExtensions.includes(".map")).toBe(true);
+  });
+
+  it("opens the picker on every save so the user can choose a different file each time", async () => {
+    const first = makeHandle("First.map");
+    const second = makeHandle("Second.map");
+    const picker = vi
+      .fn(async () => first)
+      .mockImplementationOnce(async () => first)
+      .mockImplementationOnce(async () => second);
+    (globalThis as any).showSaveFilePicker = picker;
+
+    const a = await saveToFileSystem("a", "Suggested.map");
+    const b = await saveToFileSystem("b", "Suggested.map");
+
+    expect(picker).toHaveBeenCalledTimes(2);
+    expect(a).toEqual({ type: "saved", filename: "First.map" });
+    expect(b).toEqual({ type: "saved", filename: "Second.map" });
+  });
+
+  it("treats a cancelled picker as a no-op", async () => {
+    const picker = vi.fn(async () => {
+      const error = new Error("aborted");
+      error.name = "AbortError";
+      throw error;
+    });
+    (globalThis as any).showSaveFilePicker = picker;
+
+    const outcome = await saveToFileSystem("map-data", "Suggested.map");
+    expect(outcome).toEqual({ type: "cancelled" });
+  });
+
+  it("treats a cancelled picker (DOMException-style AbortError) as a no-op", async () => {
+    // DOMException is not reliably instanceof Error across engines.
+    const abort = { name: "AbortError", message: "aborted" };
+    (globalThis as any).showSaveFilePicker = vi.fn(async () => {
+      throw abort;
+    });
+
+    const outcome = await saveToFileSystem("data", "Suggested.map");
+    expect(outcome).toEqual({ type: "cancelled" });
+  });
+
+  it("propagates non-cancel picker errors to the caller", async () => {
+    const securityError = new Error("denied");
+    securityError.name = "SecurityError";
+    (globalThis as any).showSaveFilePicker = vi.fn(async () => {
+      throw securityError;
+    });
+
+    await expect(saveToFileSystem("map-data", "Suggested.map")).rejects.toThrow("denied");
+  });
+
+  it("propagates a write failure to the caller", async () => {
+    const handle = makeHandle("Chosen.map");
+    handle.createWritable.mockImplementationOnce(async () => {
+      throw new Error("write failed");
+    });
+    (globalThis as any).showSaveFilePicker = vi.fn(async () => handle);
+
+    await expect(saveToFileSystem("data", "Suggested.map")).rejects.toThrow("write failed");
+  });
+
+  it("falls back to the shared downloadFile helper when the picker API is unavailable", async () => {
+    delete (globalThis as any).showSaveFilePicker;
+    const downloadFile = vi.fn();
+    (globalThis as any).downloadFile = downloadFile;
+
+    const outcome = await saveToFileSystem("map-data", "Suggested.map");
+
+    expect(downloadFile).toHaveBeenCalledWith("map-data", "Suggested.map");
+    expect(outcome).toEqual({ type: "downloaded-fallback", filename: "Suggested.map" });
+  });
+});

--- a/src/io/save-to-file.ts
+++ b/src/io/save-to-file.ts
@@ -1,0 +1,50 @@
+// File writer for the .map "Save to Machine" path.
+//
+// Encapsulates the File System Access API (Chromium-only): every save opens the
+// OS Save-Location Picker so the user chooses the folder and filename each time,
+// then writes the map there. Where the API is unavailable (Firefox/Safari) it
+// falls back to a Downloads write. The caller owns all user messaging — this
+// module just reports a discriminated outcome.
+
+export type SaveOutcome =
+  | { type: "saved"; filename: string }
+  | { type: "downloaded-fallback"; filename: string }
+  | { type: "cancelled" };
+
+function isFilePickerSupported(): boolean {
+  return typeof window.showSaveFilePicker === "function";
+}
+
+// Restrict the picker to .map files so the chosen name defaults to the right
+// extension.
+const MAP_FILE_TYPES = [{ description: "Fantasy Map Generator map", accept: { "application/octet-stream": [".map"] } }];
+
+async function writeToHandle(handle: FileSystemFileHandle, mapData: string): Promise<void> {
+  const writable = await handle.createWritable();
+  await writable.write(mapData);
+  await writable.close();
+}
+
+export async function saveToFileSystem(mapData: string, suggestedName: string): Promise<SaveOutcome> {
+  if (!isFilePickerSupported()) {
+    // No File System Access API — reuse the app's shared download helper.
+    downloadFile(mapData, suggestedName);
+    return { type: "downloaded-fallback", filename: suggestedName };
+  }
+
+  let handle: FileSystemFileHandle;
+  try {
+    handle = await window.showSaveFilePicker({ suggestedName, types: MAP_FILE_TYPES });
+  } catch (error) {
+    // The picker rejects with a DOMException named AbortError when the user
+    // dismisses the dialog — not a failure, just nothing to save. (DOMException
+    // isn't reliably `instanceof Error` across engines, so check the name only.)
+    if ((error as { name?: string } | null)?.name === "AbortError") {
+      return { type: "cancelled" };
+    }
+    throw error;
+  }
+
+  await writeToHandle(handle, mapData);
+  return { type: "saved", filename: handle.name };
+}

--- a/src/io/save.test.ts
+++ b/src/io/save.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { notifySaveOutcome } from "./save";
+
+describe("notifySaveOutcome", () => {
+  let tipMock: ReturnType<typeof vi.fn>;
+  let store: Record<string, string>;
+
+  beforeEach(() => {
+    tipMock = vi.fn();
+    (globalThis as any).tip = tipMock;
+
+    store = {};
+    (globalThis as any).localStorage = {
+      getItem: (key: string) => (key in store ? store[key] : null),
+      setItem: (key: string, value: string) => {
+        store[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      }
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows a success tip naming the file the user saved to", () => {
+    notifySaveOutcome({ type: "saved", filename: "MyWorld.map" });
+
+    expect(tipMock).toHaveBeenCalledTimes(1);
+    expect(tipMock).toHaveBeenCalledWith(expect.stringContaining("MyWorld.map"), true, "success", 8000);
+  });
+
+  it("shows no tip and no error when the picker was cancelled", () => {
+    notifySaveOutcome({ type: "cancelled" });
+
+    expect(tipMock).not.toHaveBeenCalled();
+  });
+
+  it("on the first Downloads fallback shows a single tip that confirms the save and explains the missing picker", () => {
+    notifySaveOutcome({ type: "downloaded-fallback", filename: "MyWorld.map" });
+
+    // Exactly one tip — a second tip() would overwrite the first in the tooltip.
+    expect(tipMock).toHaveBeenCalledTimes(1);
+    const [message] = tipMock.mock.calls[0];
+    expect(message.includes("Downloads")).toBe(true);
+    expect(message.includes("save-location picker")).toBe(true);
+  });
+
+  it("on later fallback saves shows only the success tip, not the explanation", () => {
+    notifySaveOutcome({ type: "downloaded-fallback", filename: "MyWorld.map" });
+    tipMock.mockClear();
+
+    notifySaveOutcome({ type: "downloaded-fallback", filename: "MyWorld.map" });
+
+    expect(tipMock).toHaveBeenCalledTimes(1);
+    const [message] = tipMock.mock.calls[0];
+    expect(message.includes("Downloads")).toBe(true);
+    expect(message.includes("save-location picker")).toBe(false);
+  });
+
+  it("still saves (no throw, success tip) when localStorage is unavailable", () => {
+    (globalThis as any).localStorage = {
+      getItem: () => {
+        throw new Error("storage disabled");
+      },
+      setItem: () => {
+        throw new Error("storage disabled");
+      },
+      removeItem: () => {}
+    };
+
+    expect(() => notifySaveOutcome({ type: "downloaded-fallback", filename: "MyWorld.map" })).not.toThrow();
+    expect(tipMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/io/save.ts
+++ b/src/io/save.ts
@@ -1,6 +1,7 @@
 // Save the whole .map project to storage, machine or cloud
 import { lazy } from "@/lazy-loaders";
 import { ensureEl, link, parseError, rn } from "@/utils";
+import { type SaveOutcome, saveToFileSystem } from "./save-to-file";
 
 type SaveMethod = "storage" | "machine" | "dropbox";
 
@@ -13,7 +14,7 @@ export async function saveMap(method: SaveMethod): Promise<void> {
     const filename = `${getFileName()}.map`;
 
     if (method === "storage") await saveToStorage(mapData, true);
-    if (method === "machine") saveToMachine(mapData, filename);
+    if (method === "machine") await saveToMachine(mapData, filename);
     if (method === "dropbox") await saveToDropbox(mapData, filename);
   } catch (error) {
     ERROR && console.error(error);
@@ -191,18 +192,63 @@ export async function saveToStorage(mapData: string, showTip = false): Promise<v
   showTip && tip("Map is saved to the browser storage", false, "success");
 }
 
-// download map file
-function saveToMachine(mapData: string, filename: string): void {
-  const blob = new Blob([mapData], { type: "text/plain" });
-  const URL = window.URL.createObjectURL(blob);
+const DOWNLOADS_FALLBACK_NOTICE_KEY = "savePickerFallbackNoticeShown";
 
-  const link = document.createElement("a");
-  link.download = filename;
-  link.href = URL;
-  link.click();
+// Whether the one-time fallback explanation has already been shown on this
+// browser. Guarded because localStorage can throw (e.g. Safari private mode);
+// a save must never fail just because we couldn't read/write this flag.
+function fallbackNoticeAlreadyShown(): boolean {
+  try {
+    return localStorage.getItem(DOWNLOADS_FALLBACK_NOTICE_KEY) !== null;
+  } catch {
+    return false;
+  }
+}
 
-  tip('Map is saved to the "Downloads" folder (CTRL + J to open)', true, "success", 8000);
-  setTimeout(() => window.URL.revokeObjectURL(URL), 5000);
+function rememberFallbackNoticeShown(): void {
+  try {
+    localStorage.setItem(DOWNLOADS_FALLBACK_NOTICE_KEY, "true");
+  } catch {
+    // Storage unavailable — the note may show again next time; harmless.
+  }
+}
+
+// A single tip per fallback save: the first time also explains why no picker was
+// offered. (One tip, not two — a second tip() would overwrite the first, since
+// tip() replaces the tooltip's contents.)
+function notifyDownloadsFallback(): void {
+  if (fallbackNoticeAlreadyShown()) {
+    tip('Map is saved to the "Downloads" folder (CTRL + J to open)', true, "success", 8000);
+    return;
+  }
+
+  tip(
+    'Map is saved to the "Downloads" folder (CTRL + J). Your browser can\'t offer a save-location picker — use a Chromium browser (Chrome, Edge) to choose where maps are saved.',
+    true,
+    "success",
+    12000
+  );
+  rememberFallbackNoticeShown();
+}
+
+// Map a save outcome to user feedback. A cancelled picker is a silent no-op.
+export function notifySaveOutcome(outcome: SaveOutcome): void {
+  if (outcome.type === "cancelled") return;
+
+  if (outcome.type === "downloaded-fallback") {
+    notifyDownloadsFallback();
+    return;
+  }
+
+  // saved — written to the file the user chose in the picker.
+  tip(`Map is saved to "${outcome.filename}"`, true, "success", 8000);
+}
+
+// Save the .map file to the user's machine via the save-location picker (or the
+// Downloads fallback where unsupported), then report the outcome.
+async function saveToMachine(mapData: string, filename: string): Promise<void> {
+  const outcome = await saveToFileSystem(mapData, filename);
+  notifySaveOutcome(outcome);
 }
 
 async function saveToDropbox(mapData: string, filename: string): Promise<void> {

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -131,6 +131,13 @@ declare global {
     get: (key: string) => Promise<Blob | undefined>;
     set: (key: string, value: Blob) => Promise<void>;
   };
+
+  // File System Access API — Chromium-only, absent in Firefox/Safari.
+  // Declared here so the save-location picker can feature-detect it.
+  var showSaveFilePicker: (options?: {
+    suggestedName?: string;
+    types?: Array<{ description?: string; accept: Record<string, string[]> }>;
+  }) => Promise<FileSystemFileHandle>;
   var Dropbox: any; // dropbox-sdk global, loaded on demand from libs/dropbox-sdk.min.js
   var rulers: any; // Rulers instance (classic)
   var Rulers: any;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,14 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  // Mirror the "@" → src alias from vite.config.ts / tsconfig so tests resolve
+  // runtime "@/..." imports the same way the app build does.
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url))
+    }
+  },
   test: {
     root: "./src",
     setupFiles: ["./test-setup.ts"],


### PR DESCRIPTION
## What & why

Today, **Save → machine** writes the `.map` file straight to the browser's Downloads folder under an auto-generated name. There's no way to choose where the file goes or what it's called, so users have to fish the file out of Downloads and move it, and can't decide whether to overwrite an existing map or keep a separate copy.

This PR makes **Save to Machine** open the OS "Save As" dialog **every time**, so the user chooses the folder and filename on each save:

- Overwrite an existing map by selecting it in the dialog.
- Save a new/separate file by choosing a new name or folder.

The dialog is pre-filled with the usual `<map name> <timestamp>` and filtered to `.map`.

## Browser support

Uses the **File System Access API** (`showSaveFilePicker`), available in Chromium-based browsers (Chrome, Edge, Opera, Brave). Firefox and Safari don't support it, so they **fall back to the existing Downloads behaviour** (via the shared `downloadFile` helper), with a one-time tip explaining why the picker wasn't offered. Saving works everywhere.

## Scope

Only the `.map` **Save to Machine** path — the *machine* button and the Ctrl+S hotkey, which share `saveMap("machine")`. Dropbox, browser-storage save, auto-save, and all exports are unchanged.

## Implementation

- `src/io/save-to-file.ts` (new): a small module wrapping the picker and the fallback behind one function, `saveToFileSystem(mapData, suggestedName)`, returning a discriminated outcome — `saved` / `downloaded-fallback` / `cancelled`. It holds no cross-save state. Cancelling the dialog (AbortError, matched by name so a `DOMException` is handled too) is a silent no-op; write/permission errors propagate to the existing save error dialog.
- `src/io/save.ts`: `saveToMachine` routes through the new module and maps the outcome to the usual `tip(...)` messages. The one-time fallback note is remembered in `localStorage`, guarded so a save never fails if storage is blocked (e.g. Safari private mode).
- `vitest.config.ts`: adds the `@` → `src` alias (mirroring `vite.config.ts` / `tsconfig`) so unit tests can resolve runtime `@/...` imports.

## Tests

New Vitest unit tests stub the browser globals and cover: the picker opens on every save; the suggested name and `.map` filter are passed; cancel (including a DOMException-style AbortError) is a no-op; an unsupported browser delegates to `downloadFile`; write/permission errors propagate; and the outcome → tip mapping including the one-time fallback note and the storage-unavailable case.

## Manual testing

- Chrome / Edge: every Save opens the picker; overwriting an existing file and writing a new file both work; the success tip names the chosen file; cancelling is clean.
- Firefox: falls back to Downloads with the one-time explanatory note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
