### PR TITLE
fix: clear legacy heightmap style stranded on the #terrs parent group

### DIFF
--- a/src/services/io/auto-update.ts
+++ b/src/services/io/auto-update.ts
@@ -1240,4 +1240,20 @@ export function resolveVersionConflicts(mapVersion: string, data: string[]): voi
 
     if (data[33]) pack.measurers = parse(data[33]);
   }
+
+  if (isOlderThan("1.138.1")) {
+    const terrs = select("#terrs");
+    if (terrs.attr("opacity") !== null || terrs.attr("filter") !== null || terrs.attr("scheme") !== null) {
+      terrs
+        .attr("opacity", null)
+        .attr("filter", null)
+        .attr("scheme", null)
+        .attr("terracing", null)
+        .attr("skip", null)
+        .attr("relax", null)
+        .attr("curve", null)
+        .attr("mask", null);
+      if (layerIsOn("toggleHeight")) drawHeightmap();
+    }
+  }
 }

--- a/src/services/versioning.ts
+++ b/src/services/versioning.ts
@@ -15,7 +15,7 @@
  * For the changes that may be interesting to end users, update the `latestPublicChanges` array below (new changes on top).
  */
 
-export const VERSION = "1.138.0";
+export const VERSION = "1.138.1";
 
 const latestPublicChanges = [
   "Economic simulation",


### PR DESCRIPTION
## Problem

Some maps load with a heightmap that renders permanently "washed out" (pale, low contrast, slightly blurred) and cannot be fixed by switching style presets.

## Root cause

Older maps store heightmap style — `opacity` / `filter` / `scheme` / `terracing` / … — on the parent `<g id="terrs">` group rather than on the `#oceanHeights` / `#landHeights` child groups. The `isOlderThan("1.96.0")` migration relocates those attributes to the children, but maps saved *after* 1.96 can still carry a stale `opacity`/`filter` on the parent (observed on a real 1.113.6 map with `opacity="0.35"` + a blur filter on `#terrs`).

`drawHeightmap()` and every built-in style preset target only the child groups (`#terrs > #landHeights` / `#terrs > #oceanHeights`) — nothing ever writes the parent. So a leftover parent `opacity`/`filter` silently dims and blurs the whole heightmap, and no style change can undo it.

## Fix

On load, normalize the parent `#terrs` group: if it still carries legacy style attributes, strip them so the child groups fully control the appearance, and redraw when the heightmap layer is visible. No effect on maps that already have a clean parent group.

## Test

Load a map whose saved SVG has `<g id="terrs" opacity="0.35" filter="url(#blurFilter)" …>` and toggle the Heightmap layer — before this change it stays washed out under every preset; after, it renders at full contrast. Equivalent quick check in console: `d3.select("#terrs").attr("opacity", null).attr("filter", null); drawHeightmap();`
