### PR TITLE
feat: filter Markers Overview by state, culture and type

### DIFF
--- a/src/controllers/markers-overview.ts
+++ b/src/controllers/markers-overview.ts
@@ -47,12 +47,10 @@ function renderDialog(): void {
         ></div>
       </div>
       <div id="markersBody" class="table"></div>
-      <div id="markersFilters" style="display:flex; gap:.4em; flex-wrap:wrap; align-items:center; padding:.2em 0">
+      <div id="markersFilters" style="display:flex; gap:.2em; padding:0.5em 0; flex-direction:column; font-size:smaller">
         <select id="markersFilterState" data-tip="Show only markers located in the selected state"></select>
         <select id="markersFilterCulture" data-tip="Show only markers located in the selected culture"></select>
         <select id="markersFilterType" data-tip="Show only markers of the selected type"></select>
-      </div>
-      <div>
         <label for="markersSearch" data-tip="Filter by type">Search: <input id="markersSearch" type="search" /></label>
       </div>
       <div id="markersFooter" class="totalLine">
@@ -99,13 +97,20 @@ function renderDialog(): void {
   populateFilters();
 }
 
-// fill a <select> with a leading placeholder option, preserving the current selection when still valid
-function fillSelect(select: HTMLSelectElement, placeholder: string, options: { value: string; label: string }[]): void {
-  const previous = select.value;
+// remembered filter selections, kept out of the DOM so they survive the dialog being rebuilt on each open
+const filterState = { search: "", state: "", culture: "", type: "" };
+
+// fill a <select> with a leading placeholder option, restoring `selected` when that option still exists
+function fillSelect(
+  select: HTMLSelectElement,
+  placeholder: string,
+  options: { value: string; label: string }[],
+  selected = ""
+): void {
   select.innerHTML = "";
   select.add(new Option(placeholder, ""));
   for (const { value, label } of options) select.add(new Option(label, value));
-  if (previous && options.some(option => option.value === previous)) select.value = previous;
+  if (selected && options.some(option => option.value === selected)) select.value = selected;
 }
 
 // populate the state / culture / type filter dropdowns from current pack data
@@ -113,17 +118,19 @@ function populateFilters(): void {
   const states = pack.states
     .filter(state => !state.removed)
     .map(state => ({ value: String(state.i), label: state.fullName || state.name }));
-  fillSelect(ensureEl<HTMLSelectElement>("markersFilterState"), "All states", states);
+  fillSelect(ensureEl<HTMLSelectElement>("markersFilterState"), "All states", states, filterState.state);
 
   const cultures = pack.cultures
     .filter(culture => !culture.removed)
     .map(culture => ({ value: String(culture.i), label: culture.name }));
-  fillSelect(ensureEl<HTMLSelectElement>("markersFilterCulture"), "All cultures", cultures);
+  fillSelect(ensureEl<HTMLSelectElement>("markersFilterCulture"), "All cultures", cultures, filterState.culture);
 
   const types = [...new Set(pack.markers.map(marker => marker.type))]
     .sort()
     .map(type => ({ value: type, label: type }));
-  fillSelect(ensureEl<HTMLSelectElement>("markersFilterType"), "All types", types);
+  fillSelect(ensureEl<HTMLSelectElement>("markersFilterType"), "All types", types, filterState.type);
+
+  ensureEl<HTMLInputElement>("markersSearch").value = filterState.search;
 }
 
 function closeMarkersOverview(): void {
@@ -131,11 +138,6 @@ function closeMarkersOverview(): void {
   document.getElementById("markerAdd")?.classList.remove("pressed");
   applyDefaultViewboxEvents();
   clearMainTip();
-
-  // drop the map filter so all markers are visible again once the overview is closed
-  lastFilterSignature = "";
-  setMarkersFilter(null);
-  if (layerIsOn("toggleMarkers")) drawMarkers();
 
   $("#markersOverview").dialog("destroy");
   ensureEl("markersOverview").remove();
@@ -181,7 +183,18 @@ function handleLineClick(ev: MouseEvent): void {
 function addLines(): void {
   let markers: Marker[] = pack.markers;
 
-  const searchText = ensureEl<HTMLInputElement>("markersSearch").value.toLowerCase().trim();
+  const searchRaw = ensureEl<HTMLInputElement>("markersSearch").value;
+  const stateFilter = ensureEl<HTMLSelectElement>("markersFilterState").value;
+  const cultureFilter = ensureEl<HTMLSelectElement>("markersFilterCulture").value;
+  const typeFilter = ensureEl<HTMLSelectElement>("markersFilterType").value;
+
+  // remember selections so they persist across dialog close/reopen until the user changes them
+  filterState.search = searchRaw;
+  filterState.state = stateFilter;
+  filterState.culture = cultureFilter;
+  filterState.type = typeFilter;
+
+  const searchText = searchRaw.toLowerCase().trim();
   if (searchText) {
     markers = markers.filter(marker => {
       const type = (marker.type || "").toLowerCase();
@@ -189,19 +202,16 @@ function addLines(): void {
     });
   }
 
-  const stateFilter = ensureEl<HTMLSelectElement>("markersFilterState").value;
   if (stateFilter !== "") {
     const stateId = +stateFilter;
     markers = markers.filter(marker => pack.cells.state[marker.cell] === stateId);
   }
 
-  const cultureFilter = ensureEl<HTMLSelectElement>("markersFilterCulture").value;
   if (cultureFilter !== "") {
     const cultureId = +cultureFilter;
     markers = markers.filter(marker => pack.cells.culture[marker.cell] === cultureId);
   }
 
-  const typeFilter = ensureEl<HTMLSelectElement>("markersFilterType").value;
   if (typeFilter !== "") {
     markers = markers.filter(marker => marker.type === typeFilter);
   }

--- a/src/controllers/markers-overview.ts
+++ b/src/controllers/markers-overview.ts
@@ -4,7 +4,7 @@ import { clearMainTip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
 import type { Marker } from "@/generators/markers-generator";
-import { drawMarkers } from "@/renderers/draw-markers";
+import { drawMarkers, setMarkersFilter } from "@/renderers/draw-markers";
 import { highlightElement } from "@/renderers/overlays/highlight";
 import { downloadFile, getFileName, getLatitude, getLongitude } from "@/utils";
 import { ensureEl } from "../utils";
@@ -47,6 +47,11 @@ function renderDialog(): void {
         ></div>
       </div>
       <div id="markersBody" class="table"></div>
+      <div id="markersFilters" style="display:flex; gap:.4em; flex-wrap:wrap; align-items:center; padding:.2em 0">
+        <select id="markersFilterState" data-tip="Show only markers located in the selected state"></select>
+        <select id="markersFilterCulture" data-tip="Show only markers located in the selected culture"></select>
+        <select id="markersFilterType" data-tip="Show only markers of the selected type"></select>
+      </div>
       <div>
         <label for="markersSearch" data-tip="Filter by type">Search: <input id="markersSearch" type="search" /></label>
       </div>
@@ -86,8 +91,39 @@ function renderDialog(): void {
   ensureEl("markersRemoveAll").addEventListener("click", triggerRemoveAll);
   ensureEl("markersExport").addEventListener("click", exportMarkers);
   ensureEl("markersSearch").addEventListener("input", addLines);
+  ensureEl("markersFilterState").addEventListener("change", addLines);
+  ensureEl("markersFilterCulture").addEventListener("change", addLines);
+  ensureEl("markersFilterType").addEventListener("change", addLines);
 
   populateMarkerTypeMenu();
+  populateFilters();
+}
+
+// fill a <select> with a leading placeholder option, preserving the current selection when still valid
+function fillSelect(select: HTMLSelectElement, placeholder: string, options: { value: string; label: string }[]): void {
+  const previous = select.value;
+  select.innerHTML = "";
+  select.add(new Option(placeholder, ""));
+  for (const { value, label } of options) select.add(new Option(label, value));
+  if (previous && options.some(option => option.value === previous)) select.value = previous;
+}
+
+// populate the state / culture / type filter dropdowns from current pack data
+function populateFilters(): void {
+  const states = pack.states
+    .filter(state => !state.removed)
+    .map(state => ({ value: String(state.i), label: state.fullName || state.name }));
+  fillSelect(ensureEl<HTMLSelectElement>("markersFilterState"), "All states", states);
+
+  const cultures = pack.cultures
+    .filter(culture => !culture.removed)
+    .map(culture => ({ value: String(culture.i), label: culture.name }));
+  fillSelect(ensureEl<HTMLSelectElement>("markersFilterCulture"), "All cultures", cultures);
+
+  const types = [...new Set(pack.markers.map(marker => marker.type))]
+    .sort()
+    .map(type => ({ value: type, label: type }));
+  fillSelect(ensureEl<HTMLSelectElement>("markersFilterType"), "All types", types);
 }
 
 function closeMarkersOverview(): void {
@@ -96,6 +132,11 @@ function closeMarkersOverview(): void {
   applyDefaultViewboxEvents();
   clearMainTip();
 
+  // drop the map filter so all markers are visible again once the overview is closed
+  lastFilterSignature = "";
+  setMarkersFilter(null);
+  if (layerIsOn("toggleMarkers")) drawMarkers();
+
   $("#markersOverview").dialog("destroy");
   ensureEl("markersOverview").remove();
 }
@@ -103,6 +144,7 @@ function closeMarkersOverview(): void {
 function regenerateMarkers(): void {
   Markers.regenerate();
   if (layerIsOn("toggleMarkers")) drawMarkers();
+  populateFilters();
   addLines();
 }
 
@@ -147,6 +189,26 @@ function addLines(): void {
     });
   }
 
+  const stateFilter = ensureEl<HTMLSelectElement>("markersFilterState").value;
+  if (stateFilter !== "") {
+    const stateId = +stateFilter;
+    markers = markers.filter(marker => pack.cells.state[marker.cell] === stateId);
+  }
+
+  const cultureFilter = ensureEl<HTMLSelectElement>("markersFilterCulture").value;
+  if (cultureFilter !== "") {
+    const cultureId = +cultureFilter;
+    markers = markers.filter(marker => pack.cells.culture[marker.cell] === cultureId);
+  }
+
+  const typeFilter = ensureEl<HTMLSelectElement>("markersFilterType").value;
+  if (typeFilter !== "") {
+    markers = markers.filter(marker => marker.type === typeFilter);
+  }
+
+  const anyFilterActive = Boolean(searchText) || stateFilter !== "" || cultureFilter !== "" || typeFilter !== "";
+  syncMapToFilter(markers, anyFilterActive);
+
   const lines = markers
     .map(({ i, type, icon, pinned, lock }) => {
       return /* html */ `
@@ -176,6 +238,20 @@ function addLines(): void {
   ensureEl("markersFooterTotal").innerText = String(pack.markers.length);
 
   applySorting(ensureEl("markersHeader"));
+}
+
+// last filter set pushed to the renderer, so we only redraw the map when the visible set actually changes
+let lastFilterSignature = "";
+
+// mirror the overview filter onto the map: render only matching markers, or all markers when no filter is active
+function syncMapToFilter(filteredMarkers: Marker[], anyFilterActive: boolean): void {
+  const ids = anyFilterActive ? filteredMarkers.map(marker => marker.i) : null;
+  const signature = ids ? ids.join(",") : "";
+  if (signature === lastFilterSignature) return;
+  lastFilterSignature = signature;
+
+  setMarkersFilter(ids);
+  if (layerIsOn("toggleMarkers")) drawMarkers();
 }
 
 function invertPin(): void {
@@ -295,20 +371,25 @@ function removeAllMarkers(): void {
 }
 
 function exportMarkers(): void {
-  const headers = "Id,Type,Icon,Name,Note,X,Y,Latitude,Longitude\n";
+  const headers = "Id,Type,Icon,Name,Note,State,Culture,X,Y,Latitude,Longitude\n";
   const quote = (s: string) => `"${s.replaceAll('"', '""')}"`;
 
   const body = pack.markers.map(marker => {
-    const { i, type, icon, x, y } = marker;
+    const { i, type, icon, x, y, cell } = marker;
 
     const note = notes.find(note => note.id === `marker${i}`);
     const name = note ? quote(note.name) : "Unknown";
     const legend = note ? quote(note.legend) : "";
 
+    const state = pack.states[pack.cells.state[cell]];
+    const culture = pack.cultures[pack.cells.culture[cell]];
+    const stateName = state ? quote(state.fullName || state.name) : "";
+    const cultureName = culture ? quote(culture.name) : "";
+
     const lat = getLatitude(y, mapCoordinates, graphHeight, 2);
     const lon = getLongitude(x, mapCoordinates, graphWidth, 2);
 
-    return [i, type, icon, name, legend, x, y, lat, lon].join(",");
+    return [i, type, icon, name, legend, stateName, cultureName, x, y, lat, lon].join(",");
   });
 
   const data = headers + body.join("\n");

--- a/src/renderers/draw-markers.ts
+++ b/src/renderers/draw-markers.ts
@@ -76,15 +76,24 @@ function markerRenderer(marker: Marker, rescale = 1): string {
     </svg>`;
 }
 
+// transient set of marker ids the map should render, driven by the Markers Overview filter.
+// null = no filter (render everything). Not persisted — never touches pack data or the .map file.
+let visibleMarkerIds: Set<number> | null = null;
+
+const setMarkersFilter = (ids: number[] | null): void => {
+  visibleMarkerIds = ids ? new Set(ids) : null;
+};
+
 const markersRenderer = (): void => {
   TIME && console.time("drawMarkers");
 
   const rescale = +select("#markers").attr("rescale");
   const pinned = +select("#markers").attr("pinned");
 
-  const markersData: Marker[] = pinned
+  let markersData: Marker[] = pinned
     ? (pack.markers || []).filter((marker: Marker) => marker.pinned)
     : pack.markers || [];
+  if (visibleMarkerIds) markersData = markersData.filter((marker: Marker) => visibleMarkerIds!.has(marker.i));
   const html = markersData.map(marker => markerRenderer(marker, rescale));
   select("#markers").html(html.join(""));
 
@@ -94,4 +103,4 @@ const markersRenderer = (): void => {
 window.drawMarkers = markersRenderer;
 window.drawMarker = markerRenderer;
 
-export { getPinForShape as getPin, markerRenderer as drawMarker, markersRenderer as drawMarkers };
+export { getPinForShape as getPin, markerRenderer as drawMarker, markersRenderer as drawMarkers, setMarkersFilter };


### PR DESCRIPTION
## What this does

Adds filtering to the Markers Overview. You can now narrow the list — and the pins shown on the map — by:

- **State** — markers located in the selected state
- **Culture** — markers located in the selected culture
- **Type** — markers of the selected type (only types present on the map are listed)

Filters compose with each other and with the existing text search. While the dialog is open the map shows only the matching markers; closing the dialog or clearing the filters restores all markers. CSV export gains **State** and **Culture** columns.

Filtering is view-only — it never edits, hides, or removes markers, and nothing is written to the `.map` file.

## How it works

State and culture are read from each marker's cell (`pack.cells.state[cell]` / `pack.cells.culture[cell]`), so no new `Marker` fields are introduced. The map mirrors the filter through a transient in-memory id set in the renderer — the same idea as the existing "pinned" subset — which is cleared when the dialog closes.

## Testing

- Generate a map, open Markers Overview (Shift+K), apply each filter, confirm the list count and on-map pins match.
- Combine filters + search, clear them, close the dialog — all markers reappear.
- Export CSV and confirm the State/Culture columns populate.
- `npm run lint`, `npm run build`, `npx tsc --noEmit`, and `npm run test` (198 tests) all pass.

No new dependencies.