### PR TITLE
fix(encounters): use pack.biomes instead of removed biomesData global

### DIFF
--- a/src/generators/markers-generator.test.ts
+++ b/src/generators/markers-generator.test.ts
@@ -25,11 +25,8 @@ describe("MarkersModule.addEncounter", () => {
       cells: {
         culture: Uint8Array.from([0, 2, 0, 0]),
         biome: Uint8Array.from([0, 3, 0, 0])
-      }
-    } as any;
-
-    globalThis.biomesData = {
-      name: ["", "", "", "Forest"]
+      },
+      biomes: [{ name: "" }, { name: "" }, { name: "" }, { name: "Forest" }]
     } as any;
 
     globalThis.Names = {

--- a/src/generators/markers-generator.ts
+++ b/src/generators/markers-generator.ts
@@ -1670,7 +1670,7 @@ class MarkersModule {
 
     const { cells } = pack;
     const cultureName = Names.getCulture(cells.culture[cell]);
-    const biomeName = (biomesData.name[cells.biome[cell]] || "wilderness").toLowerCase();
+    const biomeName = (pack.biomes[cells.biome[cell]]?.name || "wilderness").toLowerCase();
 
     const kinds = [
       { subject: "Bandits", verb: "have set an ambush" },


### PR DESCRIPTION
The encounter feature (merged from fix/encounter-legend) still referenced the old global `biomesData`, which the biomes refactor on master replaced with `pack.biomes`. The clean merge combined the encounter code with master's global.ts, leaving the reference dangling and breaking the build:
  - markers-generator.ts: Cannot find name 'biomesData'
  - markers-generator.test.ts: globalThis has no index signature

Switch to pack.biomes[...].name and mock pack.biomes in the test.
