### PR TITLE
Offer a reload when a lazy-loaded chunk 404s after a new release

### DIFF
--- a/src/services/app-shell.ts
+++ b/src/services/app-shell.ts
@@ -1,4 +1,5 @@
 // Browser-level behaviours of the app window: resizing, navigating away and mobile input quirks
+import { confirmationDialog } from "@/components/dialog/dialog-helpers";
 import { stored } from "@/utils/preferences";
 
 const isLocalhost = () => location.hostname === "localhost" || location.hostname === "127.0.0.1";
@@ -21,8 +22,28 @@ function onTitlebarButtonTouch(event: TouchEvent): void {
   if (target?.closest?.(".ui-dialog-titlebar-close, .ui-dialog-titlebar-collapse")) event.stopPropagation();
 }
 
+/**
+ * Each release replaces the content-hashed chunk files on the server, so a page opened before
+ * the release 404s when it lazy-loads a chunk it has not requested yet ("Failed to fetch
+ * dynamically imported module"). Offer a reload to pick up the new build
+ */
+function onChunkLoadError(): void {
+  confirmationDialog({
+    title: "New version released",
+    message:
+      "This part of the app failed to load because a new version was released while the page was open.<br />Reload the page to get the new version. If you have unsaved changes, save the map first",
+    confirm: "Reload",
+    cancel: "Not now",
+    onConfirm: () => {
+      window.onbeforeunload = null; // the user just confirmed the reload, don't ask again
+      location.reload();
+    }
+  });
+}
+
 function initialize(): void {
   window.addEventListener("resize", onResize);
+  window.addEventListener("vite:preloadError", onChunkLoadError);
   document.addEventListener("touchstart", onTitlebarButtonTouch, { capture: true, passive: true });
 
   if (!isLocalhost()) window.onbeforeunload = () => "Are you sure you want to navigate away?";

--- a/src/services/app-shell.ts
+++ b/src/services/app-shell.ts
@@ -35,7 +35,7 @@ function onChunkLoadError(): void {
     confirm: "Reload",
     cancel: "Not now",
     onConfirm: () => {
-      window.onbeforeunload = null; // the user just confirmed the reload, don't ask again
+      window.onbeforeunload = null; // the user just confirmed the reload, don't ask again.
       location.reload();
     }
   });


### PR DESCRIPTION
## Problem

Users with a long-lived session (especially the installed PWA) intermittently get broken menus with console errors like:

```
GET https://azgaar.github.io/Fantasy-Map-Generator/world-configurator-CFyNEXRn.js net::ERR_ABORTED 404 (Not Found)
Uncaught (in promise) TypeError: Failed to fetch dynamically imported module
```

Reported on Discord (2026-08-04): 404s when opening some edit menus, the 3D scene/globe, and the world configurator, while other menus keep working; closing and reopening the app fixes it "for a while".

**Root cause:** every editor is a lazy-loaded, content-hashed Vite chunk (`src/controllers/index.ts`). Each release replaces the hashed files on GitHub Pages, so a page opened before the release 404s the first time it lazy-loads a chunk it hasn't requested yet. Menus already opened that session keep working (already imported), which matches the report exactly. This became much more visible after PRs #1539/#1541 moved high-traffic dialogs (world configurator, 3D scene, trade animation, etc.) from stable-URL `modules/ui/*.js` scripts into hashed chunks. The service worker can't help: the failing chunk was never visited, so it isn't in any cache.

## Fix

Listen for Vite's [`vite:preloadError`](https://vite.dev/guide/build.html#load-error-handling) event (fired exactly for this case) in `app-shell.ts` and show a confirmation dialog explaining that a new version was released, offering a reload. On confirm, the `onbeforeunload` prompt is skipped (the user just confirmed) and the page reloads, picking up the new build.

A dialog instead of the silent `location.reload()` from the Vite docs, so users editing a map aren't blindly reloaded mid-work and get a chance to save first.

## Verification

- `tsc --noEmit` clean, `npm test` 202/202, `biome check` clean, production build ok
- Headless end-to-end repro: served `dist/`, generated a map, deleted `world-configurator-*.js` from the server (simulating a new deploy), opened the World Configurator → recovery dialog appears; clicking **Reload** refreshes the page and the World Configurator then opens normally
