### PR TITLE
fix(routes): guard against a missing reverse link when removing a route

### DIFF
--- a/src/generators/routes-generator.test.ts
+++ b/src/generators/routes-generator.test.ts
@@ -470,3 +470,36 @@ describe("RoutesModule.addMeandering", () => {
     }
   });
 });
+
+describe("RoutesModule.remove", () => {
+  let Routes: any;
+
+  beforeEach(async () => {
+    globalThis.TIME = false;
+    globalThis.window = globalThis.window || ({} as any);
+    // d3 select() needs a document in the node env
+    globalThis.document = { querySelector: () => null, documentElement: {} } as any;
+    globalThis.pack = { cells: {}, routes: [] } as any;
+    await import("./routes-generator");
+    Routes = (globalThis as any).Routes;
+  });
+
+  it("removes a route when the link index is asymmetric (reverse cell absent)", () => {
+    globalThis.pack.routes = [
+      {
+        i: 1,
+        group: "roads",
+        points: [
+          [0, 0, 10],
+          [0, 0, 20]
+        ]
+      }
+    ] as any;
+    // asymmetric index: forward link 10->20 exists but cell 20 has no reverse entry
+    globalThis.pack.cells.routes = { 10: { 20: 1 } } as any;
+
+    expect(() => Routes.remove(globalThis.pack.routes[0])).not.toThrow();
+    expect(globalThis.pack.routes).toHaveLength(0);
+    expect(globalThis.pack.cells.routes[10][20]).toBeUndefined();
+  });
+});

--- a/src/generators/routes-generator.ts
+++ b/src/generators/routes-generator.ts
@@ -808,8 +808,9 @@ class RoutesModule {
 
       for (const [to, routeId] of Object.entries(routes[from])) {
         if (routeId === route.i) {
-          delete routes[from][parseInt(to, 10)];
-          delete routes[parseInt(to, 10)][from];
+          const toCell = parseInt(to, 10);
+          delete routes[from][toCell];
+          if (routes[toCell]) delete routes[toCell][from];
         }
       }
     }


### PR DESCRIPTION
## Problem

"Remove all routes" (Routes Overview) fails on some maps: clicking **Remove** in the confirmation shows the warning but neither closes the dialog nor deletes the routes. Deleting routes **one by one still works**.

## Root cause

`RoutesModule.remove()` deletes the reverse link without checking it exists:

```js
delete routes[from][parseInt(to, 10)];
delete routes[parseInt(to, 10)][from];   // throws if routes[to] is undefined
```

The link index (`pack.cells.routes`) is loaded from the save as-is and can be inconsistent — a forward link `from -> to` with no reverse entry for `to`. On a real 1.139.8 map (attached repro), **1117 of 2016 links are dangling**. `delete undefined[from]` throws `TypeError: Cannot convert undefined or null to object`.

That exception fires inside the "Remove all" confirm handler *before* `dialog("close")`, so the loop aborts: the dialog stays open and nothing is removed. Single removal works because it only touches one route's links and typically avoids a dangling one.

## Fix

Guard the reverse delete:

```js
const toCell = parseInt(to, 10);
delete routes[from][toCell];
if (routes[toCell]) delete routes[toCell][from];
```

Removal is then robust to an asymmetric index. Verified end-to-end on the affected map: 117 → 0 routes, dialog closes, no errors.

## Test

Adds a regression test in `routes-generator.test.ts` that builds an asymmetric index (`{10:{20:1}}`, no entry for cell 20) and asserts `remove()` doesn't throw and clears the route. Fails on `master` with the exact `Cannot convert undefined or null to object`; passes with the guard.
