### PR TITLE
feat: support URL parameters for layer presets and visibility (#1530)

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -375,10 +375,10 @@ async function generateMapOnLoad() {
 
 // focus on coordinates, cell or burg provided in searchParams
 function focusOn() {
-  if (typeof applyURLLayers === "function") applyURLLayers();
-
   const url = new URL(window.location.href);
   const params = url.searchParams;
+
+  applyURLLayers(params);
 
   const fromMGCG = params.get("from") === "MFCG" && document.referrer;
   if (fromMGCG) {

--- a/public/main.js
+++ b/public/main.js
@@ -375,6 +375,8 @@ async function generateMapOnLoad() {
 
 // focus on coordinates, cell or burg provided in searchParams
 function focusOn() {
+  if (typeof applyURLLayers === "function") applyURLLayers();
+
   const url = new URL(window.location.href);
   const params = url.searchParams;
 

--- a/public/modules/ui/layers.js
+++ b/public/modules/ui/layers.js
@@ -1064,12 +1064,11 @@ function getLayer(id) {
   if (id === "toggleRulers") return $("#ruler");
 }
 
-function applyURLLayers() {
-  const params = new URL(window.location.href).searchParams;
-  const presetParam = params.get("layerPreset") || params.get("layersPreset");
-  const visibleParam = params.get("layersVisible");
+function applyURLLayers(params) {
+  const presetParam = params.get("preset");
+  const layersParam = params.get("layers");
 
-  if (!presetParam && !visibleParam) return;
+  if (!presetParam && !layersParam) return;
 
   const normalize = str => str.toLowerCase().replace(/[^a-z0-9]/g, "");
 
@@ -1099,17 +1098,15 @@ function applyURLLayers() {
     }
   }
 
-  if (visibleParam) {
-    const visibleNames = visibleParam.split(",").map(s => normalize(s));
+  if (layersParam) {
+    const visibleNames = layersParam.split(",").map(s => normalize(s));
     document.querySelectorAll("#mapLayers > li").forEach(el => {
       const idNormalized = normalize(el.id);
       const idWithoutToggleNormalized = normalize(el.id.replace(/^toggle/, ""));
       const textNormalized = normalize(el.innerText || el.textContent || "");
 
-      const shouldBeOn = visibleNames.some(name =>
-        name === idNormalized ||
-        name === idWithoutToggleNormalized ||
-        name === textNormalized
+      const shouldBeOn = visibleNames.some(
+        name => name === idNormalized || name === idWithoutToggleNormalized || name === textNormalized
       );
 
       const isOn = layerIsOn(el.id);

--- a/public/modules/ui/layers.js
+++ b/public/modules/ui/layers.js
@@ -1063,3 +1063,59 @@ function getLayer(id) {
   if (id === "toggleTrade") return $("#tradeAnimation");
   if (id === "toggleRulers") return $("#ruler");
 }
+
+function applyURLLayers() {
+  const params = new URL(window.location.href).searchParams;
+  const presetParam = params.get("layerPreset") || params.get("layersPreset");
+  const visibleParam = params.get("layersVisible");
+
+  if (!presetParam && !visibleParam) return;
+
+  const normalize = str => str.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+  if (presetParam) {
+    let matchedPreset = null;
+    const lowerParam = presetParam.toLowerCase().trim();
+    for (const key in presets) {
+      if (key.toLowerCase() === lowerParam) {
+        matchedPreset = key;
+        break;
+      }
+    }
+    if (!matchedPreset) {
+      const selectEl = document.getElementById("layersPreset");
+      if (selectEl) {
+        for (const option of selectEl.options) {
+          const optionText = option.text.toLowerCase();
+          if (optionText.includes(lowerParam) || lowerParam.includes(optionText)) {
+            matchedPreset = option.value;
+            break;
+          }
+        }
+      }
+    }
+    if (matchedPreset) {
+      handleLayersPresetChange(matchedPreset);
+    }
+  }
+
+  if (visibleParam) {
+    const visibleNames = visibleParam.split(",").map(s => normalize(s));
+    document.querySelectorAll("#mapLayers > li").forEach(el => {
+      const idNormalized = normalize(el.id);
+      const idWithoutToggleNormalized = normalize(el.id.replace(/^toggle/, ""));
+      const textNormalized = normalize(el.innerText || el.textContent || "");
+
+      const shouldBeOn = visibleNames.some(name =>
+        name === idNormalized ||
+        name === idWithoutToggleNormalized ||
+        name === textNormalized
+      );
+
+      const isOn = layerIsOn(el.id);
+      if (shouldBeOn && !isOn) el.click();
+      if (isOn && !shouldBeOn) el.click();
+    });
+  }
+}
+


### PR DESCRIPTION
# Description

Adds support for loading layer presets or specific lists of visible layers via URL parameters on load (#1530).

### Parameters

- `preset`: applies a preset on load (e.g., ?preset=Religions Map). 

Matches keys case-insensitively or by display name.

- `layers`: toggles only the listed layers on and hides the rest (e.g., ?layers=provinces,borders,lakes,rivers). 

Matches against element IDs (with or without the "toggle" prefix) and display text.

### Changes

- Added `applyURLLayers(params)` in public/modules/ui/layers.js to parse the URL parameters and toggle the layer buttons.

- Called `applyURLLayers(params)` from `focusOn()` in public/main.js , and layers are updated once map generation or data loading completes