### PR TITLE
Wheel-zoom and drag-pan for the burg preview

### DIFF
--- a/src/controllers/burg-editor.ts
+++ b/src/controllers/burg-editor.ts
@@ -5,6 +5,7 @@ import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
 import { drawLabels } from "@/renderers/labels/labels-renderer";
 import { getHeight, openURL, speak } from "@/utils";
+import { MAX_ZOOM, PAN_ZOOM_IDENTITY, type PanZoom, panBy, zoomAt } from "@/utils/panZoomUtils";
 import type { Burg } from "../generators/burgs-generator";
 import {
   convertTemperature,
@@ -20,6 +21,11 @@ import type { PromptOptions } from "../utils/commonUtils";
 declare const prompt: (text: string, options: PromptOptions, callback: (value: string | number) => void) => void;
 
 let selected: Selection<any, any, any, any> | null = null;
+let previewTransform: PanZoom = { ...PAN_ZOOM_IDENTITY };
+let previewMaxZoom = MAX_ZOOM;
+let previewCommittedK = 1;
+let previewSettleTimer = 0;
+let previewLayoutLocked = false;
 
 function open(id: number | string): void {
   if (customization) return;
@@ -179,14 +185,18 @@ function renderDialog(): void {
             </div>
           </div>
         </div>
-        <div id="burgPreviewSection" data-tip="Burg map preview" style="display: flex; flex-direction: column">
+        <div id="burgPreviewSection" data-tip="Burg map preview: scroll to zoom, drag to pan" style="display: flex; flex-direction: column">
           <div style="display: flex; justify-content: space-between">
             <span>Burg preview:</span>
             <div style="display: flex; gap: 0.5em">
+              <i id="burgPreviewReset" data-tip="Reset preview zoom" class="icon-ccw pointer"></i>
               <i id="burgLinkOpen" data-tip="Open burg map in a new tab" class="icon-link-ext pointer"></i>
             </div>
           </div>
-          <div id="burgPreviewObject" style="pointer-events: none"></div>
+          <div
+            id="burgPreviewObject"
+            style="overflow: hidden; position: relative; touch-action: none; height: 320px; max-width: 60vw; max-height: 60vh"
+          ></div>
         </div>
       </div>
       <div id="burgBottom">
@@ -248,6 +258,10 @@ function renderDialog(): void {
     .querySelectorAll<HTMLElement>(".burgFeature")
     .forEach(el => void el.addEventListener("click", toggleFeature));
   ensureEl("burgLinkOpen").addEventListener("click", openBurgLink);
+  ensureEl("burgPreviewReset").addEventListener("click", resetPreviewZoom);
+  ensureEl("burgPreviewObject").addEventListener("wheel", onPreviewWheel as EventListener, { passive: false });
+  ensureEl("burgPreviewObject").addEventListener("dblclick", onPreviewDoubleClick as EventListener);
+  ensureEl("burgPreviewObject").addEventListener("pointerdown", onPreviewPointerDown as EventListener);
 
   ensureEl("burgStyleShow").addEventListener("click", showStyleSection);
   ensureEl("burgStyleHide").addEventListener("click", hideStyleSection);
@@ -521,6 +535,115 @@ function editGroupAnchorStyle(): void {
   editStyle("anchors", g.id);
 }
 
+function getPreviewViewport(): { width: number; height: number } {
+  const container = ensureEl("burgPreviewObject");
+  return { width: container.clientWidth, height: container.clientHeight };
+}
+
+// mid-gesture the frame is scaled with a cheap transform; the layout size is committed
+// only once the gesture settles, as generators re-render asynchronously on resize.
+// canvas-backed generators (watabou) never commit at all: resizing clears their canvas
+// to transparent until the next redraw, so their layout is locked at a supersampled
+// size on load and zoom stays a pure transform of it
+function applyPreviewTransform(): void {
+  const container = ensureEl("burgPreviewObject");
+  const frame = container.querySelector<HTMLIFrameElement>("iframe");
+  if (!frame) return;
+  const { k, x, y } = previewTransform;
+  frame.style.transformOrigin = "0 0";
+  frame.style.transform = `translate(${x}px, ${y}px) scale(${k / previewCommittedK})`;
+  frame.style.left = "0";
+  frame.style.top = "0";
+  container.style.cursor = k > 1 ? "grab" : "default";
+  clearTimeout(previewSettleTimer);
+  if (!previewLayoutLocked) previewSettleTimer = window.setTimeout(commitPreviewTransform, 200);
+}
+
+function commitPreviewTransform(): void {
+  if (previewLayoutLocked) return;
+  const frame = ensureEl("burgPreviewObject").querySelector<HTMLIFrameElement>("iframe");
+  if (!frame) return;
+  const { k, x, y } = previewTransform;
+  previewCommittedK = k;
+  frame.style.width = `${k * 100}%`;
+  frame.style.height = `${k * 100}%`;
+  frame.style.transform = "none";
+  frame.style.left = `${x}px`;
+  frame.style.top = `${y}px`;
+}
+
+function resetPreviewZoom(): void {
+  previewTransform = { ...PAN_ZOOM_IDENTITY };
+  clearTimeout(previewSettleTimer);
+  if (previewLayoutLocked) applyPreviewTransform();
+  else commitPreviewTransform();
+  ensureEl("burgPreviewObject").style.cursor = "default";
+}
+
+function previewPointFromEvent(event: MouseEvent): { x: number; y: number } {
+  const rect = ensureEl("burgPreviewObject").getBoundingClientRect();
+  return { x: event.clientX - rect.left, y: event.clientY - rect.top };
+}
+
+function onPreviewWheel(event: WheelEvent): void {
+  event.preventDefault();
+  const factor = Math.exp(-event.deltaY * (event.deltaMode === 1 ? 0.05 : event.deltaMode ? 1 : 0.002));
+  previewTransform = zoomAt(
+    previewTransform,
+    previewPointFromEvent(event),
+    factor,
+    getPreviewViewport(),
+    previewMaxZoom
+  );
+  applyPreviewTransform();
+}
+
+function onPreviewDoubleClick(event: MouseEvent): void {
+  previewTransform = zoomAt(previewTransform, previewPointFromEvent(event), 2, getPreviewViewport(), previewMaxZoom);
+  applyPreviewTransform();
+}
+
+function onPreviewPointerDown(event: PointerEvent): void {
+  if (previewTransform.k <= 1) return;
+  event.preventDefault();
+  const container = ensureEl("burgPreviewObject");
+  container.setPointerCapture(event.pointerId);
+  container.style.cursor = "grabbing";
+  let last = { x: event.clientX, y: event.clientY };
+
+  const move = (e: Event) => {
+    const p = e as PointerEvent;
+    previewTransform = panBy(previewTransform, p.clientX - last.x, p.clientY - last.y, getPreviewViewport());
+    last = { x: p.clientX, y: p.clientY };
+    applyPreviewTransform();
+  };
+  const up = () => {
+    container.removeEventListener("pointermove", move);
+    container.removeEventListener("pointerup", up);
+    container.removeEventListener("pointercancel", up);
+    container.style.cursor = "grab";
+  };
+  container.addEventListener("pointermove", move);
+  container.addEventListener("pointerup", up);
+  container.addEventListener("pointercancel", up);
+}
+
+let glMaxTextureSize = 0;
+function getGlMaxTextureSize(): number {
+  if (!glMaxTextureSize) {
+    const gl = document.createElement("canvas").getContext("webgl");
+    glMaxTextureSize = gl ? (gl.getParameter(gl.MAX_TEXTURE_SIZE) as number) : 4096;
+  }
+  return glMaxTextureSize;
+}
+
+// half the reported limit: the generator's internal render textures pad past the raw canvas size
+function getPreviewTextureBudgetK(): number {
+  const { width, height } = getPreviewViewport();
+  const paneMax = Math.max(width, height, 1);
+  return getGlMaxTextureSize() / 2 / (devicePixelRatio * paneMax);
+}
+
 function updateBurgPreview(burg: Burg): void {
   const preview = Burgs.getPreview(burg).preview;
   if (!preview) {
@@ -530,15 +653,29 @@ function updateBurgPreview(burg: Burg): void {
 
   ensureEl("burgPreviewSection").style.display = "block";
 
-  // recreate object to force reload (Chrome bug)
+  // recreate the element to force reload (Chrome bug)
   const container = ensureEl("burgPreviewObject");
   container.innerHTML = "";
-  const object = document.createElement("object");
-  object.style.width = "100%";
-  object.style.maxWidth = "60vw";
-  object.style.maxHeight = "60vh";
-  object.data = preview;
-  container.insertBefore(object, null);
+  const frame = document.createElement("iframe");
+  frame.style.position = "absolute";
+  frame.style.border = "none";
+  frame.style.pointerEvents = "none";
+  frame.setAttribute("sandbox", "allow-scripts allow-same-origin");
+  frame.src = preview;
+  container.insertBefore(frame, null);
+
+  previewLayoutLocked = preview.includes("watabou.github.io");
+  if (previewLayoutLocked) {
+    const supersample = Math.max(1, Math.min(4, getPreviewTextureBudgetK()));
+    previewCommittedK = supersample;
+    frame.style.width = `${supersample * 100}%`;
+    frame.style.height = `${supersample * 100}%`;
+    previewMaxZoom = Math.min(MAX_ZOOM, supersample * 2.5);
+  } else {
+    previewCommittedK = 1;
+    previewMaxZoom = MAX_ZOOM;
+  }
+  resetPreviewZoom();
 }
 
 function openBurgLink(): void {

--- a/src/utils/panZoomUtils.test.ts
+++ b/src/utils/panZoomUtils.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { clampPanZoom, MAX_ZOOM, MIN_ZOOM, PAN_ZOOM_IDENTITY, panBy, zoomAt } from "./panZoomUtils";
+
+const viewport = { width: 400, height: 320 };
+
+describe("zoomAt", () => {
+  it("keeps the content point under the cursor fixed while zooming", () => {
+    const t = zoomAt(PAN_ZOOM_IDENTITY, { x: 100, y: 80 }, 2, viewport);
+    expect(t).toEqual({ k: 2, x: -100, y: -80 });
+  });
+
+  it("compounds zooms toward different points", () => {
+    const once = zoomAt(PAN_ZOOM_IDENTITY, { x: 100, y: 80 }, 2, viewport);
+    const twice = zoomAt(once, { x: 200, y: 160 }, 2, viewport);
+    expect(twice).toEqual({ k: 4, x: -400, y: -320 });
+  });
+
+  it("clamps scale at MAX_ZOOM and anchors with the clamped factor", () => {
+    const t = zoomAt(PAN_ZOOM_IDENTITY, { x: 100, y: 80 }, 1000, viewport);
+    expect(t).toEqual({ k: MAX_ZOOM, x: -3100, y: -2480 });
+  });
+
+  it("clamps scale at MIN_ZOOM and recentres to identity", () => {
+    const t = zoomAt({ k: 1, x: 0, y: 0 }, { x: 200, y: 160 }, 0.5, viewport);
+    expect(t).toEqual({ k: MIN_ZOOM, x: 0, y: 0 });
+  });
+
+  it("re-clamps pan when zooming out from a corner", () => {
+    const cornered = { k: 4, x: -1200, y: -960 };
+    const t = zoomAt(cornered, { x: 0, y: 0 }, 0.25, viewport);
+    expect(t).toEqual({ k: 1, x: 0, y: 0 });
+  });
+
+  it("honours a per-call maxK below MAX_ZOOM, anchoring with the clamped factor", () => {
+    const t = zoomAt(PAN_ZOOM_IDENTITY, { x: 100, y: 80 }, 1000, viewport, 3);
+    expect(t).toEqual({ k: 3, x: -200, y: -160 });
+  });
+
+  it("never lets maxK drop below MIN_ZOOM", () => {
+    const t = zoomAt(PAN_ZOOM_IDENTITY, { x: 100, y: 80 }, 2, viewport, 0.5);
+    expect(t).toEqual({ k: MIN_ZOOM, x: 0, y: 0 });
+  });
+});
+
+describe("panBy", () => {
+  it("moves the content by the pointer delta", () => {
+    const zoomed = { k: 2, x: -100, y: -80 };
+    const t = panBy(zoomed, -50, 30, viewport);
+    expect(t).toEqual({ k: 2, x: -150, y: -50 });
+  });
+
+  it("clamps pan at all four edges", () => {
+    const zoomed = { k: 2, x: -100, y: -80 };
+    expect(panBy(zoomed, 9999, 9999, viewport)).toEqual({ k: 2, x: 0, y: 0 });
+    expect(panBy(zoomed, -9999, -9999, viewport)).toEqual({ k: 2, x: -400, y: -320 });
+  });
+
+  it("cannot pan at 1x", () => {
+    expect(panBy(PAN_ZOOM_IDENTITY, 40, 40, viewport)).toEqual(PAN_ZOOM_IDENTITY);
+  });
+});
+
+describe("clampPanZoom", () => {
+  it("returns offsets to zero at scale 1", () => {
+    expect(clampPanZoom({ k: 1, x: -50, y: 20 }, viewport)).toEqual({ k: 1, x: 0, y: 0 });
+  });
+});

--- a/src/utils/panZoomUtils.ts
+++ b/src/utils/panZoomUtils.ts
@@ -1,0 +1,42 @@
+import { minmax } from "./numberUtils";
+
+export interface PanZoom {
+  k: number;
+  x: number;
+  y: number;
+}
+
+export interface Viewport {
+  width: number;
+  height: number;
+}
+
+export const MIN_ZOOM = 1;
+export const MAX_ZOOM = 32;
+export const PAN_ZOOM_IDENTITY: PanZoom = { k: 1, x: 0, y: 0 };
+
+// keep the scaled content covering the whole viewport
+export function clampPanZoom({ k, x, y }: PanZoom, viewport: Viewport): PanZoom {
+  return {
+    k,
+    x: minmax(x, viewport.width * (1 - k), 0),
+    y: minmax(y, viewport.height * (1 - k), 0)
+  };
+}
+
+// rescale by factor keeping the content point under `point` fixed
+export function zoomAt(
+  t: PanZoom,
+  point: { x: number; y: number },
+  factor: number,
+  viewport: Viewport,
+  maxK = MAX_ZOOM
+): PanZoom {
+  const k = minmax(t.k * factor, MIN_ZOOM, Math.max(MIN_ZOOM, maxK));
+  const ratio = k / t.k;
+  return clampPanZoom({ k, x: point.x - (point.x - t.x) * ratio, y: point.y - (point.y - t.y) * ratio }, viewport);
+}
+
+export function panBy(t: PanZoom, dx: number, dy: number, viewport: Viewport): PanZoom {
+  return clampPanZoom({ k: t.k, x: t.x + dx, y: t.y + dy }, viewport);
+}


### PR DESCRIPTION
Adds interactive zoom to the burg editor's preview pane: mouse wheel zooms toward the cursor, dragging pans when zoomed in, double-click zooms a step, and a ⟲ icon next to the open-in-new-tab icon resets to the 1x fit. The pane keeps its current inert behavior otherwise — the embedded page never receives pointer events, so scrolling the dialog and interacting with the editor are unaffected.

**How it zooms.** Zoom rests on the embedded frame's layout size rather than a CSS transform — a cross-origin frame is composited as a raster texture, so `transform: scale()` blurs it at any zoom, while a larger viewport makes the embedded generator re-render at the real size. Because generators re-render asynchronously on resize, the frame is transform-scaled during the gesture and the layout is committed once the wheel/drag settles.

**Watabou previews get a locked layout.** Resizing a canvas clears it to transparent until the next redraw (a visible blank on every commit), and oversizing it trips the GPU texture limit inside watabou's render loop (`texImage2D` failing every frame). So for watabou URLs the frame's layout is committed **once at load**, supersampled to up to 4× the pane (bounded by half the GPU's `MAX_TEXTURE_SIZE` ÷ devicePixelRatio), and zoom stays a pure transform of that fixed layout: crisp up to the supersample, gradually softer beyond it (cap 2.5× past it), never blank and never over-allocating.

**Details**
- The preview `<object>` is replaced with a sandboxed `<iframe>`.
- Wheel deltas are normalized per `deltaMode` (same branch d3-zoom uses), so Firefox's line-mode wheel zooms at the same rate as Chrome's pixel-mode.
- The preview pane now has an explicit 320px height (the bare `<object>` previously fell back to the replaced-element default).
- The transform math (zoom-toward-point, pan clamping so the content always covers the pane) is a small pure module, `src/utils/panZoomUtils.ts`, with unit tests.

Zoom state resets whenever the preview reloads (burg switch, custom link change).