### PR TITLE
fix: restore options.labels and options.burgs when loading an old map

### DIFF
--- a/src/services/io/load.ts
+++ b/src/services/io/load.ts
@@ -289,6 +289,8 @@ async function parseLoadedData(data: string[], mapVersion: string | null): Promi
       options.mapSize ??= 100;
       options.latitude ??= 50;
       options.prec ??= 100;
+      options.labels ??= Labels.getDefaultOptions();
+      options.burgs ??= { groups: Burgs.getDefaultGroups() };
       // setting 16 and 17 (temperature) are part of options now, kept as "" in newer versions for compatibility
       if (settings[16]) options.temperatureEquator = +settings[16];
       if (settings[17]) options.temperatureNorthPole = options.temperatureSouthPole = +settings[17];


### PR DESCRIPTION
Loading a sufficiently old map on `master` fails with

```
TypeError: Cannot read properties of undefined (reading 'groups')
```

and drops into the "Loading error" dialog.

### Cause

`parseLoadedData` assigns `options = JSON.parse(settings[19])`, replacing the whole object rather than merging into it. A map saved before `options.labels` / `options.burgs` existed therefore leaves both `undefined`.

`resolveVersionConflicts` does recreate them, but its migration blocks run in file order and the older ones toggle layers on the way there. `turnButtonOn` calls `ViewportLayers.renderNow()`, and `reconcileLabels` reads `options.labels.groups` — so the throw happens before the map reaches its own 1.140 migration.

The wholesale replace is long-standing; it only became a crash in 1.140, when `ViewportLayers` gave `turnButtonOn` something to render.

### Fix

Default both alongside the `mapSize` / `latitude` / `prec` fallbacks already applied a few lines above. `options.burgs` is included because it is the same hole and the burg-group code makes the same assumption.

### Reproduction

On `master`, load a map old enough that its saved options predate these fields (reproduced with a v1.4 map):

| | `master` | with this patch |
|---|---|---|
| Loading error dialog | shown | not shown |
| `options.labels` | `undefined` | `groups: 7` |
| State labels rendered | 0 | 156 |
| Console errors | 1 | 0 |

No change for current maps — verified against `tests/fixtures/1.139.4.map` (15 groups, 20 state labels) and `tests/fixtures/demo.map` (14 groups, 18 state labels), both loading clean before and after.

`tsc --noEmit` clean, 234 unit tests pass, biome clean.
