### PR TITLE
Don't anchor a river label on an off-map cell

### DIFF
--- a/src/renderers/labels/label-data.test.ts
+++ b/src/renderers/labels/label-data.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getLabelsData } from "./label-data";
+
+// river.cells carries -1 as a sentinel for "runs off the map edge" (see river-generator,
+// which resolves it with projectToNearestEdge). Cell -1 has no entry in pack.cells.p.
+const CELL_POINTS: [number, number][] = [
+  [0, 0],
+  [10, 10],
+  [20, 20],
+  [30, 30]
+];
+
+function stubPack(rivers: unknown[]): void {
+  globalThis.pack = {
+    states: [],
+    provinces: [],
+    addedLabels: [],
+    burgs: [],
+    routes: [],
+    rivers,
+    cells: { p: CELL_POINTS }
+  } as any;
+  globalThis.options = { labels: { groups: [] } } as any;
+  // the label path is not under test here; only the anchor is
+  globalThis.Rivers = { addMeandering: () => [] } as any;
+}
+
+describe("river labels with off-map cells", () => {
+  beforeEach(() => {
+    stubPack([]);
+  });
+
+  it("anchors a two-cell river whose second cell runs off the map edge", () => {
+    // the middle of a 2-cell river is index 1, which is exactly where the sentinel sits
+    stubPack([{ i: 1, name: "Kobat", type: "River", cells: [2, -1], points: [] }]);
+
+    const labels = getLabelsData();
+
+    const river = labels.find(label => label.type === "river");
+    expect(river).toBeDefined();
+    expect(river?.anchor).toEqual([20, 20]); // the real cell, not the sentinel
+  });
+
+  it("anchors a single-cell river that only touches the edge", () => {
+    stubPack([{ i: 1, name: "Edge", type: "River", cells: [-1], points: [] }]);
+
+    expect(() => getLabelsData()).not.toThrow();
+  });
+
+  it("still anchors on the middle cell when no cell is off-map", () => {
+    stubPack([{ i: 1, name: "Inland", type: "River", cells: [0, 1, 2], points: [] }]);
+
+    const river = getLabelsData().find(label => label.type === "river");
+    expect(river?.anchor).toEqual([10, 10]);
+  });
+});

--- a/src/renderers/labels/label-data.ts
+++ b/src/renderers/labels/label-data.ts
@@ -85,6 +85,8 @@ function buildStateLabel(state: State): LabelData | undefined {
 
 function buildRiverLabel(river: River): LabelData | undefined {
   if (!river.cells.length || !river.name) return undefined;
+  const anchor = getMiddleCellPoint(river.cells);
+  if (!anchor) return undefined; // no on-map cell to anchor to
   const customPath = getCustomPath(river.label);
   const defaultPath = isPlainText(river.label)
     ? undefined
@@ -96,7 +98,7 @@ function buildRiverLabel(river: River): LabelData | undefined {
     type: "river",
     text: river.label?.text ?? `${river.name} ${river.type}`,
     group: river.label?.group || "river",
-    anchor: getMiddleCellPoint(river.cells),
+    anchor,
     pathPoints: customPath ?? defaultPath
   };
 }
@@ -168,7 +170,9 @@ function getMiddlePoint(points: number[][]): Point {
   return [x, y];
 }
 
-function getMiddleCellPoint(cells: number[]): Point {
-  const [x, y] = pack.cells.p[cells[Math.floor(cells.length / 2)]];
-  return [x, y];
+// river.cells uses -1 for a cell past the map edge, and it has no entry in cells.p
+function getMiddleCellPoint(cells: number[]): Point | undefined {
+  const onMap = cells.filter(cellId => cellId >= 0);
+  const point = pack.cells.p[onMap[Math.floor(onMap.length / 2)]];
+  return point && [point[0], point[1]];
 }


### PR DESCRIPTION
Loading a map fails with `TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))`, thrown from `getMiddleCellPoint` while building river labels. The whole load aborts.

### Cause

`river.cells` uses `-1` for a cell past the map edge. The river generator creates them:

```js
riverCells.push(-1);
```

and resolves them when it needs a position:

```js
// anchor positions per river cell (cell centers, or override anchors), with -1 cells resolved to the map edge
if (cell === -1) return projectToNearestEdge(p[riverCells[i - 1]], graphWidth, graphHeight);
```

`getMiddleCellPoint` treated every entry as a real cell index:

```ts
const [x, y] = pack.cells.p[cells[Math.floor(cells.length / 2)]];
```

`cells.p[-1]` is `undefined`, and destructuring it throws.

### When it triggers

The middle of a two-cell river is index 1 — exactly where the sentinel sits. So a river of one or two cells that reaches the map edge kills label building for the entire map.

This is ordinary data rather than corruption: on a freshly generated map, 47 of 315 rivers carried a `-1` cell. It only becomes fatal when the river is short enough that the sentinel lands on the midpoint, which is why it is rare but not exotic. I hit it loading a 1.108.11 map into 1.141.1 — one river out of 416 (`cells: [275, -1]`) took the whole load down — but a newly generated map with such a river fails the same way.

### Fix

Anchor on the middle of the on-map cells, and emit no label when a river has no on-map cell at all.

### Tests

Adds `label-data.test.ts` covering the two-cell river, the fully-off-map river, and a control with no sentinel so the anchor choice stays pinned. The first two fail on current master with the exact production error; the control passes both before and after.

Full suite green on master + this change: 283 tests, `tsc --noEmit` clean, `biome ci .` clean.