### PR TITLE
Fix: culture regenerate-name icon never appears on row hover

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -1569,7 +1569,7 @@ div.states .biomeHabitability {
   -moz-appearance: textfield;
 }
 
-div.states:hover > .hiddenIcon {
+div.states:hover .hiddenIcon {
   visibility: visible !important;
 }
 


### PR DESCRIPTION
## Bug

Since the cultures editor moved its cells into `data-col` wrappers, the per-culture "Regenerate culture name" icon (`icon-cw`) never appears: the reveal rule `div.states:hover > .hiddenIcon` is a direct-child selector, but the icon is now a grandchild of the row, so its inline `visibility: hidden` is never overridden. The click handler is still wired — the button is just permanently invisible (and invisible elements can't be clicked).

Reproduced on current master: open the Cultures editor and hover a row — no regenerate icon next to the name input.

## Fix

Relax the selector to a descendant combinator. The only other `.hiddenIcon` (markets overview remove icon) is a direct child of its row, so it matched before and still does.

## Verification

Headless-browser check on master: computed visibility of the icon is `hidden` at rest and on hover before the fix; after the fix it is `hidden` at rest, `visible` on row hover, and clicking it regenerates the culture name (input and `pack.cultures` update in sync).