### PR TITLE
Don't re-enable provinces, goods and trade layers on map load

### DIFF
--- a/src/renderers/draw-goods.ts
+++ b/src/renderers/draw-goods.ts
@@ -25,6 +25,7 @@ export function toggleGoods(event?: MouseEvent) {
   } else {
     if (event && isCtrlClick(event)) return editStyle("goodsIcons");
     SUBGROUPS.forEach(id => void select("#goods").select(`#${id}`).html(""));
+    select("#goods").style("display", "none");
     turnButtonOff("toggleGoods");
   }
 }

--- a/src/services/io/load.ts
+++ b/src/services/io/load.ts
@@ -493,7 +493,8 @@ async function parseLoadedData(data: string[], mapVersion: string | null): Promi
       const isVisible = (selection: { node(): Element | null; style(name: string): string }) =>
         selection.node() && selection.style("display") !== "none";
       const isVisibleNode = (node: SVGElement | HTMLElement | null) => node && node.style.display !== "none";
-      const hasChildren = (selection: { node(): Element | null }) => selection.node()?.hasChildNodes();
+      // element children only: cleared layers can retain whitespace text nodes
+      const hasChildren = (selection: { node(): Element | null }) => Boolean(selection.node()?.childElementCount);
       const hasChild = (selection: { node(): Element | null }, selector: string) =>
         selection.node()?.querySelector(selector);
       const turnOn = (el: string) => ensureEl(el).classList.remove("buttonoff");
@@ -532,8 +533,10 @@ async function parseLoadedData(data: string[], mapVersion: string | null): Promi
       if (isVisible(select("#icons"))) turnOn("toggleBurgIcons");
       if (hasChildren(armies) && isVisible(armies)) turnOn("toggleMilitary");
       if (hasChild(select("#markers"), "svg")) turnOn("toggleMarkers");
-      if (isVisible(select("#tradeAnimation"))) turnOn("toggleTrade");
-      if (isVisible(select("#goods")) && hasChildren(select("#goods"))) turnOn("toggleGoods");
+      // trade animation is transient and always stripped on save, so its state is kept as an attribute
+      if (select("#tradeAnimation").attr("data-layer-active") === "true") turnOn("toggleTrade");
+      // toggling goods off keeps the empty subgroups, so check for drawn content
+      if (isVisible(select("#goods")) && hasChild(select("#goods"), "g > *")) turnOn("toggleGoods");
       if (isVisible(select("#markets")) && hasChildren(select("#markets"))) turnOn("toggleMarketsLayer");
       if (isVisible(select("#ruler"))) turnOn("toggleRulers");
       if (isVisible(select("#scaleBar"))) turnOn("toggleScaleBar");

--- a/src/services/io/save.ts
+++ b/src/services/io/save.ts
@@ -96,7 +96,10 @@ function prepareMapData(): string {
   const cloneRuler = cloneEl.querySelector("#ruler");
   if (cloneRuler) cloneRuler.innerHTML = ""; // always remove rulers
   const cloneTradeAnimation = cloneEl.querySelector("#tradeAnimation");
-  if (cloneTradeAnimation) cloneTradeAnimation.innerHTML = ""; // always remove transient trade animations
+  if (cloneTradeAnimation) {
+    cloneTradeAnimation.innerHTML = ""; // always remove transient trade animations
+    cloneTradeAnimation.setAttribute("data-layer-active", String(layerIsOn("toggleTrade")));
+  }
 
   const serializedSVG = new XMLSerializer().serializeToString(cloneEl);
 

--- a/tests/e2e/layer-state-persistence.spec.ts
+++ b/tests/e2e/layer-state-persistence.spec.ts
@@ -1,0 +1,97 @@
+import {test, expect} from "@playwright/test";
+
+// page globals used inside page.evaluate
+declare const toggleProvinces: () => void;
+declare const toggleGoods: () => void;
+declare const toggleTrade: () => void;
+
+const getActiveLayers = () =>
+  Array.from(document.querySelectorAll("#mapLayers > li:not(.buttonoff)"))
+    .map(el => el.id)
+    .sort();
+
+test.describe("Layer state persistence", () => {
+  test("save and load keeps toggled-off layers off", async ({page}) => {
+    await page.goto("/");
+    await page.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+
+    await page.goto("/?seed=test-seed&&width=1280&height=720");
+    await page.waitForFunction(() => (window as any).mapId !== undefined, {timeout: 60000});
+    await page.waitForTimeout(500);
+
+    // exercise the layers reported to auto-enable on load (#1574):
+    // draw each once, then turn it off again before saving
+    await page.evaluate(() => {
+      toggleProvinces();
+      toggleGoods();
+      toggleTrade();
+    });
+    await page.evaluate(() => {
+      toggleProvinces();
+      toggleGoods();
+      toggleTrade();
+    });
+
+    const activeBeforeSave = await page.evaluate(getActiveLayers);
+    expect(activeBeforeSave).not.toContain("toggleProvinces");
+    expect(activeBeforeSave).not.toContain("toggleGoods");
+    expect(activeBeforeSave).not.toContain("toggleTrade");
+
+    const mapData: string = await page.evaluate(() => (window as any).Services.Save.prepareMapData());
+
+    // load the just-saved map; mapId is re-exposed at the very end of loading
+    await page.evaluate(() => {
+      (window as any).mapId = undefined;
+    });
+    await page.locator("#mapToLoad").setInputFiles({
+      name: "layer-state.map",
+      mimeType: "text/plain",
+      buffer: Buffer.from(mapData)
+    });
+    await page.waitForFunction(() => (window as any).mapId !== undefined, {timeout: 120000});
+    await page.waitForTimeout(500);
+
+    const activeAfterLoad = await page.evaluate(getActiveLayers);
+    expect(activeAfterLoad).toEqual(activeBeforeSave);
+  });
+
+  test("save and load keeps toggled-on layers on", async ({page}) => {
+    await page.goto("/");
+    await page.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+
+    await page.goto("/?seed=test-seed&&width=1280&height=720");
+    await page.waitForFunction(() => (window as any).mapId !== undefined, {timeout: 60000});
+    await page.waitForTimeout(500);
+
+    await page.evaluate(() => {
+      toggleProvinces();
+      toggleGoods();
+      toggleTrade();
+    });
+
+    const activeBeforeSave = await page.evaluate(getActiveLayers);
+    expect(activeBeforeSave).toEqual(expect.arrayContaining(["toggleProvinces", "toggleGoods", "toggleTrade"]));
+
+    const mapData: string = await page.evaluate(() => (window as any).Services.Save.prepareMapData());
+
+    await page.evaluate(() => {
+      (window as any).mapId = undefined;
+    });
+    await page.locator("#mapToLoad").setInputFiles({
+      name: "layer-state.map",
+      mimeType: "text/plain",
+      buffer: Buffer.from(mapData)
+    });
+    await page.waitForFunction(() => (window as any).mapId !== undefined, {timeout: 120000});
+    await page.waitForTimeout(500);
+
+    const activeAfterLoad = await page.evaluate(getActiveLayers);
+    expect(activeAfterLoad).toEqual(activeBeforeSave);
+  });
+});


### PR DESCRIPTION
Fixes #1574.

On load, layer button state is inferred from the saved SVG. Three of those checks read a signal that doesn't actually encode the layer state, so Provinces, Goods and Trade came back enabled even when they were off at save time:

- **Provinces**: `drawProvinces` writes `#provs` via a template literal, which leaves whitespace text nodes around the `<g>`. Toggling the layer off removes the elements but not those text nodes, and the load check used `hasChildNodes()`, which counts them. `hasChildren` now checks `childElementCount`, which also heals existing saved files.
- **Goods**: toggling goods off empties the three subgroups but keeps them as children of `#goods` (they must stay for the style editor), so the `hasChildren` check was always true once the layer had been drawn. The check now looks for actual drawn content (`g > *`), and toggling off also restores the group's initial `display: none`.
- **Trade**: the animation content is always stripped on save and `#tradeAnimation` is never hidden, so the saved SVG carried no trade state at all and the `isVisible` check was always true. Save now stamps `data-layer-active` on the group (same pattern as `#labels`) and load reads it. Old files without the attribute load with the layer off.

Added a Playwright spec that round-trips a save/load with these layers toggled off (and a second one with them on) and asserts the active-layer set is unchanged. Both fail on master and pass with this change; the rest of the e2e suite, unit tests and `tsc` are unaffected.
