### PR TITLE
Fix map load crash on rivers with no cells array

### DIFF
--- a/src/renderers/labels/label-data.test.ts
+++ b/src/renderers/labels/label-data.test.ts
@@ -53,4 +53,12 @@ describe("river labels with off-map cells", () => {
     const river = getLabelsData().find(label => label.type === "river");
     expect(river?.anchor).toEqual([10, 10]);
   });
+
+  // old saves can carry rivers whose cells array was never assigned
+  it("skips a river that has no cells array", () => {
+    stubPack([{ i: 1, name: "Colorado", type: "River" }]);
+
+    expect(() => getLabelsData()).not.toThrow();
+    expect(getLabelsData().find(label => label.type === "river")).toBeUndefined();
+  });
 });

--- a/src/renderers/labels/label-data.ts
+++ b/src/renderers/labels/label-data.ts
@@ -84,7 +84,7 @@ function buildStateLabel(state: State): LabelData | undefined {
 }
 
 function buildRiverLabel(river: River): LabelData | undefined {
-  if (!river.cells.length || !river.name) return undefined;
+  if (!river.cells?.length || !river.name) return undefined;
   const anchor = getMiddleCellPoint(river.cells);
   if (!anchor) return undefined; // no on-map cell to anchor to
   const customPath = getCustomPath(river.label);


### PR DESCRIPTION
Loading some pre-1.140 maps fails with the generic load-error dialog:

```
TypeError: Cannot read properties of undefined (reading 'length')
```

thrown from `buildRiverLabel`, aborting the whole load.

### Cause

Old saves can carry rivers with no `cells` array at all. It's a legacy artifact: the v1.65 migration in auto-update skips assigning `cells` when a river's rendered path had zero length (`if (!length) continue`) or its SVG node was missing, and every later save carries that forward. Repro'd with a stock 1.139.10 map that contains two such rivers.

Since v1.140 the label migration calls `drawLabels()` during load, so the unguarded `river.cells.length` aborts the entire map load instead of just skipping one label.

### Fix

Optional-chain the guard (`river.cells?.length`) so a cells-less river simply gets no label — same defensive approach as the off-map `-1` sentinel fix (#1575) in this function.

### Verification

- Added a regression test that fails without the guard; 4/4 pass in `label-data.test.ts`
- `tsc --noEmit` and biome clean
- The crashing 1.139.10 map now loads end-to-end (headless check: correct seed, all 114 rivers, 1761 burgs, 352 states, no console errors)