### PR TITLE
Fix custom heightmap color scheme lookup

### DIFF
--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -67,7 +67,7 @@ function addCustomColorScheme(scheme) {
 function getColorScheme(scheme) {
   if (!scheme) scheme = "bright";
   if (!(scheme in heightmapColorSchemes)) {
-    const colors = schemescheme.split(",");
+    const colors = scheme.split(",");
     heightmapColorSchemes[scheme] = d3.scaleSequential(d3.interpolateRgbBasis(colors));
   }
 


### PR DESCRIPTION
cd884f01 renamed the variable read in getColorScheme to `schemescheme`, so loading any map that uses a custom heightmap color scheme throws `ReferenceError: schemescheme is not defined`. This restores the variable name.