### PR TITLE
fix: make cache clearing and update notifications work

### DIFF
--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -8,7 +8,7 @@
  *   - src/services/versioning.ts — VERSION constant
  *   - package.json           — "version" field
  *   - package-lock.json      — top-level "version" and packages[""].version fields
- *   - src/index.html         — ?v= cache-busting hashes for changed public/*.js files
+ *   - src/index.html         — ?v= cache-busting hashes for changed public/*.{js,css} files
  *   - public/**\/*.js        — ?v= cache-busting hashes in dynamic import() calls
  *
  * Usage:
@@ -76,19 +76,19 @@ function isVersionGreater(versionA, versionB) {
 }
 
 /**
- * Returns public/*.js paths (relative to repo root) that have changed.
+ * Returns public/*.{js,css} paths (relative to repo root) that have changed.
  * Checks (in order, deduplicating):
  *   1. Upstream branch diff  — catches everything on a feature/PR branch
  *   2. Staged (index) diff   — catches files staged but not yet committed
  *   3. Last-commit diff      — fallback for main / detached HEAD
  */
-function getChangedPublicJsFiles() {
+function getChangedPublicAssets() {
   const run = cmd => execSync(cmd, {encoding: "utf8", cwd: repoRoot});
   const parseFiles = output =>
     output
       .split("\n")
       .map(f => f.trim())
-      .filter(f => f.startsWith("public/") && f.endsWith(".js"));
+      .filter(f => f.startsWith("public/") && /\.(js|css)$/.test(f));
 
   const seen = new Set();
   const collect = files => files.forEach(f => seen.add(f));
@@ -291,7 +291,7 @@ async function main() {
       `\n[bump-version] Version already updated manually: ${baseVersion} → ${currentVersion} (base was ${baseVersion})\n`
     );
     console.log("  Skipping version increment — updating ?v= hashes only.\n");
-    const changedFiles = getChangedPublicJsFiles();
+    const changedFiles = getChangedPublicAssets();
     updateIndexHtmlHashes(changedFiles, currentVersion, dry);
     updatePublicJsDynamicImportHashes(changedFiles, currentVersion, dry);
     console.log(`\n[bump-version] ${dry ? "(dry run) " : ""}done.\n`);
@@ -310,7 +310,7 @@ async function main() {
 
   console.log(`\n[bump-version] ${bumpType}: ${currentVersion}  →  ${newVersion}\n`);
 
-  const changedFiles = getChangedPublicJsFiles();
+  const changedFiles = getChangedPublicAssets();
   updateVersioningTs(newVersion, dry);
   updatePackageJson(newVersion, dry);
   updatePackageLockJson(newVersion, dry);

--- a/src/services/io/load.ts
+++ b/src/services/io/load.ts
@@ -6,7 +6,7 @@ import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { clearLegend } from "@/renderers/draw-legend";
 import { Services } from "@/services";
 import { declareFont } from "@/services/fonts";
-import { cleanupData, compareVersions, isValidVersion, parseMapVersion, VERSION } from "@/services/versioning";
+import { clearCache, compareVersions, isValidVersion, parseMapVersion, VERSION } from "@/services/versioning";
 import { applyOption, calculateVoronoi, ensureEl, last, link, minmax, parseError, rn } from "@/utils";
 
 async function quickLoad(): Promise<void> {
@@ -113,7 +113,7 @@ function showUploadErrorMessage(error: string, maplink: string, random?: boolean
     title: "Loading error",
     width: "32em",
     buttons: {
-      "Clear cache": () => cleanupData(),
+      "Clear cache": () => clearCache(),
       OK: function (this: HTMLElement) {
         $(this).dialog("close");
       }
@@ -228,7 +228,7 @@ function showUploadMessage(type: string, mapData: string[] | null, mapVersion: s
   $("#alert").dialog({
     title,
     buttons: {
-      "Clear cache": () => cleanupData(),
+      "Clear cache": () => clearCache(),
       OK: function (this: HTMLElement) {
         $(this).dialog("close");
       }
@@ -723,7 +723,7 @@ async function parseLoadedData(data: string[], mapVersion: string | null): Promi
       title: "Loading error",
       maxWidth: "40em",
       buttons: {
-        "Clear cache": () => cleanupData(),
+        "Clear cache": () => clearCache(),
         "Select file": function (this: HTMLElement) {
           $(this).dialog("close");
           ensureEl("mapToLoad").click();

--- a/src/services/versioning.ts
+++ b/src/services/versioning.ts
@@ -15,6 +15,8 @@
  * For the changes that may be interesting to end users, update the `latestPublicChanges` array below (new changes on top).
  */
 
+import { tip } from "@/components/tooltips";
+
 export const VERSION = "1.145.2";
 
 const latestPublicChanges = [
@@ -86,20 +88,26 @@ export function compareVersions(
   return { isEqual, isNewer, isOlder };
 }
 
-export async function cleanupData(): Promise<void> {
-  await clearCache();
-  localStorage.clear();
-  localStorage.setItem("version", VERSION);
-  localStorage.setItem("disable_click_arrow_tooltip", "true");
+export async function clearCache(): Promise<void> {
+  const cacheNames = await caches.keys();
+  await Promise.all(cacheNames.map(cacheName => caches.delete(cacheName)));
+
+  const registrations = (await navigator.serviceWorker?.getRegistrations()) ?? [];
+  await Promise.all(registrations.map(registration => registration.unregister()));
+
   location.reload();
 }
 
-async function clearCache(): Promise<unknown> {
-  const cacheNames = await caches.keys();
-  return Promise.all(cacheNames.map(cacheName => caches.delete(cacheName)));
+export async function cleanupData(): Promise<void> {
+  localStorage.clear();
+  localStorage.setItem("version", VERSION);
+  localStorage.setItem("disable_click_arrow_tooltip", "true");
+  await clearCache();
 }
 
 function showUpdateWindow(storedVersion: string | null): void {
+  localStorage.setItem("version", VERSION);
+
   const changelog = "https://github.com/Azgaar/Fantasy-Map-Generator/wiki/Changelog";
   const reddit = "https://www.reddit.com/r/FantasyMapGenerator";
   const discord = "https://discordapp.com/invite/X7E84HU";
@@ -122,10 +130,9 @@ function showUpdateWindow(storedVersion: string | null): void {
     width: "28em",
     position: { my: "center center-4em", at: "center", of: "svg" },
     buttons: {
-      "Clear cache": () => cleanupData(),
+      "Clear cache": () => clearCache(),
       "Don't show again": function (this: HTMLElement) {
         $(this).dialog("close");
-        localStorage.setItem("version", VERSION);
       }
     }
   });
@@ -141,6 +148,9 @@ function announceVersion(): void {
   const storedVersion = localStorage.getItem("version");
   if (compareVersions(storedVersion, VERSION, { major: true, minor: true, patch: false }).isOlder) {
     setTimeout(() => showUpdateWindow(storedVersion), 6000);
+  } else if (compareVersions(storedVersion, VERSION).isOlder) {
+    localStorage.setItem("version", VERSION);
+    tip(`Updated to v${VERSION}. Reload the page if you get errors`, true, "success", 6000);
   }
 }
 


### PR DESCRIPTION
"Clear cache" is the most common answer to post-release problems in #fmg-bugs, but the action behind it does more and less than users expect. This fixes five small things behind that.

### Clearing the cache left the service worker in place

`clearCache()` deleted every Cache Storage entry but never unregistered the worker, so a stale or broken `sw.js` survived the one remedy on offer. It now unregisters registrations as well.

### "Clear cache" wiped every setting

`cleanupData()` calls `localStorage.clear()`, which is right for the **Reset to defaults** button it is wired to, but the three "Clear cache" buttons on loading errors called it too. Users lost canvas size, style presets, hidden columns and the rest to fix an asset-freshness problem — and a reset canvas size causes its own misalignment bugs.

`clearCache()` is now separate and is what those buttons call. `cleanupData()` keeps the wipe for **Reset to defaults**.

### Patch releases never told anyone to reload

```js
compareVersions(storedVersion, VERSION, {major: true, minor: true, patch: false})
```

`patch: false` zeroes both patch numbers, so 1.145.1 -> 1.145.2 never notified. Nearly every same-day hotfix is a patch bump, which is exactly when someone needs to know to refresh — and the message they never saw is *"In case of errors reload the page to update the code."*

Major and minor keep the full dialog. Patch now gets a `tip()` instead, to avoid adding popups to the releases that happen most often.

### The update dialog came back every load if closed with X

`localStorage.setItem("version", VERSION)` only ran from the "Don't show again" button, so dismissing via the titlebar left the stored version untouched and the dialog reappeared on the next load. It is now stored when the dialog is shown.

### Stylesheet changes could ship behind a stale `?v=`

`getChangedPublicJsFiles()` filtered on `.endsWith(".js")`, so `scripts/bump-version.js` could never bump a `.css` token — `index.css` and `icons.css` were correct only when someone remembered. With stylesheets cached `CacheFirst` for 30 days in `sw.js`, a forgotten bump hides a CSS fix for a month.

Same staged CSS change, before and after:

```
before:  src/index.html        (no changed public/*.js files detected)
after:   src/index.html        hashes updated for:
           - index.css
```

The `?v=` tokens themselves are fine and this does not change how they are generated — they lag the app version by design, which is the point of content-based busting.

## Checks

`tsc --noEmit` clean, 337 tests pass, biome clean.

Not covered by tests: `caches` and `navigator.serviceWorker` do not exist in the jsdom environment, so the unregister path wants a manual check against a real deploy rather than a test that only asserts its own mocks.
