### PR TITLE
Keep the only group of a layer when removing duplicates

### DIFF
--- a/src/services/io/auto-update.test.ts
+++ b/src/services/io/auto-update.test.ts
@@ -106,6 +106,37 @@ describe("v1.145 svg layer cleanup", () => {
     expect(document.querySelector("#routes > #empty")).toBeNull();
   });
 
+  it("keeps an empty layer group that is the only one with its id", () => {
+    document.body.innerHTML = /* html */ `<svg id="map"><g id="viewbox">
+      <g id="cults" opacity="0.6" stroke="#777777" stroke-width="0.5" style="display: none;"></g>
+      <g id="texture" data-href="./images/textures/marble-big.jpg" mask="url(#land)" style="display: none;"></g>
+    </g></svg>`;
+
+    resolveVersionConflicts("1.144.0", []);
+
+    const cults = document.querySelector("#cults");
+    expect(cults).not.toBeNull();
+    expect(cults?.getAttribute("stroke")).toBe("#777777");
+    expect(cults?.getAttribute("stroke-width")).toBe("0.5");
+    expect(document.querySelector("#texture")?.getAttribute("data-href")).toBe("./images/textures/marble-big.jpg");
+  });
+
+  it("keeps an empty declared child group that is the only one with its id", () => {
+    document.body.innerHTML = /* html */ `<svg id="map"><g id="viewbox">
+      <g id="routes">
+        <g id="roads" stroke="#d06324" stroke-width="0.35"><path id="road1"></path></g>
+        <g id="searoutes" stroke="#ffffff" stroke-width="0.35" stroke-dasharray="1 2"></g>
+      </g>
+    </g></svg>`;
+
+    resolveVersionConflicts("1.144.0", []);
+
+    const searoutes = document.querySelector("#routes > #searoutes");
+    expect(searoutes).not.toBeNull();
+    expect(searoutes?.getAttribute("stroke")).toBe("#ffffff");
+    expect(searoutes?.getAttribute("stroke-width")).toBe("0.35");
+  });
+
   it("does not clean current maps", () => {
     document.body.innerHTML = /* html */ `<svg id="map"><g id="viewbox">
       <g id="routes"><g id="empty"></g></g>

--- a/src/services/io/auto-update.ts
+++ b/src/services/io/auto-update.ts
@@ -1654,12 +1654,17 @@ export function resolveVersionConflicts(mapVersion: string, data: string[]): voi
       groupsById.set(group.id, sameId);
     }
 
+    const declared = new Set<string>();
+    for (const layer of Layers.all) {
+      declared.add(layer.elementId);
+      for (const child of layer.children) declared.add(child.id);
+    }
+
     const isEmpty = (group: SVGGElement) => group.childElementCount === 0;
     for (const sameId of groupsById.values()) {
-      const nonEmpty = sameId.filter(group => !isEmpty(group));
-      const keep = nonEmpty[0];
+      const keep = sameId.find(group => !isEmpty(group)) ?? (declared.has(sameId[0].id) ? sameId[0] : undefined);
       for (const group of sameId) {
-        if (isEmpty(group) || (keep && group !== keep)) group.remove();
+        if (group !== keep) group.remove();
       }
     }
   }


### PR DESCRIPTION
Loading a pre-1.145 map resets the style of every layer that was off. Reported on Discord: cultures and heightmap styles reset, and routes stop showing because their stroke colour and width are gone.

### Cause

The duplicate group cleanup in `auto-update.ts` removes any group with no children:

```ts
if (isEmpty(group) || (keep && group !== keep)) group.remove();
```

A layer that is off is stored as an empty group, and that group still holds the whole layer style. So the cleanup removes it even when it is the only group with that id, and `init()` then recreates it with no attributes.

It also looks at child groups, which is where the stroke usually lives: `#roads`, `#trails`, `#searoutes`, `#oceanHeights`, `#landHeights`, `#rural`, `#urban`.

### Evidence

In a map saved after this ran, every empty group has lost its style and every non-empty group has kept it, with no exceptions across 80 groups:

```
lava          empty  []                    freshwater  filled  [fill, opacity, stroke, stroke-width]
oceanHeights  empty  []                    statesBody  filled  [opacity]
searoutes     empty  []                    prec        filled  [fill, mask, opacity, stroke, ...]
cults         empty  []                    landmass    filled  [fill, opacity]
texture       empty  []                    provs       filled  [data-size, fill, font-family, ...]
```

Two groups did survive while empty, and both explain why. `#fogging` kept its `mask` because it is one of the three layers that declare `attrs` in the registry, so `init()` put it back. The empty `labels-*` groups kept everything because label styles are rebuilt from `style.labels.groups`. Anything with a style stored outside the svg survived; anything whose style lives only on the element did not.

### Fix

Remove duplicates only, and never the last group of a layer or a declared child. Empty groups with an unknown id are still removed, so the original cleanup still happens.

### Tests

Two tests in `auto-update.test.ts` covering a single empty layer group and a single empty child group. Both fail on master with `expected null not to be null`. The existing cleanup tests are unchanged and still pass.

`tsc --noEmit` clean, 378 tests pass, `biome check` clean.

### Note

This only stops new damage. Maps already saved after loading in 1.145 or 1.146 have the style missing from the file, so they need a separate repair.
