### PR TITLE
Restore the layer style removed from already saved maps

### DIFF
--- a/src/services/io/heal-layer-styles.test.ts
+++ b/src/services/io/heal-layer-styles.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Layers } from "@/components/layers";
+import { healLayerStyles } from "./heal-layer-styles";
+
+const DAMAGED = "1.146.0";
+
+const PRESET = {
+  "#cults": { opacity: 0.6, stroke: "#777777", "stroke-width": 0.5, filter: null },
+  "#searoutes": { opacity: 0.9, stroke: "#ffffff", "stroke-width": 0.35, mask: null },
+  "#terrain": { opacity: 0.8, set: "simple", size: 1, density: 0.4 },
+  "#fogging": { opacity: 0.98, fill: "#30426f" },
+  "#terrs > #landHeights": { opacity: 1, scheme: "bright", mask: "url(#land)" }
+};
+
+const viewbox = (html: string) => {
+  document.body.innerHTML = /* html */ `<svg id="map"><g id="viewbox">${html}</g></svg>`;
+};
+
+const attrs = (id: string) => {
+  const el = document.getElementById(id)!;
+  return Object.fromEntries(Array.from(el.attributes, a => [a.name, a.value]));
+};
+
+beforeEach(() => {
+  viewbox("");
+  localStorage.clear();
+  (globalThis as { getStylePreset?: unknown }).getStylePreset = vi.fn(async () => ["default", PRESET]);
+});
+
+describe("healLayerStyles", () => {
+  it("restores the preset style of a bare layer group", async () => {
+    viewbox(/* html */ `<g id="cults" style="display: none;"></g>`);
+
+    await healLayerStyles(DAMAGED);
+
+    expect(attrs("cults")).toMatchObject({ opacity: "0.6", stroke: "#777777", "stroke-width": "0.5" });
+  });
+
+  it("restores the preset style of a bare declared child group", async () => {
+    viewbox(/* html */ `<g id="routes"><g id="searoutes"></g></g>`);
+
+    await healLayerStyles(DAMAGED);
+
+    expect(attrs("searoutes")).toMatchObject({ opacity: "0.9", stroke: "#ffffff", "stroke-width": "0.35" });
+  });
+
+  it("resolves a child group through its parent selector", async () => {
+    viewbox(/* html */ `<g id="terrs"><g id="landHeights"></g></g>`);
+
+    await healLayerStyles(DAMAGED);
+
+    expect(attrs("landHeights")).toMatchObject({ scheme: "bright", mask: "url(#land)" });
+  });
+
+  it("skips the attributes the preset nulls out", async () => {
+    viewbox(/* html */ `<g id="cults"></g>`);
+
+    await healLayerStyles(DAMAGED);
+
+    expect(document.getElementById("cults")!.hasAttribute("filter")).toBe(false);
+  });
+
+  it("leaves a group that still has any style attribute alone", async () => {
+    viewbox(/* html */ `<g id="cults" stroke="#123456"></g>`);
+
+    await healLayerStyles(DAMAGED);
+
+    expect(attrs("cults")).toEqual({ id: "cults", stroke: "#123456" });
+  });
+
+  it("heals a group whose only attributes are the ones the registry declares", async () => {
+    viewbox(/* html */ `<g id="fogging" mask="url(#fog)"></g>`);
+
+    await healLayerStyles(DAMAGED);
+
+    expect(attrs("fogging")).toMatchObject({ opacity: "0.98", fill: "#30426f" });
+  });
+
+  it("does not write the relief options onto the terrain group", async () => {
+    viewbox(/* html */ `<g id="terrain"></g>`);
+
+    await healLayerStyles(DAMAGED);
+
+    expect(attrs("terrain")).toEqual({ id: "terrain", opacity: "0.8" });
+  });
+
+  it("leaves a bare group the preset says nothing about alone", async () => {
+    viewbox(/* html */ `<g id="debug"></g>`);
+
+    await healLayerStyles(DAMAGED);
+
+    expect(attrs("debug")).toEqual({ id: "debug" });
+  });
+
+  it("ignores an element that is not a group", async () => {
+    viewbox(/* html */ `<rect id="cults"></rect>`);
+
+    await healLayerStyles(DAMAGED);
+
+    expect(attrs("cults")).toEqual({ id: "cults" });
+  });
+
+  it("redraws the layers it healed", async () => {
+    viewbox(/* html */ `<g id="fogging" mask="url(#fog)"></g>`);
+    const draw = vi.spyOn(Layers, "draw").mockImplementation(() => {});
+
+    await healLayerStyles(DAMAGED);
+
+    expect(draw).toHaveBeenCalledWith("fogging");
+    draw.mockRestore();
+  });
+
+  it("does not redraw when it healed nothing", async () => {
+    viewbox(/* html */ `<g id="cults" stroke="#123456"></g>`);
+    const draw = vi.spyOn(Layers, "draw").mockImplementation(() => {});
+
+    await healLayerStyles(DAMAGED);
+
+    expect(draw).not.toHaveBeenCalled();
+    draw.mockRestore();
+  });
+
+  it("uses the preset the user last selected", async () => {
+    localStorage.setItem("presetStyle", "ancient");
+    viewbox(/* html */ `<g id="cults"></g>`);
+
+    await healLayerStyles(DAMAGED);
+
+    expect((globalThis as unknown as { getStylePreset: unknown }).getStylePreset).toHaveBeenCalledWith("ancient");
+  });
+
+  it("survives a preset that cannot be loaded", async () => {
+    (globalThis as { getStylePreset?: unknown }).getStylePreset = vi.fn(async () => {
+      throw new Error("Cannot fetch style preset");
+    });
+    viewbox(/* html */ `<g id="cults"></g>`);
+
+    await expect(healLayerStyles(DAMAGED)).resolves.toBeUndefined();
+    expect(attrs("cults")).toEqual({ id: "cults" });
+  });
+
+  describe("version gate", () => {
+    it("leaves maps saved before the cleanup shipped alone", async () => {
+      viewbox(/* html */ `<g id="cults"></g>`);
+
+      await healLayerStyles("1.144.0");
+
+      expect(attrs("cults")).toEqual({ id: "cults" });
+    });
+
+    it("leaves maps saved after the cleanup was fixed alone", async () => {
+      viewbox(/* html */ `<g id="cults"></g>`);
+
+      await healLayerStyles("1.147.0");
+
+      expect(attrs("cults")).toEqual({ id: "cults" });
+    });
+
+    it("heals the first version that could be damaged", async () => {
+      viewbox(/* html */ `<g id="cults"></g>`);
+
+      await healLayerStyles("1.145.0");
+
+      expect(document.getElementById("cults")!.getAttribute("stroke")).toBe("#777777");
+    });
+  });
+});

--- a/src/services/io/heal-layer-styles.ts
+++ b/src/services/io/heal-layer-styles.ts
@@ -1,0 +1,66 @@
+// Refill the layer style the v1.145 duplicate group cleanup removed
+import { type LayerId, Layers } from "@/components/layers";
+import { compareVersions } from "@/services/versioning";
+
+const DAMAGED_FROM = "1.145.0";
+const DAMAGED_UNTIL = "1.147.0";
+
+const RELIEF_OPTIONS = ["set", "size", "density"]; // stored in style.relief
+
+type PresetStyle = Record<string, string | number | null>;
+type Preset = Record<string, PresetStyle>;
+
+export async function healLayerStyles(mapVersion: string): Promise<void> {
+  const isDamaged =
+    !compareVersions(mapVersion, DAMAGED_FROM).isOlder && compareVersions(mapVersion, DAMAGED_UNTIL).isOlder;
+  if (!isDamaged) return;
+
+  const preset = await loadPreset();
+  if (!preset) return;
+
+  const healed = new Set<LayerId>();
+
+  for (const layer of Layers.all) {
+    const targets = [
+      { id: layer.elementId, selectors: [`#${layer.elementId}`], declared: layer.params.attrs },
+      ...layer.children.map(child => ({
+        id: child.id,
+        selectors: [`#${child.id}`, `#${layer.elementId} > #${child.id}`],
+        declared: child.attrs
+      }))
+    ];
+
+    for (const { id, selectors, declared } of targets) {
+      const style = selectors.map(selector => preset[selector]).find(Boolean);
+      const group = document.getElementById(id);
+      if (!style || group?.tagName !== "g" || !isBare(group, declared)) continue;
+
+      for (const [name, value] of Object.entries(style)) {
+        if (value === null || value === "null" || name === "id") continue;
+        if (id === "terrain" && RELIEF_OPTIONS.includes(name)) continue;
+        group.setAttribute(name, String(value));
+      }
+      healed.add(layer.id);
+    }
+  }
+
+  if (healed.size) Layers.draw(...healed);
+}
+
+function isBare(group: Element, declared: Record<string, string> = {}): boolean {
+  const ignored = new Set(["id", "style", ...Object.keys(declared)]);
+  return Array.from(group.attributes).every(attribute => ignored.has(attribute.name));
+}
+
+async function loadPreset(): Promise<Preset | undefined> {
+  const getStylePreset = (globalThis as { getStylePreset?: (name: string) => Promise<[string, Preset]> })
+    .getStylePreset;
+  if (!getStylePreset) return;
+
+  try {
+    const [, preset] = await getStylePreset(localStorage.getItem("presetStyle") || "default");
+    return preset;
+  } catch {
+    return;
+  }
+}

--- a/src/services/io/load.ts
+++ b/src/services/io/load.ts
@@ -433,6 +433,11 @@ async function parseLoadedData(data: string[], mapVersion: string | null): Promi
     if (data[51]) GraphOverride.restore(JSON.parse(data[51]));
     if (data[50]) Layers.restore(JSON.parse(data[50]));
 
+    {
+      const { healLayerStyles } = await import("./heal-layer-styles");
+      await healLayerStyles(mapVersion!);
+    }
+
     Goods.sync();
     Markets.sync();
     Routes.sync();


### PR DESCRIPTION
Follow-up to #1594. That one stops the damage. This one repairs the maps that already have it.

Anyone who loaded an older map in 1.145 or 1.146 and saved it now has a file with the style missing from the group, so keeping the group on load does nothing for them. Their routes, cultures and heightmap stay unstyled until they reapply a preset, which resets everything else too.

### What it does

After `Layers.restore()`, when the map version is in the affected range, it walks the layers and their declared children. A group with no style attributes of its own gets the missing attributes back from the current style preset. Then the healed layers are redrawn.

This runs after restore on purpose: the groups are all back in the dom by then, so a bare one is a real signal.

### What it will not touch

- a group that still has any style attribute, so an attribute you cleared on purpose stays cleared
- a group the preset says nothing about, which is the structural containers like `#terrs`, `#routes`, `#coastline`
- anything that is not a `g` element
- maps saved before 1.145 or after the fix

If the preset cannot be loaded it gives up quietly. A map that loads with the wrong style is better than a map that does not load.

### Verified on a real damaged map

A 1.145.2 file where the cleanup had already run, loaded with no errors:

| group | before | after |
| --- | --- | --- |
| `#cults` | no attributes | opacity 0.6, stroke #777777, stroke-width 0.5 |
| `#searoutes` | no attributes | opacity 0.9, stroke #ffffff, stroke-width 0.35 |
| `#landHeights` | no attributes | scheme bright, mask url(#land), skip 5 |
| `#texture` | no attributes | data-href, mask, data-x, data-y |
| `#lava` | no attributes | fill #90270d, stroke #f93e0c, filter url(#crumpled) |
| `#cells` | stroke-width 0, mask | unchanged, it still had style |
| `#rivers`, `#landmass` | styled | unchanged |

Turning those layers on afterwards, the texture image appears, cultures draw with the restored stroke, and the heightmap comes back in its bright scheme.

16 tests, `tsc --noEmit` clean, 392 tests pass, `biome check` clean.

### Two things to check

`DAMAGED_UNTIL` is set to 1.147.0, assuming #1594 lands before that release. If the version moves the constant needs to move with it.

The preset is read through the `getStylePreset` global, since style-presets.js is a classic script. Happy to change it if you would rather it went another way.
