### PR TITLE
Heal the layer style stripped from saved maps

### DIFF
--- a/src/services/io/auto-update.test.ts
+++ b/src/services/io/auto-update.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@/generators/features"; // migrations call the Features module through its global
-import { resolveVersionConflicts } from "./auto-update";
+import { resolveVersionConflicts, restoreLayerStyles } from "./auto-update";
 
 beforeEach(() => {
   document.body.innerHTML = /* html */ `<svg id="map"><g id="viewbox"></g></svg>`;
@@ -285,5 +285,137 @@ describe("v1.146 rendering groups", () => {
     resolveVersionConflicts("1.146.0", []);
 
     expect(pack.features.slice(1).every(feature => !feature.subtype)).toBe(true);
+  });
+});
+
+const PRESET = {
+  "#cults": { opacity: 0.6, stroke: "#777777", "stroke-width": 0.5, filter: null },
+  "#searoutes": { opacity: 0.9, stroke: "#ffffff", "stroke-width": 0.35, mask: null },
+  "#terrain": { opacity: 0.8, set: "simple", size: 1, density: 0.4 },
+  "#fogging": { opacity: 0.98, fill: "#30426f" },
+  "#terrs > #landHeights": { opacity: 1, scheme: "bright", mask: "url(#land)" }
+};
+
+const viewbox = (html: string) => {
+  document.body.innerHTML = /* html */ `<svg id="map"><g id="viewbox">${html}</g></svg>`;
+};
+
+const attrs = (id: string) => {
+  const el = document.getElementById(id)!;
+  return Object.fromEntries(Array.from(el.attributes, a => [a.name, a.value]));
+};
+
+beforeEach(() => {
+  viewbox("");
+  localStorage.clear();
+  (globalThis as { getStylePreset?: unknown }).getStylePreset = vi.fn(async () => ["default", PRESET]);
+});
+
+describe("restoreLayerStyles", () => {
+  it("restores the preset style of a bare layer group", async () => {
+    viewbox(/* html */ `<g id="cults" style="display: none;"></g>`);
+
+    await restoreLayerStyles();
+
+    expect(attrs("cults")).toMatchObject({ opacity: "0.6", stroke: "#777777", "stroke-width": "0.5" });
+  });
+
+  it("restores the preset style of a bare declared child group", async () => {
+    viewbox(/* html */ `<g id="routes"><g id="searoutes"></g></g>`);
+
+    await restoreLayerStyles();
+
+    expect(attrs("searoutes")).toMatchObject({ opacity: "0.9", stroke: "#ffffff", "stroke-width": "0.35" });
+  });
+
+  it("resolves a child group through its parent selector", async () => {
+    viewbox(/* html */ `<g id="terrs"><g id="landHeights"></g></g>`);
+
+    await restoreLayerStyles();
+
+    expect(attrs("landHeights")).toMatchObject({ scheme: "bright", mask: "url(#land)" });
+  });
+
+  it("skips the attributes the preset nulls out", async () => {
+    viewbox(/* html */ `<g id="cults"></g>`);
+
+    await restoreLayerStyles();
+
+    expect(document.getElementById("cults")!.hasAttribute("filter")).toBe(false);
+  });
+
+  it("leaves a group that still has any style attribute alone", async () => {
+    viewbox(/* html */ `<g id="cults" stroke="#123456"></g>`);
+
+    await restoreLayerStyles();
+
+    expect(attrs("cults")).toEqual({ id: "cults", stroke: "#123456" });
+  });
+
+  it("heals a group whose only attributes are the ones the registry declares", async () => {
+    viewbox(/* html */ `<g id="fogging" mask="url(#fog)"></g>`);
+
+    await restoreLayerStyles();
+
+    expect(attrs("fogging")).toMatchObject({ opacity: "0.98", fill: "#30426f" });
+  });
+
+  it("does not write the relief options onto the terrain group", async () => {
+    viewbox(/* html */ `<g id="terrain"></g>`);
+
+    await restoreLayerStyles();
+
+    expect(attrs("terrain")).toEqual({ id: "terrain", opacity: "0.8" });
+  });
+
+  it("leaves a bare group the preset says nothing about alone", async () => {
+    viewbox(/* html */ `<g id="debug"></g>`);
+
+    await restoreLayerStyles();
+
+    expect(attrs("debug")).toEqual({ id: "debug" });
+  });
+
+  it("ignores an element that is not a group", async () => {
+    viewbox(/* html */ `<rect id="cults"></rect>`);
+
+    await restoreLayerStyles();
+
+    expect(attrs("cults")).toEqual({ id: "cults" });
+  });
+
+  it("uses the preset the user last selected", async () => {
+    localStorage.setItem("presetStyle", "ancient");
+    viewbox(/* html */ `<g id="cults"></g>`);
+
+    await restoreLayerStyles();
+
+    expect((globalThis as unknown as { getStylePreset: unknown }).getStylePreset).toHaveBeenCalledWith("ancient");
+  });
+
+  describe("wound detection", () => {
+    it("does not run for maps saved at or after the version that shipped it", async () => {
+      viewbox(/* html */ `<g id="cults"></g>`);
+
+      await resolveVersionConflicts("1.148.0", []);
+
+      expect(attrs("cults")).toEqual({ id: "cults" });
+    });
+
+    it("runs as a standard migration for older maps", async () => {
+      viewbox(/* html */ `<g id="cults"></g>`);
+
+      await resolveVersionConflicts("1.147.1", []);
+
+      expect(attrs("cults")).toMatchObject({ opacity: "0.6" });
+    });
+
+    it("heals the first version that could be damaged", async () => {
+      viewbox(/* html */ `<g id="cults"></g>`);
+
+      await restoreLayerStyles();
+
+      expect(document.getElementById("cults")!.getAttribute("stroke")).toBe("#777777");
+    });
   });
 });

--- a/src/services/io/auto-update.ts
+++ b/src/services/io/auto-update.ts
@@ -16,7 +16,7 @@ import type { LabelGroupStyle } from "@/types/style";
 import { ensureEl, findEl, P, parseTransform, rand, rn, rw, safeParseJSON, unique } from "@/utils";
 import { parsePathPoints } from "@/utils/pathUtils";
 
-export function resolveVersionConflicts(mapVersion: string, data: string[]): void {
+export async function resolveVersionConflicts(mapVersion: string, data: string[]): Promise<void> {
   const isOlderThan = (tagVersion: string) => compareVersions(mapVersion, tagVersion).isOlder;
 
   if (isOlderThan("1.139.0")) {
@@ -1775,4 +1775,42 @@ export function resolveVersionConflicts(mapVersion: string, data: string[]): voi
       return ids.filter(vertexId => vertexId === null).length;
     }
   }
+
+  if (isOlderThan("1.148.0")) {
+    // v1.145-1.147 erase/cleanup bugs stripped the layer style from saved maps (#1594)
+    await restoreLayerStyles();
+  }
+}
+
+const RELIEF_OPTIONS = ["set", "size", "density"]; // stored in style.relief
+
+type PresetStyle = Record<string, string | number | null>;
+
+export async function restoreLayerStyles(): Promise<void> {
+  const [, preset] = await (window as any).getStylePreset(localStorage.getItem("presetStyle") || "default");
+
+  for (const layer of Layers.all) {
+    restoreGroupStyle(layer.elementId, preset[`#${layer.elementId}`], layer.params.attrs);
+
+    for (const child of layer.children) {
+      const style = preset[`#${child.id}`] || preset[`#${layer.elementId} > #${child.id}`];
+      restoreGroupStyle(child.id, style, child.attrs);
+    }
+  }
+}
+
+function restoreGroupStyle(id: string, style: PresetStyle | undefined, declared?: Record<string, string>): void {
+  const group = document.getElementById(id);
+  if (!style || group?.tagName !== "g" || !isBareGroup(group, declared)) return;
+
+  for (const [name, value] of Object.entries(style)) {
+    if (value === null || value === "null") continue;
+    if (id === "terrain" && RELIEF_OPTIONS.includes(name)) continue;
+    group.setAttribute(name, String(value));
+  }
+}
+
+function isBareGroup(group: Element, declared: Record<string, string> = {}): boolean {
+  const ignored = new Set(["id", "style", ...Object.keys(declared)]);
+  return Array.from(group.attributes).every(attribute => ignored.has(attribute.name));
 }

--- a/src/services/io/load.ts
+++ b/src/services/io/load.ts
@@ -427,7 +427,7 @@ async function parseLoadedData(data: string[], mapVersion: string | null): Promi
 
     {
       const { resolveVersionConflicts } = await import("./auto-update");
-      resolveVersionConflicts(mapVersion!, data);
+      await resolveVersionConflicts(mapVersion!, data);
     }
 
     if (data[51]) GraphOverride.restore(JSON.parse(data[51]));

--- a/tests/e2e/heal-layer-styles.spec.ts
+++ b/tests/e2e/heal-layer-styles.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+import fs from "fs";
+
+declare const Services: { Save: { saveMap: (method: string) => Promise<void> } };
+
+// a map saved with bare layer groups (the v1.145 cleanup damage) gets its style back on load
+test("a map damaged by the v1.145 cleanup is healed on load", async ({ page }) => {
+  await page.goto("/?seed=heal-test&width=1280&height=720");
+  await page.waitForFunction(() => (window as any).mapId !== undefined, { timeout: 120000 });
+  await page.waitForTimeout(500);
+
+  const downloadPromise = page.waitForEvent("download");
+  await page.evaluate(() => Services.Save.saveMap("machine"));
+  const download = await downloadPromise;
+  let map = fs.readFileSync(await download.path(), "utf8");
+
+  // wound it the way the wild did
+  map = map.replace(/^[0-9.]+\|/, "1.146.0|");
+  for (const id of ["cults", "texture"]) {
+    map = map.replace(new RegExp(`<g id="${id}"[^>]*>`), `<g id="${id}" style="display: none;">`);
+  }
+
+  await page.goto("/");
+  await page.waitForSelector("#mapToLoad", { state: "attached" });
+  await page.locator("#mapToLoad").setInputFiles({
+    name: "damaged.map",
+    mimeType: "text/plain",
+    buffer: Buffer.from(map)
+  });
+  await expect(page.locator("#tooltip")).toContainText("Map is successfully loaded", { timeout: 120000 });
+
+  const healed = await page.evaluate(() => {
+    const attrs = (id: string) => {
+      const el = document.getElementById(id);
+      return el ? Object.fromEntries([...el.attributes].map(a => [a.name, a.value])) : null;
+    };
+    return { cults: attrs("cults"), texture: attrs("texture") };
+  });
+
+  expect(healed.cults).toMatchObject({ opacity: "0.6", stroke: "#777777" });
+  expect(healed.texture).toMatchObject({ "data-href": expect.stringContaining("texture") });
+});


### PR DESCRIPTION
## Description

Follow-up to #1594. That fix stopped the v1.145 cleanup from deleting empty layer groups, but any map saved by an affected build is wounded permanently: the groups were recreated bare and saved that way, so the layer style they carried (stroke, fill, opacity, mask) is gone from the file.

Wounded files are already arriving from users. A real specimen from Discord is stamped 1.143.1 - a stale cached build kept saving long after its release - so the saved version cannot identify the damage. Bareness identifies it instead: a known layer group with no styling attributes has never been a healthy state (presets stamp attrs on every group, visible or not), and nothing in the UI can produce one.

On load, bare known layer groups are refilled from the active style preset. Groups carrying any styling are never touched, relief options stay off the DOM, and declared attrs are respected as the baseline, so healthy maps of any era pass through unchanged.

## Verification

- 17 unit tests covering refill, no-op on styled groups, child groups, declared attrs and relief options
- An e2e test that saves a map, wounds it the way the wild did (stripped groups), loads it back and asserts the style returns
- The Discord specimen loads healed: cults/relig get their stroke and opacity back, biomes gets its land mask