### PR TITLE
feat: option to redraw viewport layers only after a zoom

### DIFF
--- a/docs/wiki/Quick-Start-Tutorial.md
+++ b/docs/wiki/Quick-Start-Tutorial.md
@@ -88,6 +88,7 @@ Generator settings:
 * _Emblem shape_: defines shield shape used during emblems generation.
 * _Zoom extent_: minimal and maximal zoom levels. Click on the button on the right to restore the default values.
 * _Rendering_: set map rendering quality. Best quality can reduce the map performance.
+* _Redraw on zoom_: when labels, icons and relief are redrawn during a zoom or pan. _After zoom_ redraws once per gesture, which is faster on big maps but makes new content appear all at once.
 * _Language_: load Google Translate and select a language to translate the interface. Automatic translation can break some functionality — use the reset icon or refresh the page if it does.
 
 There is also the _Restore default options_ button. It cancels all user changes and refreshes the page.

--- a/src/components/zoom.test.ts
+++ b/src/components/zoom.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/renderers/viewport/viewport-renderer", () => ({
 }));
 
 import "@/generators/styles";
+import { ViewportLayers } from "@/renderers/viewport/viewport-renderer";
 import { rn } from "@/utils/numberUtils";
 import { applyZoomBehavior, setMapZoom } from "./zoom";
 
@@ -20,6 +21,7 @@ beforeEach(() => {
       <g id="markers"><image id="marker0" width="30" height="30" x="185" y="170"></image></g>
     </svg>
     <select id="shapeRendering"><option value="optimizeSpeed" selected></option></select>
+    <select id="viewportRedraw"><option value="continuous" selected></option><option value="settled"></option></select>
   `;
 
   const map = document.getElementById("map")!;
@@ -44,6 +46,8 @@ beforeEach(() => {
     vi.fn(() => 1)
   );
   vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  vi.mocked(ViewportLayers.schedule).mockClear();
+  vi.mocked(ViewportLayers.renderNow).mockClear();
   applyZoomBehavior();
 });
 
@@ -53,6 +57,23 @@ describe("programmatic zoom", () => {
 
     expect(scale).toBe(4);
     expect(document.getElementById("viewbox")!.getAttribute("transform")).toBe("translate(-1500 -900) scale(4)");
+  });
+});
+
+describe("viewport redraw during zoom", () => {
+  it("redraws viewport layers per frame and again when the gesture settles", () => {
+    setMapZoom(4);
+
+    expect(ViewportLayers.schedule).toHaveBeenCalledTimes(1);
+    expect(ViewportLayers.renderNow).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the per-frame redraw when set to redraw after the zoom only", () => {
+    (document.getElementById("viewportRedraw") as HTMLSelectElement).value = "settled";
+    setMapZoom(4);
+
+    expect(ViewportLayers.schedule).not.toHaveBeenCalled();
+    expect(ViewportLayers.renderNow).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/components/zoom.ts
+++ b/src/components/zoom.ts
@@ -58,7 +58,7 @@ function handleZoomPerFrame(): void {
 
   window.updateMinimap?.();
   redrawTracedImage();
-  ViewportLayers.schedule();
+  if (ensureEl<HTMLSelectElement>("viewportRedraw").value === "continuous") ViewportLayers.schedule();
 }
 
 /** Rewrite map content once zoom gesture settles */

--- a/src/index.html
+++ b/src/index.html
@@ -1688,6 +1688,19 @@
               <td></td>
             </tr>
             <tr
+              data-tip="When labels, icons and relief are redrawn during a zoom or pan. 'After zoom' redraws once per gesture: faster on big maps, but new content appears all at once"
+            >
+              <td></td>
+              <td>Redraw on zoom</td>
+              <td>
+                <select id="viewportRedraw" data-stored="viewportRedraw">
+                  <option value="continuous" selected>While zooming</option>
+                  <option value="settled">After zoom</option>
+                </select>
+              </td>
+              <td></td>
+            </tr>
+            <tr
               data-tip="Load Google Translate and select language. Note that automatic translation can break some page functional. In this case reset the language back to English or refresh the page"
             >
               <td>

--- a/tests/e2e/zoom-redraw-option.spec.ts
+++ b/tests/e2e/zoom-redraw-option.spec.ts
@@ -1,0 +1,46 @@
+import {expect, test, type Page} from "@playwright/test";
+
+// real wheel input on purpose: programmatic setMapZoom dispatches "end" with the frame still
+// pending, so it cannot catch a reconcile that never runs after human-paced gestures
+const materialized = (page: Page) =>
+  page.evaluate(() =>
+    [...document.querySelectorAll("#burgIcons use, #labels [data-label-type]")].map(el => el.id).join(",")
+  );
+
+async function wheelZoomIn(page: Page) {
+  await page.mouse.move(640, 360);
+  for (let i = 0; i < 6; i++) await page.mouse.wheel(0, -240);
+  await page.waitForTimeout(800);
+}
+
+test.describe("Redraw on zoom option", () => {
+  test.beforeEach(async ({page}) => {
+    await page.goto("/?seed=zoom-redraw&width=1280&height=720");
+    await page.waitForFunction(() => (window as any).mapId !== undefined, {timeout: 120000});
+    await page.waitForTimeout(500);
+  });
+
+  test("defaults to redrawing while zooming and reconciles at gesture end", async ({page}) => {
+    expect(await page.locator("#viewportRedraw").inputValue()).toBe("continuous");
+    const before = await materialized(page);
+    await wheelZoomIn(page);
+    expect(await materialized(page)).not.toBe(before);
+  });
+
+  test("after-zoom mode still reconciles once the gesture settles and is remembered", async ({page}) => {
+    // the select sits in the collapsed options pane; drive it the way the pane's change listener sees it
+    await page.evaluate(() => {
+      const select = document.getElementById("viewportRedraw") as HTMLSelectElement;
+      select.value = "settled";
+      select.dispatchEvent(new Event("change", {bubbles: true}));
+    });
+    const before = await materialized(page);
+    await wheelZoomIn(page);
+    expect(await materialized(page)).not.toBe(before);
+
+    expect(await page.evaluate(() => localStorage.getItem("viewportRedraw"))).toBe("settled");
+    await page.reload();
+    await page.waitForFunction(() => (window as any).mapId !== undefined, {timeout: 120000});
+    expect(await page.locator("#viewportRedraw").inputValue()).toBe("settled");
+  });
+});


### PR DESCRIPTION
Reworked per the discussion below: mid-gesture redraw stays the default, and redrawing once per gesture becomes a named option.

## What

Options → Rendering gains **Redraw on zoom**, next to the Rendering select:

- **While zooming** (default): labels, icons and relief are redrawn per frame during a zoom or pan, as today.
- **After zoom**: the per-frame redraw is skipped and the layers are redrawn once when the gesture settles. Faster on big maps; new content appears all at once.

The choice is stored per device through the same `data-stored` mechanism as the Rendering select, so it needs no new plumbing and survives a reload.

## How

`handleZoomPerFrame` skips `ViewportLayers.schedule()` unless the option is "While zooming". The end-of-gesture render in `invokeActiveZooming` is unchanged, so labels always catch up. Master has already taken the per-gesture `isViewChanged` flag from the earlier version of this PR.

## Tests

- `zoom.test.ts`: both modes at the unit level.
- `tests/e2e/zoom-redraw-option.spec.ts`: drives a real wheel gesture. Programmatic zooms dispatch `end` with the frame still pending and cannot see a missing end-of-gesture redraw. Checks the default, that "After zoom" still reconciles at gesture end, and that the choice survives a reload.

Quick-Start tutorial gains one bullet under the options list.
