### PR TITLE
fix: remove river labels along with the rivers (#1596)

### DIFF
--- a/src/controllers/river-editor.ts
+++ b/src/controllers/river-editor.ts
@@ -332,6 +332,7 @@ function removeRiver(): void {
         const river = +selectedRiver.attr("id").slice(5);
         Rivers.remove(river);
         selectedRiver.remove();
+        Layers.draw("labels");
         $("#riverEditor").dialog("close");
       },
       Cancel: function (this: any) {

--- a/src/controllers/rivers-overview.ts
+++ b/src/controllers/rivers-overview.ts
@@ -312,6 +312,7 @@ function triggerRiverRemove(this: HTMLElement): void {
     buttons: {
       Remove: function (this: any) {
         Rivers.remove(river);
+        Layers.draw("labels");
         riversTable.refresh();
         $(this).dialog("close");
       },
@@ -343,6 +344,7 @@ function removeAllRivers(): void {
   pack.rivers = [];
   pack.cells.r = new Uint16Array(pack.cells.i.length);
   select("#rivers").selectAll("*").remove();
+  Layers.draw("labels");
   riversTable.refresh();
 }
 

--- a/tests/e2e/river-label-removal.spec.ts
+++ b/tests/e2e/river-label-removal.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("removing a river removes its label", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/?seed=123456789&width=1280&height=720");
+    await page.waitForFunction(() => (window as any).mapId !== undefined, { timeout: 120000 });
+
+    // river labels are zoom-gated, so bring one into view
+    await page.evaluate(() => {
+      const w = window as any;
+      const river = w.pack.rivers.find((r: any) => r.cells?.length && r.name);
+      const [x, y] = w.pack.cells.p[river.cells[Math.floor(river.cells.length / 2)]];
+      w.zoomTo(x, y, 8, 0);
+    });
+    await page.waitForFunction(() => document.querySelector("#labels [id^=riverLabel]") !== null, { timeout: 10000 });
+  });
+
+  const labelledRiverId = (page: any) =>
+    page.evaluate(() => +document.querySelector("#labels [id^=riverLabel]")!.id.replace("riverLabel", ""));
+
+  test("through the river editor", async ({ page }) => {
+    const id = await labelledRiverId(page);
+
+    await page.evaluate(riverId => (window as any).Controllers.RiverEditor.open(`river${riverId}`), id);
+    await page.click("#riverRemove");
+    await page.click('.ui-dialog-buttonpane button:has-text("Remove")');
+
+    await expect(page.locator(`#riverLabel${id}`)).toHaveCount(0);
+  });
+
+  test("through remove all rivers", async ({ page }) => {
+    await page.evaluate(() => (window as any).Controllers.RiversOverview.open());
+    await page.click("#riversRemoveAll");
+    await page.click('.ui-dialog-buttonpane button:has-text("Remove")');
+
+    await expect(page.locator("#labels [id^=riverLabel]")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Fixes #1596.

`Rivers.remove()` drops the river paths and the `pack.rivers` entry, but the label belongs to the labels scene and stays materialized. Nothing backs it any more, so it cannot be selected, edited or deleted - and the labels editor correctly shows nothing for it, because that list is rebuilt from `pack.rivers`. That combination is exactly what the reporter describes: a label visible on the map that does not exist anywhere in the UI.

Fixed by redrawing labels after removal at the UI call sites, the way burg removal already does it (`burg-editor.ts` calls `Layers.draw("burgIcons", "labels")` after `Burgs.remove`).

Three call sites, one of them a second bug the issue does not mention:

- river editor trash button
- rivers overview per-row trash button
- **remove all rivers** - this one never went through `Rivers.remove()` at all (it assigns `pack.rivers = []` directly), so it orphaned every river label on the map at once

The pre-1.6.0 load migration also calls `Rivers.remove()` and is deliberately left alone: it runs during load, before labels exist, and drawing labels there risks the same class of crash as #1572. Keeping the redraw at the UI call sites avoids that entirely.

A single `Layers.draw("labels")` is enough per site even though removal cascades to tributaries and basin members, since it rebuilds the whole label scene from `pack.rivers`.

## Verification

New e2e covers both paths, driving the real dialogs rather than calling the module directly. Both fail on master (the orphaned label is still in the DOM after removal) and pass with the fix; I re-confirmed the red by stashing only the source change and re-running. Also `tsc` clean, Biome clean, 378/378 unit tests.