### PR TITLE
fix: label group migration leaves pre-1.140 maps with unusable groups

### DIFF
--- a/src/services/io/auto-update.test.ts
+++ b/src/services/io/auto-update.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@/generators/added-labels";
 import "@/generators/features"; // migrations call the Features module through its global
+import "@/generators/labels-generator";
 import { resolveVersionConflicts, restoreLayerStyles } from "./auto-update";
 
 beforeEach(() => {
@@ -417,5 +419,59 @@ describe("restoreLayerStyles", () => {
 
       expect(document.getElementById("cults")!.getAttribute("stroke")).toBe("#777777");
     });
+  });
+});
+
+describe("v1.140 label group migration", () => {
+  // a legacy burg group can be named like a group the migration creates by a fixed name
+  const LEGACY_BURG_GROUPS = [
+    { id: "towns", size: 3 },
+    { id: "river", size: 50 }
+  ];
+
+  function setupLegacyMap() {
+    const burgGroups = LEGACY_BURG_GROUPS.map(
+      ({ id, size }) => `<g id="${id}" data-size="${size}" fill="#3e3e4b"></g>`
+    ).join("");
+
+    document.body.innerHTML = /* html */ `<svg id="map">
+      <defs id="deftemp"></defs>
+      <g id="viewbox">
+        <g id="labels">
+          <g id="burgLabels">${burgGroups}</g>
+          <g id="addedLabels" data-size="120"></g>
+          <g id="states" data-size="70"></g>
+        </g>
+      </g>
+    </svg>`;
+
+    globalThis.options = {
+      labels: { groups: [] },
+      burgs: { groups: LEGACY_BURG_GROUPS.map(({ id }) => ({ name: id })) }
+    } as unknown as typeof globalThis.options;
+    globalThis.style = { labels: { groups: {} } } as unknown as typeof globalThis.style;
+    globalThis.pack = {
+      features: [],
+      burgs: [0, { i: 1, group: "river" }],
+      addedLabels: []
+    } as unknown as typeof globalThis.pack;
+    globalThis.notes = [];
+  }
+
+  // the Label Groups editor renders the bounds into <input type="number" min="0.01">, so a bound
+  // below that leaves the form invalid and Apply does nothing until every such row is hand-edited
+  it("derives zoom bounds the Label Groups editor accepts", () => {
+    setupLegacyMap();
+
+    resolveVersionConflicts("1.139.0", []);
+
+    const outOfRange = options.labels.groups
+      .filter(({ zoom }) => (zoom.min !== null && zoom.min < 0.01) || (zoom.max !== null && zoom.max < 0.01))
+      .map(({ name, zoom }) => `${name}[${zoom.min}, ${zoom.max}]`);
+    expect(outOfRange).toEqual([]);
+
+    // a group already larger than 12px at any zoom has no lower bound
+    expect(options.labels.groups.find(({ name }) => name === "state")?.zoom).toEqual({ min: null, max: 2.4 });
+    expect(options.labels.groups.find(({ name }) => name === "towns")?.zoom).toEqual({ min: 7, max: 79 });
   });
 });

--- a/src/services/io/auto-update.test.ts
+++ b/src/services/io/auto-update.test.ts
@@ -474,4 +474,18 @@ describe("v1.140 label group migration", () => {
     expect(options.labels.groups.find(({ name }) => name === "state")?.zoom).toEqual({ min: null, max: 2.4 });
     expect(options.labels.groups.find(({ name }) => name === "towns")?.zoom).toEqual({ min: 7, max: 79 });
   });
+
+  // group styles and the rendered <g> ids are keyed by name alone, so a duplicate name means one
+  // group's style silently replaces the other's
+  it("renames a legacy group that claims a name the migration reserves", () => {
+    setupLegacyMap();
+
+    resolveVersionConflicts("1.139.0", []);
+
+    const names = options.labels.groups.map(({ name }) => name);
+    expect(names).toHaveLength(new Set(names).size);
+    expect(options.labels.groups.find(({ name }) => name === "river")?.type).toBe("river");
+    expect(options.labels.groups.find(({ name }) => name === "river2")?.type).toBe("burg");
+    expect(pack.burgs[1].label?.group).toBe("river2"); // burgs of the renamed group follow it
+  });
 });

--- a/src/services/io/auto-update.ts
+++ b/src/services/io/auto-update.ts
@@ -1282,6 +1282,18 @@ export async function resolveVersionConflicts(mapVersion: string, data: string[]
     options.labels = { resizeOnZoom, showAll: !autoVisibility, groups: [] };
     style.labels.groups = {};
 
+    // styles and the rendered <g> ids are keyed by group name, so names have to stay unique: the
+    // groups this migration creates by a fixed name keep it, a legacy group claiming one is renamed
+    const takenNames = new Set(["river", "route", "province", "state", "added"]);
+    const renamedGroups = new Map<string, string>();
+    function claimName(name: string) {
+      let claimed = name;
+      for (let i = 2; takenNames.has(claimed); i++) claimed = `${name}${i}`;
+      takenNames.add(claimed);
+      if (claimed !== name) renamedGroups.set(name, claimed);
+      return claimed;
+    }
+
     for (const type of ["river", "route"] as const) {
       options.labels.groups.push(Labels.getFallbackGroup(type));
       style.labels.groups[type] = getGroupStyle({ name: type, type });
@@ -1289,26 +1301,39 @@ export async function resolveVersionConflicts(mapVersion: string, data: string[]
 
     const burgGroups = Array.from(document.querySelectorAll<SVGGElement>("#burgLabels > g"));
     for (const burgGroup of burgGroups) {
-      const name = burgGroup.id;
+      const name = claimName(burgGroup.id);
       const oldStyle = deriveLabelsStyle(burgGroup);
       const zoom = deriveZoomExtent(Number.parseFloat(oldStyle["font-size"] as string));
 
-      options.labels.groups.push({ name, type: "burg", isDefault: name === "towns", zoom });
+      options.labels.groups.push({ name, type: "burg", isDefault: burgGroup.id === "towns", zoom });
       style.labels.groups[name] = oldStyle;
     }
 
     const migratedBurgStyle = burgGroups.length ? style.labels.groups[burgGroups[0].id] : undefined;
-    for (const { name } of options.burgs.groups) {
-      if (options.labels.groups.some(group => group.name === name)) continue;
+    const migratedBurgGroupIds = new Set(burgGroups.map(burgGroup => burgGroup.id));
+    for (const burgGroup of options.burgs.groups) {
+      if (migratedBurgGroupIds.has(burgGroup.name)) continue;
 
-      const defaultGroup = Labels.getDefaultGroups().find(group => group.type === "burg" && group.name === name);
+      const defaultGroup = Labels.getDefaultGroups().find(
+        group => group.type === "burg" && group.name === burgGroup.name
+      );
       const { zoom } = defaultGroup ?? Labels.getFallbackGroup("burg");
+      const name = claimName(burgGroup.name);
       options.labels.groups.push({ name, type: "burg", zoom });
       style.labels.groups[name] = migratedBurgStyle ? { ...migratedBurgStyle } : getGroupStyle({ name, type: "burg" });
     }
 
     if (options.labels.groups.every(group => !group.isDefault) && options.labels.groups[0])
       options.labels.groups[0].isDefault = true;
+
+    // a burg label takes its group from the burg, so a renamed group has to be repointed
+    if (renamedGroups.size) {
+      for (const burg of pack.burgs) {
+        if (!burg?.i) continue;
+        const renamed = burg.group && renamedGroups.get(burg.group);
+        if (renamed) burg.label = { ...burg.label, group: renamed };
+      }
+    }
 
     // migrate manually shifted burg labels to pack.burgs[burgId].label
     for (const textEl of document.querySelectorAll<SVGTextElement>("#burgLabels > g > text")) {
@@ -1347,9 +1372,8 @@ export async function resolveVersionConflicts(mapVersion: string, data: string[]
     pack.addedLabels = [];
     const addedGroups = Array.from(labels.querySelectorAll<SVGGElement>(":scope > g:not(#states):not(#burgLabels)"));
     for (const addedGroup of addedGroups) {
-      let name = addedGroup.id === "addedLabels" ? "added" : addedGroup.id;
-      const isExisting = options.labels.groups.find(group => group.name === name);
-      if (isExisting) name += options.labels.groups.length;
+      const isDefaultGroup = addedGroup.id === "addedLabels";
+      const name = isDefaultGroup ? "added" : claimName(addedGroup.id);
 
       const oldStyle = deriveLabelsStyle(addedGroup);
       const fontSize = Number.parseFloat(oldStyle["font-size"] as string);
@@ -1357,7 +1381,7 @@ export async function resolveVersionConflicts(mapVersion: string, data: string[]
       options.labels.groups.push({
         name,
         type: "added",
-        isDefault: name === "added",
+        isDefault: isDefaultGroup,
         zoom: deriveZoomExtent(fontSize)
       });
       style.labels.groups[name] = oldStyle;

--- a/src/services/io/auto-update.ts
+++ b/src/services/io/auto-update.ts
@@ -1291,8 +1291,7 @@ export async function resolveVersionConflicts(mapVersion: string, data: string[]
     for (const burgGroup of burgGroups) {
       const name = burgGroup.id;
       const oldStyle = deriveLabelsStyle(burgGroup);
-      const fontSize = Number.parseFloat(oldStyle["font-size"] as string);
-      const zoom = { min: rn(12 / fontSize - 1, 1), max: rn(120 / fontSize - 1, 1) };
+      const zoom = deriveZoomExtent(Number.parseFloat(oldStyle["font-size"] as string));
 
       options.labels.groups.push({ name, type: "burg", isDefault: name === "towns", zoom });
       style.labels.groups[name] = oldStyle;
@@ -1426,8 +1425,13 @@ export async function resolveVersionConflicts(mapVersion: string, data: string[]
       };
     }
 
+    // group font sizes are a percentage of #labels, which is (100 + 100 / scale) / 2 px, so a label
+    // is drawn at fontSize * (scale + 1) / 2 screen px. Keep the group between 12 and 120 px; a bound
+    // outside the zoom range the Label Groups editor accepts means no limit on that side
     function deriveZoomExtent(fontSize: number) {
-      return { min: rn(12 / fontSize - 1, 1), max: rn(120 / fontSize - 1, 1) };
+      const minBound = 0.01; // the Label Groups editor rejects anything below it
+      const inRange = (bound: number) => (bound >= minBound ? bound : null);
+      return { min: inRange(rn(24 / fontSize - 1, 1)), max: inRange(rn(240 / fontSize - 1, 1)) };
     }
 
     function getPathLabel({


### PR DESCRIPTION
Reported on r/FantasyMapGenerator: after upgrading, a user's pre-1.140 maps came back with label
groups they never created, giant river names painted across the map, and a Configure Label Groups
dialog that refused to apply any change — several Zoom min fields highlighted as invalid.

Two problems in the v1.140 label group migration, both still present on 1.148.0.

### Zoom bounds land outside the range the editor accepts

`deriveZoomExtent` derives a group's zoom window from its font size as
`{min: 12 / fontSize - 1, max: 120 / fontSize - 1}`, and the burg loop repeats the same expression
inline. Any legacy group with a font size above 12 gets a negative `zoom.min`; above 120, a negative
`zoom.max` as well. The editor renders those into `<input type="number" min="0.01">`, and `submitForm`
returns early on `form.checkValidity()` — so Apply silently does nothing until the user hand-edits
every affected row. A group of size 50 migrates to `[-0.8, 1.4]`, one of size 120 to `[-0.9, 0]`.

The size the bounds are meant to describe is also off by a factor of two. Group font sizes are a
percentage of `#labels`, which `handleZoomPerFrame` keeps at `(100 + 100 / scale) / 2` px, so a label
is drawn at `fontSize * (scale + 1) / 2` screen px. Measured in the browser:

| zoom | `#labels` | group | computed | screen px | `fontSize * (scale + 1) / 2` |
|---|---|---|---|---|---|
| 1 | 100px | capital 6% | 6px | 6 | 6 |
| 2 | 75px | town 4% | 3px | 6 | 6 |
| 4 | 62.5px | village 3% | 1.875px | 7.5 | 7.5 |
| 8 | 56.25px | river 1.5% | 0.84px | 6.75 | 6.75 |

So the 12–120 px band the constants aim at is reached at `24 / fontSize - 1` and `240 / fontSize - 1`.
This commit uses those and drops a bound below the editor's minimum to `null` (no limit on that side),
which is what a group already larger than 12 px at any zoom actually means.

### A legacy group can claim a name the migration reserves

Group styles (`style.labels.groups`) and the rendered group ids (`labels-${name}`) are keyed by name
alone, but the migration creates `river`, `route`, `province`, `state` and `added` by fixed name while
also creating one group per legacy `#burgLabels > g` and `#labels > g` — under the legacy element's id.
Only the added-label loop guarded against a repeat. A map with a burg group named `river` therefore
produced two `river` rows, one style entry (the burg group's, written last), two `<g id="labels-river">`,
and every river label rendered at the burg group's font size — the giant river names in the report.

Legacy groups now yield the name and take a numbered one (`river2`), and burgs that referenced the
renamed group are repointed through `burg.label.group`, so their labels keep the migrated style.

### Tests

Two cases in `auto-update.test.ts` build a pre-1.140 map with a burg group named `river` at size 50
and an added group at size 120; both fail on master and pass here. Full suite: 393 passing, `tsc`
clean, biome clean.
