### PR TITLE
Optionally gzip-compress .map save files

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2433,19 +2433,31 @@
         <div style="margin-top: 0.3em">
           <strong>Save map to</strong>
           <button
-            onclick="window.Services.Save.saveMap('machine')"
+            onclick="window.Services.Save.saveMap('machine', saveMapCompressed.checked)"
             data-tip="Download map file to your local disk"
             data-shortcut="Ctrl + S"
             style="font-weight: 600"
           >
             machine
           </button>
-          <button onclick="window.Services.Save.saveMap('dropbox')" data-tip="Save map file to your Dropbox" data-shortcut="Ctrl + C">
+          <button
+            onclick="window.Services.Save.saveMap('dropbox', saveMapCompressed.checked)"
+            data-tip="Save map file to your Dropbox"
+            data-shortcut="Ctrl + C"
+          >
             dropbox
           </button>
-          <button onclick="window.Services.Save.saveMap('storage')" data-tip="Save the project to browser storage only" data-shortcut="F6">
+          <button
+            onclick="window.Services.Save.saveMap('storage', saveMapCompressed.checked)"
+            data-tip="Save the project to browser storage only"
+            data-shortcut="F6"
+          >
             browser
           </button>
+        </div>
+        <div style="margin-top: 0.6em" data-tip="Gzip-compress the save file to reduce its size, without losing any data">
+          <input id="saveMapCompressed" class="checkbox" type="checkbox" checked />
+          <label for="saveMapCompressed" class="checkbox-label">compress file (recommended, smaller file size)</label>
         </div>
         <p>
           Maps are saved in <i>.map</i> format, that can be loaded back via the <i>Load</i> in menu. There is no way to

--- a/src/services/autosave.ts
+++ b/src/services/autosave.ts
@@ -19,7 +19,8 @@ export function initiateAutosave(): void {
 
     try {
       tip("Autosave: saving map...", false, "warn", 3000);
-      await Services.Save.saveToStorage(await Services.Save.prepareMapData());
+      const mapData = await Services.Save.prepareMapData();
+      await Services.Save.saveToStorage(new Blob([mapData], { type: "text/plain" }));
       tip("Autosave: map is saved", false, "success", 2000);
 
       lastSavedAt = Date.now();

--- a/src/services/io/cloud.ts
+++ b/src/services/io/cloud.ts
@@ -31,7 +31,7 @@ interface DropboxProvider {
   call(name: string, param?: unknown): Promise<any>;
   initialize(): Promise<void>;
   connect(tokens: DropboxTokens): Promise<void>;
-  save(fileName: string, contents: string): Promise<boolean>;
+  save(fileName: string, contents: string | Blob): Promise<boolean>;
   load(path: string): Promise<Blob>;
   list(): Promise<CloudFile[]>;
   auth(): Promise<void>;
@@ -197,7 +197,7 @@ export const Cloud = { providers: { dropbox } };
 // Method facade so the registry (which dispatches method calls, not property
 // reads) can reach cloud storage uniformly as `Services.Cloud.<method>()`.
 export const CloudStorage = {
-  save: (fileName: string, contents: string) => dropbox.save(fileName, contents),
+  save: (fileName: string, contents: string | Blob) => dropbox.save(fileName, contents),
   load: (path: string) => dropbox.load(path),
   getLink: (path: string) => dropbox.getLink(path),
   list: () => dropbox.list(),

--- a/src/services/io/load.ts
+++ b/src/services/io/load.ts
@@ -157,13 +157,8 @@ function uploadMap(file: Blob, callback?: () => void): void {
 async function uncompress(compressedData: ArrayBuffer): Promise<Uint8Array | null> {
   try {
     const uncompressedStream = new Blob([compressedData]).stream().pipeThrough(new DecompressionStream("gzip"));
-
-    let uncompressedData: number[] = [];
-    for await (const chunk of uncompressedStream) {
-      uncompressedData = uncompressedData.concat(Array.from(chunk));
-    }
-
-    return new Uint8Array(uncompressedData);
+    const uncompressedBuffer = await new Response(uncompressedStream).arrayBuffer();
+    return new Uint8Array(uncompressedBuffer);
   } catch (error) {
     ERROR && console.error(error);
     return null;

--- a/src/services/io/save.ts
+++ b/src/services/io/save.ts
@@ -12,17 +12,34 @@ import { ensureEl, getFileName, link, parseError, rn } from "@/utils";
 
 type SaveMethod = "storage" | "machine" | "dropbox";
 
-async function saveMap(method: SaveMethod): Promise<void> {
+function isCompressionSupported(): boolean {
+  return typeof CompressionStream !== "undefined";
+}
+
+async function getMapDataBlob(mapData: string, compressed: boolean): Promise<Blob> {
+  if (!compressed || !isCompressionSupported()) return new Blob([mapData], { type: "text/plain" });
+
+  const compressedStream = new Blob([mapData]).stream().pipeThrough(new CompressionStream("gzip"));
+  return new Response(compressedStream).blob();
+}
+
+async function saveMap(method: SaveMethod, compressed = true): Promise<void> {
   if (customization) return tip("Map cannot be saved in EDIT mode, please complete the edit and retry", false, "error");
   closeDialogs("#alert");
 
   try {
     const mapData = prepareMapData();
     const filename = `${getFileName()}.map`;
+    const fallbackToUncompressed = compressed && !isCompressionSupported();
+    const blob = await getMapDataBlob(mapData, compressed);
 
-    if (method === "storage") await saveToStorage(mapData, true);
-    if (method === "machine") saveToMachine(mapData, filename);
-    if (method === "dropbox") await saveToDropbox(mapData, filename);
+    if (method === "storage") await saveToStorage(blob, true);
+    if (method === "machine") saveToMachine(blob, filename);
+    if (method === "dropbox") await saveToDropbox(blob, filename);
+
+    if (fallbackToUncompressed) {
+      tip("Your browser doesn't support file compression, the map is saved uncompressed", true, "warn", 8000);
+    }
   } catch (error) {
     ERROR && console.error(error);
     alertMessage.innerHTML = /* html */ `An error occurred while saving the map. If the issue persists, please copy the message below and report it on ${link(
@@ -37,7 +54,7 @@ async function saveMap(method: SaveMethod): Promise<void> {
       buttons: {
         Retry: function (this: HTMLElement) {
           $(this).dialog("close");
-          saveMap(method);
+          saveMap(method, compressed);
         },
         Close: function (this: HTMLElement) {
           $(this).dialog("close");
@@ -208,15 +225,13 @@ function prepareMapData(): string {
 }
 
 // save map file to indexedDB
-async function saveToStorage(mapData: string, showTip = false): Promise<void> {
-  const blob = new Blob([mapData], { type: "text/plain" });
+async function saveToStorage(blob: Blob, showTip = false): Promise<void> {
   await ldb.set("lastMap", blob);
   showTip && tip("Map is saved to the browser storage", false, "success");
 }
 
 // download map file
-function saveToMachine(mapData: string, filename: string): void {
-  const blob = new Blob([mapData], { type: "text/plain" });
+function saveToMachine(blob: Blob, filename: string): void {
   const URL = window.URL.createObjectURL(blob);
 
   const link = document.createElement("a");
@@ -228,8 +243,8 @@ function saveToMachine(mapData: string, filename: string): void {
   setTimeout(() => window.URL.revokeObjectURL(URL), 5000);
 }
 
-async function saveToDropbox(mapData: string, filename: string): Promise<void> {
-  await Services.Cloud.save(filename, mapData);
+async function saveToDropbox(blob: Blob, filename: string): Promise<void> {
+  await Services.Cloud.save(filename, blob);
   tip("Map is saved to your Dropbox", true, "success", 8000);
 }
 


### PR DESCRIPTION
.map save files are plain, uncompressed text, and they can get quite large since they embed the fully rendered SVG alongside all the grid and pack data. The loader already knows how to transparently decompress gzip files (`load.ts`'s `uncompress()`), it just never had a producer on the save side.

This adds a "compress file" checkbox to the save dialog, checked by default, that gzip-compresses the save via `CompressionStream` before writing it to disk, browser storage, or Dropbox. No data is lost and no load-side changes are needed since decompression support already exists. If a browser doesn't support `CompressionStream`, the save falls back to the existing uncompressed format and shows a warning tip rather than failing.

- `src/services/io/save.ts`: build the save `Blob` as gzip or plain text depending on the checkbox/support, with a `CompressionStream` feature-detection fallback
- `src/services/io/cloud.ts`: widen the Dropbox `save` contents type to accept a `Blob`
- `src/services/autosave.ts`: unaffected by compression, updated only for the `saveToStorage` signature change
- `src/index.html`: add the "compress file" checkbox to the save dialog, wired to the machine/dropbox/browser save buttons