### PR TITLE
Add a proper toast notification system

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -823,7 +823,7 @@ fieldset {
   font-size: calc(12px + 0.5vw);
   white-space: pre-line;
   z-index: 99999;
-  background: linear-gradient(0.1turn, #ffffff00, #c71d1d66, #ffffff00);
+  background: linear-gradient(0.1turn, #ffffff00, #5e5c5c80, #ffffff00);
 }
 
 #optionsContent table {

--- a/public/main.js
+++ b/public/main.js
@@ -360,7 +360,7 @@ function findBurgForMFCG(params) {
   }
 
   zoomTo(b.x, b.y, 8, 1600);
-  tip("Here stands the glorious city of " + b.name, true, "success", 15000);
+  toast("Here stands the glorious city of " + b.name, "success", 15000);
 }
 
 // add drag to upload logic, pull request from @evyatron

--- a/public/modules/ui/options.js
+++ b/public/modules/ui/options.js
@@ -177,7 +177,7 @@ function mapSizeInputChange() {
 
   if (tooWide || tooHigh) {
     const message = `Canvas size is larger than window size (${window.innerWidth} x ${window.innerHeight}). It can affect performance`;
-    tip(message, false, "warn", 4000);
+    toast(message, "warn", 4000);
   }
 }
 
@@ -266,7 +266,7 @@ function testSpeaker() {
 }
 
 function generateMapWithSeed() {
-  if (optionsSeed.value === seed) return tip("The current map already has this seed", false, "error");
+  if (optionsSeed.value === seed) return toast("The current map already has this seed", "error");
   regeneratePrompt({ seed: optionsSeed.value });
 }
 
@@ -308,10 +308,10 @@ function copyMapURL() {
   navigator.clipboard
     .writeText(location.host + location.pathname + search)
     .then(() => {
-      tip("Map URL is copied to clipboard", false, "success", 3000);
+      toast("Map URL is copied to clipboard", "success", 3000);
       //window.history.pushState({}, null, search);
     })
-    .catch(err => tip("Could not copy URL: " + err, false, "error", 5000));
+    .catch(err => toast("Could not copy URL: " + err, "error", 5000));
 }
 
 const cellsDensityMap = {
@@ -696,7 +696,7 @@ function regenerateEra() {
 function changeYear() {
   if (!yearInput.value) return;
   if (isNaN(+yearInput.value)) {
-    tip("Current year should be a number", false, "error");
+    toast("Current year should be a number", "error");
     return;
   }
   options.year = +yearInput.value;
@@ -724,7 +724,7 @@ ensureEl("sticked").addEventListener("click", function (event) {
 
 function regeneratePrompt(options) {
   if (customization)
-    return tip("New map cannot be generated when edit mode is active, please exit the mode and retry", false, "error");
+    return toast("New map cannot be generated when edit mode is active, please exit the mode and retry", "error");
   const workingTime = (Date.now() - last(mapHistory).created) / 60000; // minutes
   if (workingTime < 1) return regenerateMap(options);
 
@@ -765,7 +765,7 @@ function showSavePane() {
 function copyLinkToClickboard() {
   const shrableLink = ensureEl("sharableLink");
   const link = shrableLink.getAttribute("href");
-  navigator.clipboard.writeText(link).then(() => tip("Link is copied to the clipboard", true, "success", 8000));
+  navigator.clipboard.writeText(link).then(() => toast("Link is copied to the clipboard", "success", 8000));
 }
 
 ensureEl("showLabels").addEventListener("change", function () {
@@ -860,7 +860,7 @@ function loadURL() {
       Load: function () {
         const value = mapURL.value;
         if (!pattern.test(value)) {
-          tip("Please provide a valid URL", false, "error");
+          toast("Please provide a valid URL", "error");
           return;
         }
         window.Services.Load.loadMapFromURL(value);

--- a/public/modules/ui/style-presets.js
+++ b/public/modules/ui/style-presets.js
@@ -475,11 +475,11 @@ function addStylePreset() {
     const styleJSON = styleSaverJSON.value;
     const desiredName = styleSaverName.value;
 
-    if (!styleJSON) return tip("Please provide a style JSON", false, "error");
-    if (!JSON.isValid(styleJSON)) return tip("JSON string is not valid, please check the format", false, "error");
-    if (!desiredName) return tip("Please provide a preset name", false, "error");
+    if (!styleJSON) return toast("Please provide a style JSON", "error");
+    if (!JSON.isValid(styleJSON)) return toast("JSON string is not valid, please check the format", "error");
+    if (!desiredName) return toast("Please provide a preset name", "error");
     if (styleSaverTip.innerHTML === "default")
-      return tip("You cannot overwrite default preset, please change the name", false, "error");
+      return toast("You cannot overwrite default preset, please change the name", "error");
 
     const presetName = customPresetPrefix + desiredName;
     applyOption(stylePreset, presetName, desiredName + " [custom]");
@@ -487,7 +487,7 @@ function addStylePreset() {
     localStorage.setItem(presetName, styleJSON);
 
     applyStyleWithUiRefresh(JSON.parse(styleJSON));
-    tip("Style preset is saved and applied", false, "success", 4000);
+    toast("Style preset is saved and applied", "success", 4000);
     $("#styleSaver").dialog("close");
   }
 
@@ -495,9 +495,9 @@ function addStylePreset() {
     const styleJSON = styleSaverJSON.value;
     const styleName = styleSaverName.value;
 
-    if (!styleJSON) return tip("Please provide a style JSON", false, "error");
-    if (!JSON.isValid(styleJSON)) return tip("JSON string is not valid, please check the format", false, "error");
-    if (!styleName) return tip("Please provide a preset name", false, "error");
+    if (!styleJSON) return toast("Please provide a style JSON", "error");
+    if (!JSON.isValid(styleJSON)) return toast("JSON string is not valid, please check the format", "error");
+    if (!styleName) return toast("Please provide a preset name", "error");
 
     downloadFile(styleJSON, styleName + ".json", "application/json");
   }
@@ -507,21 +507,21 @@ function addStylePreset() {
     uploadFile(this, styleUpload);
 
     function styleUpload(dataLoaded) {
-      if (!dataLoaded) return tip("Cannot load the file. Please check the data format", false, "error");
+      if (!dataLoaded) return toast("Cannot load the file. Please check the data format", "error");
       const isValid = JSON.isValid(dataLoaded);
-      if (!isValid) return tip("Loaded data is not a valid JSON, please check the format", false, "error");
+      if (!isValid) return toast("Loaded data is not a valid JSON, please check the format", "error");
 
       styleSaverJSON.value = JSON.stringify(JSON.parse(dataLoaded), null, 2);
       styleSaverName.value = fileName;
       checkName();
-      tip("Style preset is uploaded", false, "success", 4000);
+      toast("Style preset is uploaded", "success", 4000);
     }
   }
 }
 
 function requestRemoveStylePreset() {
   const isDefault = systemPresets.includes(stylePreset.value);
-  if (isDefault) return tip("Cannot remove system preset", false, "error");
+  if (isDefault) return toast("Cannot remove system preset", "error");
 
   confirmationDialog({
     title: "Remove style preset",

--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -754,7 +754,7 @@ openCreateHeightmapSchemeButton.addEventListener("click", function () {
 
   function handleCreate() {
     const stops = openCreateHeightmapSchemeButton.dataset.stops;
-    if (stops in heightmapColorSchemes) return tip("This scheme already exists", false, "error");
+    if (stops in heightmapColorSchemes) return toast("This scheme already exists", "error");
 
     addCustomColorScheme(stops);
     getEl().attr("scheme", stops);
@@ -919,13 +919,13 @@ styleFontAdd.addEventListener("click", function () {
         const src = addFontURLInput.value;
         const method = addFontMethod.value;
 
-        if (!family) return tip("Please provide a font name", false, "error");
+        if (!family) return toast("Please provide a font name", "error");
 
         const existingFont =
           method === "fontURL"
             ? fonts.find(font => font.family === family && font.src === src)
             : fonts.find(font => font.family === family);
-        if (existingFont) return tip("The font is already added", false, "error");
+        if (existingFont) return toast("The font is already added", "error");
 
         if (method === "fontURL") addWebFont(family, src);
         else if (method === "googleFont") addGoogleFont(family);
@@ -1103,7 +1103,7 @@ function textureProvideURL() {
     width: "28em",
     buttons: {
       Apply: function () {
-        if (!textureURL.value) return tip("Please provide a valid URL", false, "error");
+        if (!textureURL.value) return toast("Please provide a valid URL", "error");
         changeTexture(textureURL.value);
         updateTextureSelectValue(textureURL.value);
         $(this).dialog("close");

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -12,3 +12,5 @@ import "./dialog/dialog-helpers";
 import "./dialog/sorting";
 import "./fill-box";
 import "./slider-input";
+import "./toast/container";
+import "./toast"; // registers window.toast for legacy public/ scripts outside the module graph

--- a/src/components/map-placement.ts
+++ b/src/components/map-placement.ts
@@ -10,7 +10,6 @@ export function toggleMapPlacement(
   buttonId: string,
   onClick: (event: MouseEvent) => void,
   message: string,
-  type?: "warn",
   onStop?: () => void
 ): boolean {
   const button = ensureEl(buttonId);
@@ -23,7 +22,7 @@ export function toggleMapPlacement(
   button.classList.add("pressed");
   cleanupActivePlacement = onStop;
   select<SVGGElement, unknown>("#viewbox").style("cursor", "crosshair").on("click", onClick);
-  tip(message, true, type);
+  tip(message, true);
   return true;
 }
 

--- a/src/components/toast/container.ts
+++ b/src/components/toast/container.ts
@@ -23,6 +23,13 @@ styleElement.innerHTML = style;
 document.head.appendChild(styleElement);
 
 class ToastContainer extends HTMLElement {
+  // Custom element constructors must not add attributes; set these once connected instead.
+  connectedCallback() {
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+    this.setAttribute("role", "status");
+  }
+
   show(message: string, type: ToastType = "info", duration = 4000): void {
     const item = document.createElement("toast-item") as ToastItemElement;
     item.type = type;

--- a/src/components/toast/container.ts
+++ b/src/components/toast/container.ts
@@ -1,0 +1,37 @@
+// <toast-container> — stacks <toast-item> notifications; use the `toast()` helper
+// from "@/components/toast" rather than calling the element directly.
+import "./item";
+import type { ToastItemElement, ToastType } from "./item";
+
+const style = /* css */ `
+  toast-container {
+    position: fixed;
+    top: 0.6em;
+    right: 0.6em;
+    z-index: 99999;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.4em;
+    pointer-events: none;
+  }
+`;
+
+const styleElement = document.createElement("style");
+styleElement.setAttribute("type", "text/css");
+styleElement.innerHTML = style;
+document.head.appendChild(styleElement);
+
+class ToastContainer extends HTMLElement {
+  show(message: string, type: ToastType = "info", duration = 4000): void {
+    const item = document.createElement("toast-item") as ToastItemElement;
+    item.type = type;
+    item.message = message;
+    this.prepend(item);
+    if (duration) item.autoDismiss(duration);
+  }
+}
+
+customElements.define("toast-container", ToastContainer);
+
+export type ToastContainerElement = InstanceType<typeof ToastContainer>;

--- a/src/components/toast/index.ts
+++ b/src/components/toast/index.ts
@@ -1,0 +1,12 @@
+// Pure, side-effect-free entry point for showing toasts. Deliberately kept separate from
+// ./container so importing this function doesn't trigger that module's
+// customElements.define/document.createElement side effects (e.g. in Node-env tests).
+// The custom elements themselves are registered via "@/components" (see components/index.ts).
+import type { ToastContainerElement } from "./container";
+import type { ToastType } from "./item";
+
+export function toast(message: string, type: ToastType = "info", duration: number = 4000): void {
+  document.querySelector<ToastContainerElement>("toast-container")?.show(message, type, duration);
+}
+
+window.toast = toast;

--- a/src/components/toast/index.ts
+++ b/src/components/toast/index.ts
@@ -1,7 +1,8 @@
-// Pure, side-effect-free entry point for showing toasts. Deliberately kept separate from
-// ./container so importing this function doesn't trigger that module's
-// customElements.define/document.createElement side effects (e.g. in Node-env tests).
-// The custom elements themselves are registered via "@/components" (see components/index.ts).
+// Entry point for showing toasts. Deliberately kept separate from ./container so importing
+// this function doesn't trigger that module's customElements.define/document.createElement
+// calls (which throw in Node-env tests without a real DOM). The custom elements themselves are
+// registered via "@/components" (see components/index.ts). The only side effect here is
+// registering the window.toast bridge below, for legacy public/ scripts outside the module graph.
 import type { ToastContainerElement } from "./container";
 import type { ToastType } from "./item";
 

--- a/src/components/toast/item.ts
+++ b/src/components/toast/item.ts
@@ -1,0 +1,165 @@
+// <toast-item> — a single dismissible, auto-expiring notification card
+
+export type ToastType = "info" | "success" | "warn" | "error";
+
+const style = /* css */ `
+  toast-item {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 0.7em;
+    pointer-events: auto;
+    max-width: 26em;
+    padding: 0.6em 0.8em 0.75em;
+    border: 1px solid var(--dark-solid, #5e4fa2);
+    border-left-width: 4px;
+    border-radius: 1px;
+    box-shadow: 0.5px 0.5px 0px var(--dark-solid, #5e4fa2);
+    background: var(--bg-dialogs, #f2f2f2);
+    color: #333333;
+    font-family: var(--sans-serif);
+    font-size: 1rem;
+    white-space: pre-line;
+    opacity: 0;
+    transform: translateY(0.5em);
+    overflow: hidden;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+
+  toast-item.shown {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  toast-item[data-type="info"] {
+    border-left-color: #5e5c5c;
+  }
+
+  toast-item[data-type="success"] {
+    border-left-color: #127912;
+  }
+
+  toast-item[data-type="warn"] {
+    border-left-color: #be5d08;
+  }
+
+  toast-item[data-type="error"] {
+    border-left-color: #c13119;
+  }
+
+  toast-item .toast-message {
+    flex: 1;
+  }
+
+  toast-item .toast-close {
+    background: none;
+    border: none;
+    color: var(--dark-solid, #5e4fa2);
+    cursor: pointer;
+    font-size: 1.1em;
+    line-height: 1;
+    opacity: 0.7;
+  }
+
+  toast-item .toast-close:hover {
+    opacity: 1;
+  }
+
+  toast-item .toast-timebar {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    height: 3px;
+    width: 100%;
+    transform-origin: left;
+  }
+
+  toast-item[data-type="info"] .toast-timebar {
+    background: #5e5c5c;
+  }
+
+  toast-item[data-type="success"] .toast-timebar {
+    background: #127912;
+  }
+
+  toast-item[data-type="warn"] .toast-timebar {
+    background: #be5d08;
+  }
+
+  toast-item[data-type="error"] .toast-timebar {
+    background: #c13119;
+  }
+`;
+
+const styleElement = document.createElement("style");
+styleElement.setAttribute("type", "text/css");
+styleElement.innerHTML = style;
+document.head.appendChild(styleElement);
+
+const template = document.createElement("template");
+template.innerHTML = /* html */ `
+  <span class="toast-message"></span>
+  <button type="button" class="toast-close" aria-label="Dismiss">&times;</button>
+  <div class="toast-timebar"></div>
+`;
+
+class ToastItem extends HTMLElement {
+  private pendingMessage = "";
+  private timebarAnimation?: Animation;
+
+  // Custom element constructors must not add children (document.createElement throws
+  // a NotSupportedError otherwise); build the template once connected instead.
+  connectedCallback() {
+    this.appendChild(template.content.cloneNode(true));
+    this.querySelector(".toast-message")!.innerHTML = this.pendingMessage;
+    this.querySelector(".toast-close")?.addEventListener("click", () => this.dismiss());
+    this.addEventListener("mouseenter", () => this.timebarAnimation?.pause());
+    this.addEventListener("mouseleave", () => this.timebarAnimation?.play());
+    // Double rAF before adding the class: without it the browser can coalesce the initial
+    // and "shown" styles into one frame and skip the enter transition entirely.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => this.classList.add("shown"));
+    });
+  }
+
+  set message(message: string) {
+    this.pendingMessage = message;
+    const messageEl = this.querySelector(".toast-message");
+    if (messageEl) messageEl.innerHTML = message;
+  }
+
+  set type(type: ToastType) {
+    this.dataset.type = type;
+  }
+
+  // The Web Animations API gives us native pause()/play() (hover pauses the dismiss timer),
+  // which a hand-rolled CSS transition + manual freeze/resume can't do reliably: resuming a
+  // CSS transition from a frozen mid-animation value tends to jump straight to the end state
+  // instead of continuing to animate.
+  autoDismiss(duration: number) {
+    const timebar = this.querySelector<HTMLElement>(".toast-timebar");
+    if (!timebar) return;
+
+    this.timebarAnimation = timebar.animate([{ transform: "scaleX(1)" }, { transform: "scaleX(0)" }], {
+      duration,
+      easing: "linear",
+      fill: "forwards"
+    });
+    this.timebarAnimation.onfinish = () => this.dismiss();
+  }
+
+  dismiss() {
+    this.timebarAnimation?.cancel();
+    this.classList.remove("shown");
+    const onTransitionEnd = (event: TransitionEvent) => {
+      if (event.target !== this) return;
+      this.removeEventListener("transitionend", onTransitionEnd);
+      this.remove();
+    };
+    this.addEventListener("transitionend", onTransitionEnd);
+  }
+}
+
+customElements.define("toast-item", ToastItem);
+
+export type ToastItemElement = InstanceType<typeof ToastItem>;

--- a/src/components/toast/item.ts
+++ b/src/components/toast/item.ts
@@ -106,12 +106,17 @@ template.innerHTML = /* html */ `
 class ToastItem extends HTMLElement {
   private pendingMessage = "";
   private timebarAnimation?: Animation;
+  private built = false;
 
   // Custom element constructors must not add children (document.createElement throws
-  // a NotSupportedError otherwise); build the template once connected instead.
+  // a NotSupportedError otherwise); build the template once connected instead. Guard against
+  // building twice: connectedCallback re-runs if the element is ever disconnected and reattached.
   connectedCallback() {
+    if (this.built) return;
+    this.built = true;
+
     this.appendChild(template.content.cloneNode(true));
-    this.querySelector(".toast-message")!.innerHTML = this.pendingMessage;
+    this.querySelector(".toast-message")!.textContent = this.pendingMessage;
     this.querySelector(".toast-close")?.addEventListener("click", () => this.dismiss());
     this.addEventListener("mouseenter", () => this.timebarAnimation?.pause());
     this.addEventListener("mouseleave", () => this.timebarAnimation?.play());
@@ -125,7 +130,7 @@ class ToastItem extends HTMLElement {
   set message(message: string) {
     this.pendingMessage = message;
     const messageEl = this.querySelector(".toast-message");
-    if (messageEl) messageEl.innerHTML = message;
+    if (messageEl) messageEl.textContent = message;
   }
 
   set type(type: ToastType) {
@@ -151,12 +156,22 @@ class ToastItem extends HTMLElement {
   dismiss() {
     this.timebarAnimation?.cancel();
     this.classList.remove("shown");
+
+    let removed = false;
+    const removeOnce = () => {
+      if (removed) return;
+      removed = true;
+      this.remove();
+    };
     const onTransitionEnd = (event: TransitionEvent) => {
       if (event.target !== this) return;
       this.removeEventListener("transitionend", onTransitionEnd);
-      this.remove();
+      removeOnce();
     };
     this.addEventListener("transitionend", onTransitionEnd);
+    // Fallback in case transitionend never fires (e.g. reduced-motion overrides or the
+    // element is disconnected before the transition can run).
+    setTimeout(removeOnce, 300);
   }
 }
 

--- a/src/components/tools.ts
+++ b/src/components/tools.ts
@@ -1,6 +1,6 @@
 import { refreshEditors } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { Controllers } from "@/controllers";
 import { Emblems } from "@/generators/emblems-generator";
 import { Population } from "@/generators/population-generator";
@@ -8,7 +8,7 @@ import { unfog } from "@/renderers/overlays/fogging";
 import { ensureEl, gauss, isCtrlClick } from "@/utils";
 
 ensureEl("toolsContent").addEventListener("click", event => {
-  if (customization) return tip("Please exit the customization mode first", false, "error");
+  if (customization) return toast("Please exit the customization mode first", "error");
   if (!(event instanceof MouseEvent) || !(event.target instanceof HTMLElement)) return;
   if (!["BUTTON", "I"].includes(event.target.tagName)) return;
 
@@ -138,8 +138,8 @@ function regeneratePopulation(): void {
 
 function regenerateStates(): void {
   const { warning, error } = States.regenerate();
-  if (error) return void tip(error, false, "error");
-  if (warning) tip(warning, false, "warn");
+  if (error) return void toast(error, "error");
+  if (warning) toast(warning, "warn");
 
   unfog();
   Layers.draw("states", "borders", "provinces", "labels", "burgIcons", "military", "goods", "emblems");

--- a/src/components/tooltips.ts
+++ b/src/components/tooltips.ts
@@ -1,45 +1,26 @@
 import { debounce, ensureEl, findEl } from "@/utils";
 
-type TipType = "info" | "success" | "warn" | "error";
-
-const TIP_BACKGROUND: Record<TipType, string> = {
-  info: "linear-gradient(0.1turn, #ffffff00, #5e5c5c80, #ffffff00)",
-  success: "linear-gradient(0.1turn, #ffffff00, #127912cc, #ffffff00)",
-  warn: "linear-gradient(0.1turn, #ffffff00, #be5d08cc, #ffffff00)",
-  error: "linear-gradient(0.1turn, #ffffff00, #e11d1dcc, #ffffff00)"
-};
-
 const getTooltip = () => ensureEl("tooltip");
 
 /**
- * Show a message in the tooltip line
+ * Show a message in the hover-tooltip line
  * @param message - text to show, may contain html
  * @param main - pin the message so it is restored after transient tips
- * @param type - defines the tooltip background color
- * @param time - if set, clear the main tip after that many ms
  */
-export function tip(message: string, main = false, type: TipType = "info", time = 0): void {
+export function tip(message: string, main = false): void {
   const tooltip = getTooltip();
   tooltip.innerHTML = message;
-  tooltip.style.background = TIP_BACKGROUND[type];
 
-  if (main) {
-    tooltip.dataset.main = message;
-    tooltip.dataset.color = tooltip.style.background;
-  }
-
-  if (time) setTimeout(clearMainTip, time);
+  if (main) tooltip.dataset.main = message;
 }
 
 export function showMainTip(): void {
   const tooltip = getTooltip();
-  tooltip.style.background = tooltip.dataset.color || "";
   tooltip.innerHTML = tooltip.dataset.main || "";
 }
 
 export function clearMainTip(): void {
   const tooltip = getTooltip();
-  tooltip.dataset.color = "";
   tooltip.dataset.main = "";
   tooltip.innerHTML = "";
 }

--- a/src/controllers/ai-generator.ts
+++ b/src/controllers/ai-generator.ts
@@ -1,5 +1,5 @@
 import { destroyDialog } from "@/components/dialog/dialog-helpers";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { openURL } from "@/utils";
 import { ensureEl } from "../utils";
 
@@ -198,7 +198,7 @@ function open(defaultPrompt: string, onApply: (result: string) => void): void {
       },
       Apply: function (this: HTMLElement) {
         const result = ensureEl<HTMLTextAreaElement>("aiGeneratorResult").value;
-        if (!result) return tip("No result to apply", true, "error", 4000);
+        if (!result) return toast("No result to apply", "error", 4000);
         onApply(result);
         $(this).dialog("close");
       },
@@ -273,20 +273,20 @@ function setInitialValues(defaultPrompt: string): void {
 
 async function generate(button: HTMLButtonElement): Promise<void> {
   const key = ensureEl<HTMLInputElement>("aiGeneratorKey").value;
-  if (!key) return tip("Please enter an API key", true, "error", 4000);
+  if (!key) return toast("Please enter an API key", "error", 4000);
 
   const model = ensureEl<HTMLSelectElement>("aiGeneratorModel").value;
-  if (!model) return tip("Please select a model", true, "error", 4000);
+  if (!model) return toast("Please select a model", "error", 4000);
   localStorage.setItem("fmg-ai-model", model);
 
   const provider = MODELS[model];
   localStorage.setItem(`fmg-ai-kl-${provider}`, key);
 
   const prompt = ensureEl<HTMLTextAreaElement>("aiGeneratorPrompt").value;
-  if (!prompt) return tip("Please enter a prompt", true, "error", 4000);
+  if (!prompt) return toast("Please enter a prompt", "error", 4000);
 
   const temperature = ensureEl<HTMLInputElement>("aiGeneratorTemperature").valueAsNumber;
-  if (Number.isNaN(temperature)) return tip("Temperature must be a number", true, "error", 4000);
+  if (Number.isNaN(temperature)) return toast("Temperature must be a number", "error", 4000);
   localStorage.setItem("fmg-ai-temperature", String(temperature));
 
   try {
@@ -301,7 +301,7 @@ async function generate(button: HTMLButtonElement): Promise<void> {
     await PROVIDERS[provider].generate({ key, model, prompt, temperature, onContent });
   } catch (error) {
     const message = (error instanceof Error && error.message) || String(error) || "Failed to generate text";
-    return tip(message, true, "error", 4000);
+    return toast(message, "error", 4000);
   } finally {
     button.disabled = false;
     ensureEl<HTMLTextAreaElement>("aiGeneratorResult").disabled = false;

--- a/src/controllers/battle-screen.ts
+++ b/src/controllers/battle-screen.ts
@@ -2,7 +2,7 @@ import { mean, select, sum } from "d3";
 import { closeDialogs } from "@/components/dialog/dialog-helpers";
 import { applySorting, applySortingByHeader } from "@/components/dialog/sorting";
 import { Layers } from "@/components/layers";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { moveRegiment } from "@/renderers/draw-military";
 import type { Marker } from "../generators/markers-generator";
 import type { Regiment } from "../generators/military-generator";
@@ -636,7 +636,7 @@ function addSide(): void {
   function selectLine(event: Event): void {
     const target = event.target as HTMLElement;
     if (target.className === "inactive") {
-      tip("Regiment is already in the battle", false, "error");
+      toast("Regiment is already in the battle", "error");
       return;
     }
     target.classList.toggle("selected");
@@ -645,7 +645,7 @@ function addSide(): void {
   function addSideClicked(side: Side): void {
     const selected = body.querySelectorAll<HTMLElement>(".selected");
     if (!selected.length) {
-      tip("Please select a regiment first", false, "error");
+      toast("Please select a regiment first", "error");
       return;
     }
 
@@ -1089,11 +1089,11 @@ function runBattle(): void {
   const b = battle!;
   // validations
   if (!b.attackers.power) {
-    tip("Attackers army destroyed", false, "warn");
+    toast("Attackers army destroyed", "warn");
     return;
   }
   if (!b.defenders.power) {
-    tip("Defenders army destroyed", false, "warn");
+    toast("Defenders army destroyed", "warn");
     return;
   }
 
@@ -1360,7 +1360,7 @@ function applyResults(): void {
 
   notes.push({ id: `marker${i}`, name: b.name, legend });
 
-  tip(`${b.name} is over. ${result}`, true, "success", 4000);
+  toast(`${b.name} is over. ${result}`, "success", 4000);
 
   closeBattleScreen();
   cleanData();

--- a/src/controllers/biomes-editor.ts
+++ b/src/controllers/biomes-editor.ts
@@ -12,7 +12,7 @@ import {
 } from "@/components/dialog/table";
 import type { FillBoxElement } from "@/components/fill-box";
 import { Layers } from "@/components/layers";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { Controllers } from "@/controllers";
 import type { Biome } from "@/generators/biomes-generator";
 import { Population } from "@/generators/population-generator";
@@ -323,7 +323,7 @@ function biomeChangeHabitability(el: HTMLInputElement): void {
   const failed = Number.isNaN(+el.value) || +el.value < 0 || +el.value > 9999;
   if (failed) {
     el.value = String(pack.biomes[biome].habitability);
-    tip("Please provide a valid number in range 0-9999", false, "error");
+    toast("Please provide a valid number in range 0-9999", "error");
     return;
   }
   pack.biomes[biome].habitability = +el.value;
@@ -335,7 +335,7 @@ function biomeChangeHabitability(el: HTMLInputElement): void {
 function openWiki(el: HTMLElement): void {
   const biomeName = el.closest<HTMLElement>(".biomes")?.dataset.name;
   if (biomeName === "Custom" || !biomeName) {
-    tip("Please fill in the biome name", false, "error");
+    toast("Please fill in the biome name", "error");
     return;
   }
 
@@ -428,7 +428,7 @@ export function removeCustomBiome(biomes: Biome[], cellBiomes: ArrayLike<number>
 function addCustomBiome(): void {
   const biome = createCustomBiome(pack.biomes, getRandomColor());
   if (!biome) {
-    tip("Maximum number of biomes reached (255), data cleansing is required", false, "error");
+    toast("Maximum number of biomes reached (255), data cleansing is required", "error");
     return;
   }
 

--- a/src/controllers/burg-creator.ts
+++ b/src/controllers/burg-creator.ts
@@ -2,7 +2,7 @@ import { pointer } from "d3";
 import { closeDialogs, refreshEditors } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
 import { stopMapPlacement, toggleMapPlacement } from "@/components/map-placement";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { redrawEmblem } from "@/renderers/draw-emblems";
 
 function toggle(): void {
@@ -16,7 +16,6 @@ function toggle(): void {
     "addBurgTool",
     addOnClick,
     "Click on the map to create a new burg. Hold Shift to add multiple",
-    "warn",
     unpressProxyButton
   );
   document.getElementById("addNewBurg")?.classList.add("pressed");
@@ -30,11 +29,11 @@ function addOnClick(event: MouseEvent): void {
   if (cell === undefined) return;
 
   if (pack.cells.h[cell] < 20) {
-    tip("You cannot place a burg in the water. Please click on a land cell", false, "error");
+    toast("You cannot place a burg in the water. Please click on a land cell", "error");
     return;
   }
   if (pack.cells.burg[cell]) {
-    tip("There is already a burg in this cell. Please select a free cell", false, "error");
+    toast("There is already a burg in this cell. Please select a free cell", "error");
     return;
   }
 

--- a/src/controllers/burg-editor.ts
+++ b/src/controllers/burg-editor.ts
@@ -1,6 +1,7 @@
 import { type Selection, select } from "d3";
 import { closeDialogs, confirmationDialog, destroyDialog } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { clearMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
@@ -424,7 +425,7 @@ function togglePort(burgId: number): void {
     } else {
       portFeatureId = Rivers.resolveDrainFeature(burg.cell);
       if (!portFeatureId) {
-        tip("No navigable water body found downstream, cannot assign port", false, "warn");
+        toast("No navigable water body found downstream, cannot assign port", "warn");
         return;
       }
     }
@@ -446,13 +447,13 @@ function toggleCapital(burgId: number): void {
   const { burgs, states } = pack;
 
   if (burgs[burgId].capital) {
-    tip("To change capital please assign a capital status to another burg of this state", false, "error");
+    toast("To change capital please assign a capital status to another burg of this state", "error");
     return;
   }
 
   const stateId = burgs[burgId].state;
   if (!stateId) {
-    tip("Neutral lands cannot have a capital", false, "error");
+    toast("Neutral lands cannot have a capital", "error");
     return;
   }
 
@@ -734,18 +735,18 @@ function relocateBurgOnClick(this: SVGGElement, event: any): void {
   const burg = pack.burgs[id];
 
   if (cells.h[cellId] < 20) {
-    tip("Cannot place burg into the water! Select a land cell", false, "error");
+    toast("Cannot place burg into the water! Select a land cell", "error");
     return;
   }
   if (cells.burg[cellId] && cells.burg[cellId] !== id) {
-    tip("There is already a burg in this cell. Please select a free cell", false, "error");
+    toast("There is already a burg in this cell. Please select a free cell", "error");
     return;
   }
 
   const newState = cells.state[cellId];
   const oldState = burg.state;
   if (newState !== oldState && burg.capital) {
-    tip("Capital cannot be relocated into another state!", false, "error");
+    toast("Capital cannot be relocated into another state!", "error");
     return;
   }
 

--- a/src/controllers/burg-group-editor.ts
+++ b/src/controllers/burg-group-editor.ts
@@ -1,6 +1,6 @@
 import { closeDialogs, confirmationDialog, destroyDialog, refreshEditors } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { Controllers } from "@/controllers";
 import type { BurgGroup } from "@/types/burg-groups";
 import { ensureEl } from "../utils";
@@ -207,7 +207,7 @@ function selectLimitation(
           return acc;
         }, []);
 
-        if (!selected.length) return tip("Select at least one element", false, "error");
+        if (!selected.length) return toast("Select at least one element", "error");
 
         const allAreSelected = selected.length === inputs.length;
         (el.previousElementSibling as HTMLInputElement).value = allAreSelected ? "" : selected.join(",");
@@ -297,7 +297,7 @@ function selectFeaturesLimitation(el: HTMLElement): void {
 function removeRow(row: HTMLElement): void {
   const rows = ensureEl("burgGroupsBody").children;
   if (rows.length < 2) {
-    tip("At least one group should be defined", false, "error");
+    toast("At least one group should be defined", "error");
     return;
   }
 
@@ -408,7 +408,7 @@ function submitForm(event: Event): void {
 
   const rows = Array.from(ensureEl("burgGroupsBody").children);
   if (!rows.length) {
-    tip("At least one group should be defined", false, "error");
+    toast("At least one group should be defined", "error");
     return;
   }
 

--- a/src/controllers/burgs-overview.ts
+++ b/src/controllers/burgs-overview.ts
@@ -12,6 +12,7 @@ import {
   type TableView
 } from "@/components/dialog/table";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { tip } from "@/components/tooltips";
 import { Controllers } from "@/controllers";
 import type { Burg } from "@/generators/burgs-generator";
@@ -453,7 +454,7 @@ function openBurgEditor(this: HTMLElement): void {
 function triggerBurgRemove(this: HTMLElement): void {
   const burgId = +(this.closest(".states") as HTMLElement).dataset.id!;
   if (pack.burgs[burgId].capital) {
-    tip("You cannot remove the capital. Please change the state capital first", false, "error");
+    toast("You cannot remove the capital. Please change the state capital first", "error");
     return;
   }
 
@@ -513,7 +514,7 @@ function showBurgsChart(): void {
     });
   const data: any[] = (states as any[]).concat(burgs);
   if (data.length < 2) {
-    tip("No burgs to show", false, "error");
+    toast("No burgs to show", "error");
     return;
   }
 
@@ -734,7 +735,7 @@ function renameBurgsInBulk(): void {
 
 function importBurgNames(dataLoaded: string): void {
   if (!dataLoaded) {
-    tip("Cannot load the file, please check the format", false, "error");
+    toast("Cannot load the file, please check the format", "error");
     return;
   }
   const data = dataLoaded
@@ -742,7 +743,7 @@ function importBurgNames(dataLoaded: string): void {
     .split("\n")
     .filter(Boolean);
   if (!data.length) {
-    tip("Cannot parse the list, please check the file format", false, "error");
+    toast("Cannot parse the list, please check the file format", "error");
     return;
   }
 

--- a/src/controllers/charts-overview.ts
+++ b/src/controllers/charts-overview.ts
@@ -18,6 +18,7 @@ import {
   sum
 } from "d3";
 import { closeDialogs } from "@/components/dialog/dialog-helpers";
+import { toast } from "@/components/toast";
 import { tip } from "@/components/tooltips";
 import { downloadFile, getArea, getAreaUnit, getFileName, getHeight, getPrecipitation } from "@/utils";
 import { capitalize, convertTemperature, ensureEl, formatPrice, isWater, rn, si } from "../utils";
@@ -560,17 +561,12 @@ function addChart(event?: Event) {
   };
   const incompatible = [entity, groupBy].find(lacksTag);
   if (incompatible) {
-    tip(
-      `${plotByLabel} cannot be broken down by ${entitiesMap[incompatible].label.toLowerCase()}`,
-      false,
-      "error",
-      4000
-    );
+    toast(`${plotByLabel} cannot be broken down by ${entitiesMap[incompatible].label.toLowerCase()}`, "error", 4000);
     return;
   }
 
   if (!stackable && groupBy !== entity) {
-    tip(`Grouping is not supported for ${plotBy}`, false, "warn", 4000);
+    toast(`Grouping is not supported for ${plotBy}`, "warn", 4000);
     groupBy = entity;
   }
 

--- a/src/controllers/coastline-vertex-editor.ts
+++ b/src/controllers/coastline-vertex-editor.ts
@@ -1,6 +1,7 @@
 import { type D3DragEvent, drag, type Selection, select } from "d3";
 import { closeDialogs, destroyDialog } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Coastline } from "@/generators/coastline-generator";
@@ -198,12 +199,12 @@ function createNewGroup(this: HTMLInputElement): void {
     .replace(/[^\w\s]/gi, "");
 
   if (findEl(group)) {
-    tip("Element with this id already exists. Please provide a unique name", false, "error");
+    toast("Element with this id already exists. Please provide a unique name", "error");
     return;
   }
 
   if (Number.isFinite(+group.charAt(0))) {
-    tip("Group name should start with a letter", false, "error");
+    toast("Group name should start with a letter", "error");
     return;
   }
 
@@ -235,7 +236,7 @@ function createNewGroup(this: HTMLInputElement): void {
 function removeCoastlineGroup(): void {
   const group = (selectedCoastline.node()!.parentNode as SVGGElement).id;
   if (["sea_island", "lake_island"].includes(group)) {
-    tip("This is one of the default groups, it cannot be removed", false, "error");
+    toast("This is one of the default groups, it cannot be removed", "error");
     return;
   }
 

--- a/src/controllers/color-picker.ts
+++ b/src/controllers/color-picker.ts
@@ -1,5 +1,6 @@
 // The fill picker: an SVG overlay to pick a color or a hatching pattern.
 import { type D3DragEvent, drag, hsl, rgb, select } from "d3";
+import { toast } from "@/components/toast";
 import { tip } from "@/components/tooltips";
 import { parseTransform, rn } from "@/utils";
 
@@ -297,7 +298,7 @@ function onControlDrag(
 
 function onSpaceChanged(event: Event, callback: (fill: string) => void): void {
   const input = event.currentTarget as HTMLInputElement;
-  const invalid = () => tip("You must provide a correct value", false, "error");
+  const invalid = () => toast("You must provide a correct value", "error");
   if (!input.checkValidity()) return void invalid();
 
   const space = input.dataset.space as ColorSpace;

--- a/src/controllers/cultures-editor.ts
+++ b/src/controllers/cultures-editor.ts
@@ -13,6 +13,7 @@ import {
 } from "@/components/dialog/table";
 import type { FillBoxElement } from "@/components/fill-box";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { clearMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
@@ -490,7 +491,7 @@ function cultureRegenerateName(this: HTMLElement): void {
   const cultureId = +(this.closest(".states") as HTMLElement).dataset.id!;
   const base = pack.cultures[cultureId].base;
   if (!Names.nameBases[base]) {
-    tip("Namesbase is not defined, please select a valid namesbase", false, "error", 5000);
+    toast("Namesbase is not defined, please select a valid namesbase", "error", 5000);
     return;
   }
 
@@ -569,7 +570,7 @@ function changePopulation(this: HTMLElement): void {
   const cultureId = +(this.closest(".states") as HTMLElement).dataset.id!;
   const culture = pack.cultures[cultureId];
   if (!culture.cells) {
-    tip("Culture does not have any cells, cannot change population", false, "error");
+    toast("Culture does not have any cells, cannot change population", "error");
     return;
   }
 
@@ -671,7 +672,7 @@ function cultureRegenerateBurgs(this: HTMLElement): void {
   const cultureId = +(this.closest(".states") as HTMLElement).dataset.id!;
   const base = pack.cultures[cultureId].base;
   if (!Names.nameBases[base]) {
-    tip("Namesbase is not defined, please select a valid namesbase", false, "error", 5000);
+    toast("Namesbase is not defined, please select a valid namesbase", "error", 5000);
     return;
   }
 
@@ -680,7 +681,7 @@ function cultureRegenerateBurgs(this: HTMLElement): void {
     b.name = Names.getCulture(cultureId);
   });
   Layers.draw("labels");
-  tip(`Names for ${cultureBurgs.length} burgs are regenerated`, false, "success");
+  toast(`Names for ${cultureBurgs.length} burgs are regenerated`, "success");
 }
 
 function removeCulture(cultureId: number): void {
@@ -925,13 +926,13 @@ function addCulture(this: SVGElement, event: MouseEvent): void {
   const center = findCell(point[0], point[1])!;
 
   if (pack.cells.h[center] < 20) {
-    tip("You cannot place culture center into the water. Please click on a land cell", false, "error");
+    toast("You cannot place culture center into the water. Please click on a land cell", "error");
     return;
   }
 
   const occupied = pack.cultures.some(c => !c.removed && c.center === center);
   if (occupied) {
-    tip("This cell is already a culture center. Please select a different cell", false, "error");
+    toast("This cell is already a culture center. Please select a different cell", "error");
     return;
   }
 

--- a/src/controllers/diplomacy-editor.ts
+++ b/src/controllers/diplomacy-editor.ts
@@ -11,7 +11,8 @@ import {
   type TableView
 } from "@/components/dialog/table";
 import { Layers } from "@/components/layers";
-import { clearMainTip, tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
+import { clearMainTip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import type { State } from "@/generators/states-generator";
 import { EmblemRenderer } from "@/renderers/emblems/renderer";
@@ -102,7 +103,7 @@ const getChronicle = () => pack.states[0].diplomacy as unknown as string[][];
 function open(): void {
   if (customization) return;
   if (pack.states.filter(s => s.i && !s.removed).length < 2) {
-    tip("There should be at least 2 states to edit the diplomacy", false, "error");
+    toast("There should be at least 2 states to edit the diplomacy", "error");
     return;
   }
   if (!selectedDiplomacyId || !pack.states[selectedDiplomacyId] || pack.states[selectedDiplomacyId].removed) {

--- a/src/controllers/elevation-profile.ts
+++ b/src/controllers/elevation-profile.ts
@@ -14,6 +14,7 @@ import {
   select
 } from "d3";
 import { closeDialogs } from "@/components/dialog/dialog-helpers";
+import { toast } from "@/components/toast";
 import { tip } from "@/components/tooltips";
 import { downloadFile, getFileName, getHeight, getLatitude, getLongitude } from "@/utils";
 import type { Burg } from "../generators/burgs-generator";
@@ -33,7 +34,7 @@ function open(cells: number[], routeLen: number, isRiver: boolean): void {
   const firstCell = cells[0];
   const lastCell = cells.at(-1);
   if (firstCell === undefined || lastCell === undefined) {
-    tip("Elevation profile: no data", true, "error");
+    toast("Elevation profile: no data", "error");
     return;
   }
 

--- a/src/controllers/emblems-editor.ts
+++ b/src/controllers/emblems-editor.ts
@@ -1,6 +1,7 @@
 import { type D3DragEvent, drag, select } from "d3";
 import { destroyDialog } from "@/components/dialog/dialog-helpers";
-import { clearMainTip, tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
+import { clearMainTip } from "@/components/tooltips";
 import type { Burg } from "@/generators/burgs-generator";
 import { Emblems } from "@/generators/emblems-generator";
 import type { Province } from "@/generators/provinces-generator";
@@ -35,7 +36,7 @@ async function openDefault(): Promise<void> {
   const type = firstState ? "state" : "burg";
   const element = firstState ?? firstBurg;
   if (!element?.coa) {
-    tip("No emblems to edit, please generate states and burgs first", false, "error");
+    toast("No emblems to edit, please generate states and burgs first", "error");
     return;
   }
 
@@ -451,7 +452,7 @@ function upload(type: "image" | "svg"): void {
   if (file.size > 500000) {
     const message =
       "File is too big, please optimize file size up to 500kB and re-upload. Recommended size is 200x200 px and up to 100kB";
-    tip(message, true, "error", 5000);
+    toast(message, "error", 5000);
     return;
   }
 
@@ -477,7 +478,7 @@ function upload(type: "image" | "svg"): void {
 
       const svgEl = wrapper.querySelector("svg");
       if (!svgEl) {
-        tip("The file is not a valid SVG. Please use Armoria or other relevant tools", false, "error");
+        toast("The file is not a valid SVG. Please use Armoria or other relevant tools", "error");
         return;
       }
 
@@ -667,7 +668,7 @@ async function downloadGallery(): Promise<void> {
 }
 
 async function renderAllEmblems(states: State[], provinces: Province[], burgs: Burg[]): Promise<void> {
-  tip("Preparing for download...", true, "warn");
+  toast("Preparing for download...", "warn");
 
   const statePromises = states.map(state => EmblemRenderer.trigger(`stateCOA${state.i}`, state.coa));
   const provincePromises = provinces.map(province => EmblemRenderer.trigger(`provinceCOA${province.i}`, province.coa));

--- a/src/controllers/good-editor.ts
+++ b/src/controllers/good-editor.ts
@@ -1,6 +1,6 @@
 import { destroyDialog, refreshEditors } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { Controllers } from "@/controllers";
 import { capitalize, rn } from "@/utils";
 import { CULTURE_TYPES } from "../generators/cultures-generator";
@@ -181,7 +181,7 @@ function open(editedGood?: Good, onUpdate?: () => void) {
           Goods.sync();
         }
 
-        tip(editedGood ? "Good is updated" : "Good is added", false, "success", 5000);
+        toast(editedGood ? "Good is updated" : "Good is added", "success", 5000);
         onUpdate?.();
         $(dialog).dialog("close");
       }
@@ -505,9 +505,8 @@ function uploadImage(type: "image" | "svg", callback: (type: string, id: string)
   input.value = "";
 
   if (file.size > 200000) {
-    tip(
+    toast(
       `File is too big, please optimize file size up to 200kB and re-upload. Recommended size is 48x48 px and up to 10kB`,
-      true,
       "error",
       5000
     );
@@ -541,9 +540,8 @@ function uploadImage(type: "image" | "svg", callback: (type: string, id: string)
 
       const svg = el.querySelector("svg");
       if (!svg)
-        return void tip(
+        return void toast(
           "The file should be prepared for load to FMG. If you don't know why it's happening, try to upload raster image",
-          false,
           "error"
         );
 

--- a/src/controllers/heightmap-editor.ts
+++ b/src/controllers/heightmap-editor.ts
@@ -2,6 +2,7 @@ import { drag, easeSinInOut, hsl, interpolateRound, lab, max, mean, quadtree, ra
 import { closeDialogs, destroyDialog, refreshEditors } from "@/components/dialog/dialog-helpers";
 import { dialogState } from "@/components/dialog/state";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { clearMainTip, showMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
@@ -437,11 +438,11 @@ function getFriendlyHeight(h: number): string {
 // Exit customization mode
 function finalizeHeightmap(): void {
   if (select<SVGElement, unknown>("#viewbox").select("#heights").selectAll("*").size() < 200) {
-    tip("Insufficient land area. There should be at least 200 land cells!", false, "error");
+    toast("Insufficient land area. There should be at least 200 land cells!", "error");
     return;
   }
   if (findEl("imageConverter")) {
-    tip("Please exit the Image Conversion mode first", false, "error");
+    toast("Please exit the Image Conversion mode first", "error");
     return;
   }
 
@@ -1165,7 +1166,7 @@ function placeLinearFeature(this: SVGElement, event: any): void {
 
   const power = ensureEl<HTMLInputElement>("heightmapLinePower").valueAsNumber;
   if (power === 0) {
-    tip("Power should not be zero", false, "error");
+    toast("Power should not be zero", "error");
     return;
   }
 
@@ -1204,21 +1205,21 @@ function applyFillBrush(this: SVGElement, event: any): void {
 
   const cellTypeFilter = ensureEl<HTMLSelectElement>("cellTypeFilter").value;
   if (cellTypeFilter === "water") {
-    tip("Fill brush is not available with 'only water cells' filter", false, "error");
+    toast("Fill brush is not available with 'only water cells' filter", "error");
     return;
   }
   if (cellTypeFilter === "land" && isWaterFill) {
-    tip("Land filter is active, water areas cannot be filled", false, "error");
+    toast("Land filter is active, water areas cannot be filled", "error");
     return;
   }
 
   const { selection, reachedBorder } = collectFillSelection(start, isWaterFill, startHeight);
   if (selection.length < MIN_FILL_CELLS) {
-    tip("No enclosed area found to fill", false, "error");
+    toast("No enclosed area found to fill", "error");
     return;
   }
   if (isWaterFill && reachedBorder) {
-    tip("Selected water area is open to map border and is not enclosed", false, "error");
+    toast("Selected water area is open to map border and is not enclosed", "error");
     return;
   }
 
@@ -1383,7 +1384,7 @@ function changeHeightForSelection(selection: number[], start: number): void {
 function cellTypeFilterChange(): void {
   const cellTypeFilter = ensureEl<HTMLSelectElement>("cellTypeFilter");
   if (cellTypeFilter.value === "land" && ensureEl("heightmapEditMode").innerHTML === "keep") {
-    tip("You cannot change the coastline in 'Keep' edit mode", false, "error");
+    toast("You cannot change the coastline in 'Keep' edit mode", "error");
     cellTypeFilter.value = "all";
   }
   filterState.cellType = cellTypeFilter.value as typeof filterState.cellType;
@@ -1408,11 +1409,11 @@ function rescaleWithCondition(): void {
   const operator = ensureEl<HTMLSelectElement>("conditionSign").value;
   const operand = ensureEl<HTMLInputElement>("rescaleModifier").valueAsNumber;
   if (Number.isNaN(operand)) {
-    tip("Operand should be a number", false, "error");
+    toast("Operand should be a number", "error");
     return;
   }
   if ((operator === "add" || operator === "subtract") && !Number.isInteger(operand)) {
-    tip("Operand should be an integer", false, "error");
+    toast("Operand should be an integer", "error");
     return;
   }
 
@@ -1443,16 +1444,16 @@ function disruptAllHeights(): void {
 function startFromScratch(): void {
   const cellTypeFilter = ensureEl<HTMLSelectElement>("cellTypeFilter").value;
   if (cellTypeFilter === "land") {
-    tip("Not allowed when 'only land cells' filter is set", false, "error");
+    toast("Not allowed when 'only land cells' filter is set", "error");
     return;
   }
   if (cellTypeFilter === "water") {
-    tip("Not allowed when 'only water cells' filter is set", false, "error");
+    toast("Not allowed when 'only water cells' filter is set", "error");
     return;
   }
   const someHeights = grid.cells.h.some((h: number) => h);
   if (!someHeights) {
-    tip("Heightmap is already cleared, please do not click twice if not required", false, "error");
+    toast("Heightmap is already cleared, please do not click twice if not required", "error");
     return;
   }
 
@@ -1658,7 +1659,7 @@ function changeTemplate(template: string): void {
 
   const steps = templateString.split("\n");
   if (!steps.length) {
-    tip(`Heightmap template: no steps defined`, false, "error");
+    toast(`Heightmap template: no steps defined`, "error");
     return;
   }
 
@@ -1739,7 +1740,7 @@ function downloadTemplate(): void {
 function uploadTemplate(dataLoaded: string): void {
   const steps = dataLoaded.split("\r\n");
   if (!steps.length) {
-    tip("Cannot parse the template, please check the file", false, "error");
+    toast("Cannot parse the template, please check the file", "error");
     return;
   }
   ensureEl("templateBody").innerHTML = "";
@@ -1779,7 +1780,7 @@ function openImageConverter(): void {
 
   setOverlayOpacity(0);
   clearMainTip();
-  tip("Image Converter is opened. Upload image and assign height value for each color", false, "warn"); // main tip
+  toast("Image Converter is opened. Upload image and assign height value for each color", "warn"); // main tip
 
   // remove all heights
   grid.cells.h = new Uint8Array(grid.cells.i.length);
@@ -1932,7 +1933,7 @@ function autoAssing(type: string): void {
     heightsFromImage(+ensureEl<HTMLInputElement>("convertColors").value);
     unassigned = colorsUnassignedContainer.querySelectorAll<HTMLElement>("div");
     if (!unassigned.length) {
-      tip("No unassigned colors. Please load an image and click the button again", false, "error");
+      toast("No unassigned colors. Please load an image and click the button again", "error");
       return;
     }
   }
@@ -2013,7 +2014,7 @@ function setOverlayOpacity(v: number): void {
 
 function applyConversion(): void {
   if (ensureEl("colorsAssignedContainer").childElementCount < 3) {
-    tip("Please assign colors to heights first", false, "error");
+    toast("Please assign colors to heights first", "error");
     return;
   }
 

--- a/src/controllers/hierarchy-tree.ts
+++ b/src/controllers/hierarchy-tree.ts
@@ -1,6 +1,7 @@
 import type { D3DragEvent, D3ZoomEvent } from "d3";
 import { drag, mean, select, stratify, tree, zoom } from "d3";
 import { closeDialogs } from "@/components/dialog/dialog-helpers";
+import { toast } from "@/components/toast";
 import { tip } from "@/components/tooltips";
 import { capitalize } from "@/utils";
 import { ensureEl, minmax } from "../utils";
@@ -59,7 +60,7 @@ function open(props: OpenProps): void {
   dataElements = props.data;
   validElements = cleanupOrigins(dataElements);
   if (validElements.length < 3) {
-    tip(`Not enough ${props.type} to show hierarchy`, false, "error");
+    toast(`Not enough ${props.type} to show hierarchy`, "error");
     return;
   }
 
@@ -231,7 +232,7 @@ function getRoot(): any {
     oldRoot = root;
     return root;
   } catch (error) {
-    tip(`Hierarchy data issue. ${error}`, false, "error", 6000);
+    toast(`Hierarchy data issue. ${error}`, "error", 6000);
     return oldRoot;
   }
 }
@@ -409,8 +410,8 @@ function selectElement(d: any): void {
 
   ensureEl<HTMLInputElement>("hierarchyTree_selectedCode").onchange = function () {
     const input = this as HTMLInputElement;
-    if (input.value.length > 3) return tip("Abbreviation must be 3 characters or less", false, "error", 3000);
-    if (!input.value.length) return tip("Abbreviation cannot be empty", false, "error", 3000);
+    if (input.value.length > 3) return toast("Abbreviation must be 3 characters or less", "error", 3000);
+    if (!input.value.length) return toast("Abbreviation cannot be empty", "error", 3000);
 
     node.select("text").text(input.value);
     dataElement.code = input.value;

--- a/src/controllers/icon-selector.ts
+++ b/src/controllers/icon-selector.ts
@@ -1,5 +1,6 @@
 // The Icon Selector: pick an emoji or add an external image to use as an icon
 import { destroyDialog } from "@/components/dialog/dialog-helpers";
+import { toast } from "@/components/toast";
 import { tip } from "@/components/tooltips";
 import { ICONS, ICONS_PER_ROW } from "@/data/icons-list";
 import { ensureEl } from "@/utils";
@@ -33,8 +34,8 @@ function open(initial: string, callback: (value: string) => void): void {
   addImageButton.onclick = () => {
     const urlInput = addImageButton.previousElementSibling as HTMLInputElement;
     const url = urlInput.value;
-    if (!url) return tip("Enter image URL to add", false, "error", 4000);
-    if (!url.match(/^((http|https):\/\/)|data:image\//)) return tip("Enter valid URL", false, "error", 4000);
+    if (!url) return toast("Enter image URL to add", "error", 4000);
+    if (!url.match(/^((http|https):\/\/)|data:image\//)) return toast("Enter valid URL", "error", 4000);
 
     addImage(url, callback);
     callback(url);

--- a/src/controllers/labels-editor.ts
+++ b/src/controllers/labels-editor.ts
@@ -1,6 +1,7 @@
 import { curveNatural, type D3DragEvent, drag, line, select } from "d3";
 import { closeDialogs, confirmationDialog, destroyDialog } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { showMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
@@ -394,9 +395,9 @@ function changeText(): void {
   const input = ensureEl<HTMLInputElement>("labelText").value;
   label.text = input;
   applyLabelChanges();
-  if (label.type === "state") tip("Use States Editor to change the actual state name, not just a label", false, "warn");
+  if (label.type === "state") toast("Use States Editor to change the actual state name, not just a label", "warn");
   if (label.type === "province")
-    tip("Use Provinces Editor to change the actual province name, not just a label", false, "warn");
+    toast("Use Provinces Editor to change the actual province name, not just a label", "warn");
 }
 
 const nameGenerators: Record<LabelType, (label: LabelData) => string> = {

--- a/src/controllers/labels-group-editor.ts
+++ b/src/controllers/labels-group-editor.ts
@@ -1,7 +1,7 @@
 import { closeDialogs, confirmationDialog, destroyDialog } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
 import { LAYER_TOGGLES } from "@/components/layers-tab";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { Controllers } from "@/controllers";
 import { LABEL_TYPES, type LabelGroup, type LabelNameMode, type LabelType } from "@/generators/labels-generator";
 import { getLabelsData } from "@/renderers/labels/label-data";
@@ -215,7 +215,7 @@ function onBodyClick(event: Event): void {
 function removeRow(row: HTMLTableRowElement): void {
   const rows = ensureEl("labelGroupsBody").children;
   if (rows.length < 2) {
-    tip("At least one group should be defined", false, "error");
+    toast("At least one group should be defined", "error");
     return;
   }
 
@@ -263,7 +263,7 @@ function submitForm(event: Event): void {
   if (!validateForm()) return;
 
   const rows = Array.from(ensureEl("labelGroupsBody").children) as HTMLTableRowElement[];
-  if (!rows.length) return void tip("At least one group should be defined", false, "error");
+  if (!rows.length) return void toast("At least one group should be defined", "error");
 
   const newGroupNames = new Set<string>();
   rows.forEach(row => {

--- a/src/controllers/labels-overview.ts
+++ b/src/controllers/labels-overview.ts
@@ -10,7 +10,7 @@ import {
   type TableView
 } from "@/components/dialog/table";
 import { Layers } from "@/components/layers";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { Controllers } from "@/controllers";
 import { calculateLabelSpread, type LabelSpreadPatch } from "@/controllers/label-spread";
 import { LABEL_TYPES, type Label, type LabelType } from "@/generators/labels-generator";
@@ -340,7 +340,7 @@ function assignGroup(labels: LabelData[], groupName: string): void {
     for (const { type, entityId } of labels) Labels.setGroup({ type, entityId, group: groupName });
     Layers.draw("labels");
     refresh();
-    tip(`${labels.length} label(s) assigned to the "${groupName}" group`, false, "success", 4000);
+    toast(`${labels.length} label(s) assigned to the "${groupName}" group`, "success", 4000);
   };
 
   const crossTyped = labels.filter(({ type }) => type !== group.type);
@@ -400,10 +400,10 @@ function toggleSelectAll(): void {
 
 function applyBulkAssignment(): void {
   const labels = getSelectedLabels();
-  if (!labels.length) return void tip("Select at least one label", false, "error");
+  if (!labels.length) return void toast("Select at least one label", "error");
 
   const group = ensureEl<HTMLSelectElement>("labelsBulkGroup").value;
-  if (group === ALL) return void tip("Define a label group to assign the labels to", false, "error");
+  if (group === ALL) return void toast("Define a label group to assign the labels to", "error");
 
   assignGroup(labels, group);
 }

--- a/src/controllers/lakes-editor.ts
+++ b/src/controllers/lakes-editor.ts
@@ -1,6 +1,7 @@
 import { drag, mean, min, polygonLength, type Selection, select } from "d3";
 import { closeDialogs, destroyDialog } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
@@ -266,12 +267,12 @@ function createNewGroup(this: HTMLInputElement): void {
     .replace(/[^\w\s]/gi, "");
 
   if (findEl(group)) {
-    tip("Element with this id already exists. Please provide a unique name", false, "error");
+    toast("Element with this id already exists. Please provide a unique name", "error");
     return;
   }
 
   if (Number.isFinite(+group.charAt(0))) {
-    tip("Group name should start with a letter", false, "error");
+    toast("Group name should start with a letter", "error");
     return;
   }
 
@@ -303,7 +304,7 @@ function createNewGroup(this: HTMLInputElement): void {
 function removeLakeGroup(): void {
   const group = (selectedLake.node()!.parentNode as SVGGElement).id;
   if (isLakeType(group)) {
-    tip("This is one of the default groups, it cannot be removed", false, "error");
+    toast("This is one of the default groups, it cannot be removed", "error");
     return;
   }
 

--- a/src/controllers/marker-creator.ts
+++ b/src/controllers/marker-creator.ts
@@ -16,7 +16,6 @@ function toggle(baseMarker?: Marker): void {
     "addMarker",
     event => addOnClick(event, baseMarker),
     "Click on map to add a marker. Hold Shift to add multiple",
-    undefined,
     unpressProxyButtons
   );
   document.getElementById("markersAddFromOverview")?.classList.add("pressed");

--- a/src/controllers/markers-in-radius.ts
+++ b/src/controllers/markers-in-radius.ts
@@ -1,6 +1,7 @@
 import { closeDialogs, confirmationDialog, refreshEditors } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
-import { clearMainTip, tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
+import { clearMainTip } from "@/components/tooltips";
 import { Controllers } from "@/controllers";
 import type { Marker } from "@/generators/markers-generator";
 import { clearMarkerRadius, drawMarkerRadius } from "@/renderers/draw-marker-radius";
@@ -179,7 +180,7 @@ function confirmRemove(marker: Marker): void {
 }
 
 function exportInRange(): void {
-  if (!inRangeMarkers.length) return void tip("No markers in range to export", false, "error");
+  if (!inRangeMarkers.length) return void toast("No markers in range to export", "error");
 
   const headers = "Id,Type,Icon,Name,Note,State,Culture,X,Y,Latitude,Longitude\n";
   const quote = (s: string) => `"${s.replaceAll('"', '""')}"`;

--- a/src/controllers/market-deals-overview.ts
+++ b/src/controllers/market-deals-overview.ts
@@ -9,7 +9,7 @@ import {
   renderEditorPagination,
   type TableView
 } from "@/components/dialog/table";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { downloadFile, getFileName } from "@/utils";
 import type { Burg } from "../generators/burgs-generator";
 import type { Deal } from "../generators/markets-generator";
@@ -68,7 +68,7 @@ const marketDealsTable = initEditorTable<Deal>({
 function open(marketId: number): void {
   const market = Markets.get(marketId);
   if (!market) {
-    tip("Invalid market. The selected market does not exist", true, "error", 5000);
+    toast("Invalid market. The selected market does not exist", "error", 5000);
     return;
   }
 
@@ -145,7 +145,7 @@ function closeMarketDeals(): void {
 function getFilteredMarketDeals(): Deal[] {
   const market = Markets.get(activeMarketId);
   if (!market) {
-    tip("Invalid market. The selected market does not exist", true, "error", 5000);
+    toast("Invalid market. The selected market does not exist", "error", 5000);
     return [];
   }
 

--- a/src/controllers/market-overview.ts
+++ b/src/controllers/market-overview.ts
@@ -10,6 +10,7 @@ import {
   type TableView
 } from "@/components/dialog/table";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { clearMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
@@ -59,7 +60,7 @@ function open(marketId: number): void {
 
   const market = Markets.get(marketId);
   if (!market) {
-    tip("Invalid market. The selected market does not exist", true, "error", 5000);
+    toast("Invalid market. The selected market does not exist", "error", 5000);
     return;
   }
   activeMarketId = marketId;
@@ -156,13 +157,13 @@ function resetMarketName(): void {
 function getMarketGoods(): MarketGoodRow[] {
   const market = Markets.get(activeMarketId);
   if (!market) {
-    tip("Invalid market. The selected market does not exist", true, "error", 5000);
+    toast("Invalid market. The selected market does not exist", "error", 5000);
     return [];
   }
 
   const centerBurg = pack.burgs[market.centerBurgId] as Burg | undefined;
   if (!centerBurg || centerBurg.removed) {
-    tip("Invalid market. The selected market has no center burg", true, "error", 5000);
+    toast("Invalid market. The selected market has no center burg", "error", 5000);
     return [];
   }
 
@@ -238,17 +239,17 @@ function relocateMarketOnClick(this: SVGGElement, event: MouseEvent): void {
   const burgId = pack.cells.burg[cellId];
   const burg = pack.burgs[burgId] as Burg | undefined;
   if (!burgId || !burg || burg.removed) {
-    tip("No valid burg in this cell. Click on a cell with a burg", false, "error");
+    toast("No valid burg in this cell. Click on a cell with a burg", "error");
     return;
   }
 
   if (burgId === market.centerBurgId) {
-    tip("This burg is already the center of this market", false, "error");
+    toast("This burg is already the center of this market", "error");
     return;
   }
 
   if (pack.markets.some(m => m.centerBurgId === burgId)) {
-    tip("This burg is already a center of another market", false, "error");
+    toast("This burg is already a center of another market", "error");
     return;
   }
 

--- a/src/controllers/markets-overview.ts
+++ b/src/controllers/markets-overview.ts
@@ -11,6 +11,7 @@ import {
 } from "@/components/dialog/table";
 import type { FillBoxElement } from "@/components/fill-box";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { clearMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
@@ -298,7 +299,7 @@ function addMarketOnClick(this: SVGElement, ev: MouseEvent): void {
 
   const burgId = pack.cells.burg[cellId];
   if (!burgId) {
-    tip("Click on a burg to create a new market — no burg found here", false, "error");
+    toast("Click on a burg to create a new market — no burg found here", "error");
     return;
   }
 

--- a/src/controllers/measurers-editor.ts
+++ b/src/controllers/measurers-editor.ts
@@ -1,6 +1,7 @@
 import { type D3DragEvent, drag, type Selection, select } from "d3";
 import { closeDialogs, destroyDialog } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { clearMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { type Measurer, Measurers, type MeasurerType } from "@/generators/measurers-generator";
@@ -174,7 +175,7 @@ function toggleRouteOpisometerMode(this: HTMLElement): void {
     const cell = findCell(event.x, event.y)!;
     if (!Routes.isConnected(cell) && !event.sourceEvent.shiftKey) {
       exitDrawingMode();
-      tip("Must start in a cell with a route in it", false, "error");
+      toast("Must start in a cell with a route in it", "error");
       return;
     }
 

--- a/src/controllers/military-overview.ts
+++ b/src/controllers/military-overview.ts
@@ -11,6 +11,7 @@ import {
   type TableView
 } from "@/components/dialog/table";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { tip } from "@/components/tooltips";
 import { Controllers } from "@/controllers";
 import type { State } from "@/generators/states-generator";
@@ -541,7 +542,7 @@ function militaryCustomize(): void {
           }, []);
 
           if (!selected.length) {
-            tip("Select at least one element", false, "error");
+            toast("Select at least one element", "error");
             return;
           }
 
@@ -562,7 +563,7 @@ function militaryCustomize(): void {
     const unitLines = Array.from(tableBody.querySelectorAll("tr"));
     const names = unitLines.map(r => sanitizeId(r.querySelector("input")!.value));
     if (new Set(names).size !== names.length) {
-      tip("All units should have unique names", false, "error");
+      toast("All units should have unique names", "error");
       return;
     }
 

--- a/src/controllers/namesbase-editor.ts
+++ b/src/controllers/namesbase-editor.ts
@@ -1,6 +1,6 @@
 import { max as d3max, min as d3min, mean, median } from "d3";
 import { closeDialogs, destroyDialog } from "@/components/dialog/dialog-helpers";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { downloadFile, getFileName, speak, uploadFile } from "@/utils";
 import { ensureEl, openURL, rn, unique } from "../utils";
 
@@ -154,7 +154,7 @@ function createBasesList(): void {
 function updateInputs(): void {
   const base = +ensureEl<HTMLSelectElement>("namesbaseSelect").value;
   if (!Names.nameBases[base]) {
-    tip(`Namesbase ${base} is not defined`, false, "error");
+    toast(`Namesbase ${base} is not defined`, "error");
     return;
   }
   (ensureEl("namesbaseTextarea") as HTMLTextAreaElement).value = Names.nameBases[base].b;
@@ -184,7 +184,7 @@ function updateNamesData(): void {
   const base = +ensureEl<HTMLSelectElement>("namesbaseSelect").value;
   const input = ensureEl<HTMLTextAreaElement>("namesbaseTextarea");
   if (input.value.split(",").length < 3) {
-    tip("The names data provided is too short or incorrect", false, "error");
+    toast("The names data provided is too short or incorrect", "error");
     return;
   }
   const securedNamesData = input.value.replace(/[/|]/g, "");
@@ -204,7 +204,7 @@ function updateBaseName(rawName: string): void {
 function updateBaseMin(value: string): void {
   const base = +ensureEl<HTMLSelectElement>("namesbaseSelect").value;
   if (+value > Names.nameBases[base].max) {
-    tip("Minimal length cannot be greater than maximal", false, "error");
+    toast("Minimal length cannot be greater than maximal", "error");
     return;
   }
   Names.nameBases[base].min = +value;
@@ -213,7 +213,7 @@ function updateBaseMin(value: string): void {
 function updateBaseMax(value: string): void {
   const base = +ensureEl<HTMLSelectElement>("namesbaseSelect").value;
   if (+value < Names.nameBases[base].min) {
-    tip("Maximal length should be greater than minimal", false, "error");
+    toast("Maximal length should be greater than minimal", "error");
     return;
   }
   Names.nameBases[base].max = +value;
@@ -229,7 +229,7 @@ function analyzeNamesbase(): void {
   const namesArray = namesSourceString.toLowerCase().split(",");
   const length = namesArray.length;
   if (!namesSourceString || !length) {
-    tip("Names data should not be empty", false, "error");
+    toast("Names data should not be empty", "error");
     return;
   }
 
@@ -358,7 +358,7 @@ function namesbaseUpload(dataLoaded: string, override = true): void {
     .split("\n")
     .filter(Boolean);
   if (!lines.length) {
-    tip("Cannot load a namesbase. Please check the data format", false, "error");
+    toast("Cannot load a namesbase. Please check the data format", "error");
     return;
   }
 

--- a/src/controllers/notes-editor.ts
+++ b/src/controllers/notes-editor.ts
@@ -1,5 +1,5 @@
 import { confirmationDialog, destroyDialog } from "@/components/dialog/dialog-helpers";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { highlightElement } from "@/renderers/overlays/highlight";
 import { downloadFile, getFileName, speak, uploadFile } from "@/utils";
 import { ensureEl } from "../utils";
@@ -145,7 +145,7 @@ function updateLegend(): void {
   const notesSelect = ensureEl<HTMLSelectElement>("notesSelect");
   const note = (notes as Note[]).find(note => note.id === notesSelect.value);
   if (!note) {
-    tip("Note element is not found", true, "error", 4000);
+    toast("Note element is not found", "error", 4000);
     return;
   }
 
@@ -162,7 +162,7 @@ function updateNotesBox(note: Note): void {
 function changeElement(this: HTMLSelectElement): void {
   const note = (notes as Note[]).find(note => note.id === this.value);
   if (!note) {
-    tip("Note element is not found", true, "error", 4000);
+    toast("Note element is not found", "error", 4000);
     return;
   }
 
@@ -177,7 +177,7 @@ function changeName(this: HTMLInputElement): void {
   const notesSelect = ensureEl<HTMLSelectElement>("notesSelect");
   const note = (notes as Note[]).find(note => note.id === notesSelect.value);
   if (!note) {
-    tip("Note element is not found", true, "error", 4000);
+    toast("Note element is not found", "error", 4000);
     return;
   }
 
@@ -240,7 +240,7 @@ function downloadLegends(): void {
 
 function uploadLegends(dataLoaded: string): void {
   if (!dataLoaded) {
-    tip("Cannot load the file. Please check the data format", false, "error");
+    toast("Cannot load the file. Please check the data format", "error");
     return;
   }
   notes = JSON.parse(dataLoaded);

--- a/src/controllers/production-chains.ts
+++ b/src/controllers/production-chains.ts
@@ -1,5 +1,5 @@
 import { type Selection, select, zoom, zoomIdentity } from "d3";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import type { Good } from "../generators/goods-generator";
 import { ensureEl } from "../utils";
 import { C_12 } from "../utils/colorUtils";
@@ -117,13 +117,13 @@ const FLOW_OPACITY_MAX = 0.92;
 function open() {
   const goods = [...(pack.goods as Good[])];
   if (!goods.length) {
-    tip("No goods data available.", true, "warn");
+    toast("No goods data available.", "warn");
     return;
   }
 
   const layout = buildLayout(goods);
   if (!layout.nodes.length) {
-    tip("No production chains found: add manufactured goods with recipes first.", true, "warn");
+    toast("No production chains found: add manufactured goods with recipes first.", "warn");
     return;
   }
 

--- a/src/controllers/production-overview.ts
+++ b/src/controllers/production-overview.ts
@@ -1,4 +1,4 @@
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import type { Burg } from "../generators/burgs-generator";
 import type { DemandCategory } from "../generators/goods-generator";
 import { DEMAND_CATEGORY_ICONS, DEMAND_PRIORITY, DEMAND_TARGET_FACTORS } from "../generators/goods-generator";
@@ -13,19 +13,19 @@ function open(burgId: number): void {
   if (customization) return;
   const burg = pack.burgs[burgId];
   if (!burg || burg.removed) {
-    tip("Invalid burg. The selected burg does not exist or was removed.", true, "error", 5000);
+    toast("Invalid burg. The selected burg does not exist or was removed.", "error", 5000);
     return;
   }
 
   const market = Markets.get(burg.market);
   if (!market) {
-    tip("No market. This burg is not connected to any market.", true, "error", 5000);
+    toast("No market. This burg is not connected to any market.", "error", 5000);
     return;
   }
 
   const data = burg.production;
   if (!data) {
-    tip("No production data for this burg.", true, "error", 5000);
+    toast("No production data for this burg.", "error", 5000);
     return;
   }
 

--- a/src/controllers/provinces-editor.ts
+++ b/src/controllers/provinces-editor.ts
@@ -13,6 +13,7 @@ import {
 } from "@/components/dialog/table";
 import type { FillBoxElement } from "@/components/fill-box";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { clearMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
@@ -431,11 +432,11 @@ function declareProvinceIndependence(provinceId: number): [number, number] | und
   const { name, burg: burgId, burgs: provinceBurgs } = province;
 
   if (provinceBurgs!.some(b => burgs[b].capital)) {
-    tip("Cannot declare independence of a province having capital burg. Please change capital first", false, "error");
+    toast("Cannot declare independence of a province having capital burg. Please change capital first", "error");
     return;
   }
   if (!burgId) {
-    tip("Cannot declare independence of a province without burg", false, "error");
+    toast("Cannot declare independence of a province without burg", "error");
     return;
   }
 
@@ -541,7 +542,7 @@ function changePopulation(province: number): void {
   const p = pack.provinces[province];
   const cells = pack.cells.i.filter(i => pack.cells.province[i] === province);
   if (!cells.length) {
-    tip("Province does not have any cells, cannot change population", false, "error");
+    toast("Province does not have any cells, cannot change population", "error");
     return;
   }
   const rural = rn(p.rural! * populationRate);
@@ -1076,7 +1077,7 @@ function openPaintEditor(): void {
       if (!isLand(cell, pack) || !pack.cells.state[cell]) return false;
       if (pack.cells.state[cell] !== pack.provinces[nextProvince].state) return false;
       if (!currentProvince || cell !== pack.provinces[currentProvince].center) return true;
-      tip("Province center cannot be assigned to a different region. Please remove the province first", false, "error");
+      toast("Province center cannot be assigned to a different region. Please remove the province first", "error");
       return false;
     },
     dontOverrideControl: true,
@@ -1116,19 +1117,19 @@ function addProvince(this: SVGElement, event: any): void {
   const point = getPointer(event, this);
   const center = findCell(point[0], point[1])!;
   if (cells.h[center] < 20) {
-    tip("You cannot place province into the water. Please click on a land cell", false, "error");
+    toast("You cannot place province into the water. Please click on a land cell", "error");
     return;
   }
 
   const oldProvince = cells.province[center];
   if (oldProvince && provinces[oldProvince].center === center) {
-    tip("The cell is already a center of a different province. Select other cell", false, "error");
+    toast("The cell is already a center of a different province. Select other cell", "error");
     return;
   }
 
   const state = cells.state[center];
   if (!state) {
-    tip("You cannot create a province in neutral lands. Please assign this land to a state first", false, "error");
+    toast("You cannot create a province in neutral lands. Please assign this land to a state first", "error");
     return;
   }
 
@@ -1325,7 +1326,7 @@ function openProvinceMergeDialog(): void {
         const formData = new FormData(ensureEl<HTMLFormElement>("mergeProvincesForm"));
         const primaryProvinceId = Number(formData.get("rulingProvince"));
         if (!primaryProvinceId) {
-          tip("Please select a province to merge into", false, "error");
+          toast("Please select a province to merge into", "error");
           return;
         }
 
@@ -1334,7 +1335,7 @@ function openProvinceMergeDialog(): void {
           .map(Number)
           .filter(provinceId => provinceId !== primaryProvinceId);
         if (!provincesToMergeIds.length) {
-          tip("Please select several provinces to merge", false, "error");
+          toast("Please select several provinces to merge", "error");
           return;
         }
 

--- a/src/controllers/regiment-editor.ts
+++ b/src/controllers/regiment-editor.ts
@@ -1,6 +1,7 @@
 import { type D3DragEvent, drag, easeSinInOut, select, sum, transition } from "d3";
 import { closeDialogs, destroyDialog, refreshEditors } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { clearMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
@@ -267,7 +268,7 @@ function splitRegiment(): void {
   }); // halved new reg
   const a = sum(Object.values(u2)); // new reg total
   if (!a) {
-    tip("Not enough forces to split", false, "error");
+    toast("Not enough forces to split", "error");
     return;
   }
 
@@ -388,22 +389,22 @@ async function attackRegimentOnClick(this: SVGGElement, event: MouseEvent): Prom
   const newState = +regSelected.dataset.state!;
 
   if (army?.parentElement?.id !== "armies") {
-    tip("Please click on a regiment to attack", false, "error");
+    toast("Please click on a regiment to attack", "error");
     return;
   }
   if ((regSelected as Node) === (selectedRegiment as Node)) {
-    tip("Regiment cannot attack itself", false, "error");
+    toast("Regiment cannot attack itself", "error");
     return;
   }
   if (oldState === newState) {
-    tip("Cannot attack fraternal regiment", false, "error");
+    toast("Cannot attack fraternal regiment", "error");
     return;
   }
 
   const attacker = getRegiment();
   const defender = pack.states[+regSelected.dataset.state!].military!.find(r => r.i === +regSelected.dataset.id!);
   if (!attacker || !defender || !attacker.a || !defender.a) {
-    tip("Regiment has no troops to battle", false, "error");
+    toast("Regiment has no troops to battle", "error");
     return;
   }
 
@@ -460,11 +461,11 @@ function attachRegimentOnClick(this: SVGGElement, event: MouseEvent): void {
   const newState = +regSelected.dataset.state!;
 
   if (army?.parentElement?.id !== "armies") {
-    tip("Please click on a regiment", false, "error");
+    toast("Please click on a regiment", "error");
     return;
   }
   if ((regSelected as Node) === (selectedRegiment as Node)) {
-    tip("Cannot attach regiment to itself. Please click on another regiment", false, "error");
+    toast("Cannot attach regiment to itself. Please click on another regiment", "error");
     return;
   }
 

--- a/src/controllers/regiments-overview.ts
+++ b/src/controllers/regiments-overview.ts
@@ -11,6 +11,7 @@ import {
   type TableView
 } from "@/components/dialog/table";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { clearMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
@@ -278,7 +279,7 @@ function toggleAdd(): void {
 function addRegimentOnClick(this: SVGGElement, event: MouseEvent): void {
   const state = filterState.stateId;
   if (state === -1) {
-    tip("Please select state from the list", false, "error");
+    toast("Please select state from the list", "error");
     return;
   }
 

--- a/src/controllers/relief-editor.ts
+++ b/src/controllers/relief-editor.ts
@@ -1,6 +1,7 @@
 import { drag, quadtree, range, select } from "d3";
 import { closeDialogs, destroyDialog } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { clearMainTip, showMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { RELIEF_ICONS, RELIEF_SETS } from "@/data/relief-icons";
@@ -256,7 +257,7 @@ function moveBrush(this: SVGElement, event: any): void {
 function dragToAdd(this: SVGElement, event: any): void {
   const pressed = ensureEl("reliefIconsDiv").querySelector<SVGElement>("svg.pressed");
   if (!pressed) {
-    tip("Please select an icon", false, "error");
+    toast("Please select an icon", "error");
     return;
   }
 
@@ -325,7 +326,7 @@ function enterBulkRemoveMode(): void {
 function dragToRemove(this: SVGElement, event: any): void {
   const pressed = ensureEl("reliefIconsDiv").querySelector<SVGElement>("svg.pressed");
   if (!pressed) {
-    tip("Please select an icon", false, "error");
+    toast("Please select an icon", "error");
     return;
   }
 

--- a/src/controllers/religions-editor.ts
+++ b/src/controllers/religions-editor.ts
@@ -12,6 +12,7 @@ import {
   type TableView
 } from "@/components/dialog/table";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { clearMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
@@ -545,7 +546,7 @@ function changePopulation(this: HTMLElement): void {
   const religionId = +(this.closest(".states") as HTMLElement).dataset.id!;
   const religion = pack.religions[religionId];
   if (!religion.cells) {
-    tip("Religion does not have any cells, cannot change population", false, "error");
+    toast("Religion does not have any cells, cannot change population", "error");
     return;
   }
 
@@ -880,13 +881,13 @@ function addReligion(this: SVGElement, event: MouseEvent): void {
   const [x, y] = getPointer(event, this);
   const center = findCell(x, y)!;
   if (pack.cells.h[center] < 20) {
-    tip("You cannot place religion center into the water. Please click on a land cell", false, "error");
+    toast("You cannot place religion center into the water. Please click on a land cell", "error");
     return;
   }
 
   const occupied = pack.religions.some(r => !r.removed && r.center === center);
   if (occupied) {
-    tip("This cell is already a religion center. Please select a different cell", false, "error");
+    toast("This cell is already a religion center. Please select a different cell", "error");
     return;
   }
 

--- a/src/controllers/river-auto-creator.ts
+++ b/src/controllers/river-auto-creator.ts
@@ -2,7 +2,7 @@ import { pointer } from "d3";
 import { closeDialogs, refreshEditors } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
 import { stopMapPlacement, toggleMapPlacement } from "@/components/map-placement";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 
 function toggle(): void {
   if (document.getElementById("addRiver")?.classList.contains("pressed")) {
@@ -14,8 +14,7 @@ function toggle(): void {
   toggleMapPlacement(
     "addRiver",
     addOnClick,
-    "Click on map to place new river or extend an existing one. Hold Shift to place multiple rivers",
-    "warn"
+    "Click on map to place new river or extend an existing one. Hold Shift to place multiple rivers"
   );
   Layers.show("rivers");
 }
@@ -25,18 +24,18 @@ function addOnClick(event: MouseEvent): void {
   const cell = findCell(point[0], point[1]);
   if (cell === undefined) return;
   if (pack.cells.r[cell]) {
-    tip("There is already a river here", false, "error");
+    toast("There is already a river here", "error");
     return;
   }
   if (pack.cells.h[cell] < 20) {
-    tip("Cannot create river in water cell", false, "error");
+    toast("Cannot create river in water cell", "error");
     return;
   }
   if (pack.cells.b[cell]) return;
 
   const result = Rivers.addDownhill(cell);
   if (result.error) {
-    tip(result.error, false, "error");
+    toast(result.error, "error");
     return;
   }
 

--- a/src/controllers/river-creator.ts
+++ b/src/controllers/river-creator.ts
@@ -1,6 +1,7 @@
 import { select } from "d3";
 import { closeDialogs, destroyDialog } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { clearMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
@@ -105,7 +106,7 @@ function addRiver(): void {
   const { rivers: packRivers, cells } = pack;
   const riverCells = creatorCells;
   if (riverCells.length < 2) {
-    tip("Add at least 2 cells", false, "error");
+    toast("Add at least 2 cells", "error");
     return;
   }
 

--- a/src/controllers/route-creator.ts
+++ b/src/controllers/route-creator.ts
@@ -2,6 +2,7 @@ import { select } from "d3";
 import { closeDialogs, destroyDialog } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
 import { stopMapPlacement } from "@/components/map-placement";
+import { toast } from "@/components/toast";
 import { clearMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
@@ -134,7 +135,7 @@ function drawRoute(points: number[][]): void {
 function completeCreation(): void {
   const points = creatorPoints;
   if (points.length < 2) {
-    tip("Add at least 2 points", false, "error");
+    toast("Add at least 2 points", "error");
     return;
   }
 

--- a/src/controllers/route-editor.ts
+++ b/src/controllers/route-editor.ts
@@ -1,6 +1,7 @@
 import { drag, type Selection, select } from "d3";
 import { closeDialogs, confirmationDialog, destroyDialog } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { clearMainTip, tip } from "@/components/tooltips";
 import { Controllers } from "@/controllers";
 import { type Route, UNNAMED_ROUTE } from "@/generators/routes-generator";
@@ -327,13 +328,13 @@ function openJoinRoutesDialog(): void {
           const selectedRouteId = +alertMessage.querySelector("select")!.value;
           const selectedRoute = pack.routes.find((r: Route) => r.i === selectedRouteId) as Route;
           joinRoutes(route, selectedRoute);
-          tip("Routes joined", false, "success", 5000);
+          toast("Routes joined", "success", 5000);
           $("#alert").dialog("close");
         }
       }
     });
   } else {
-    tip("No routes to join with. Route must start or end at current route's start or end cell", false, "error", 4000);
+    toast("No routes to join with. Route must start or end at current route's start or end cell", "error", 4000);
   }
 }
 

--- a/src/controllers/route-groups-editor.ts
+++ b/src/controllers/route-groups-editor.ts
@@ -1,7 +1,7 @@
 import { select } from "d3";
 import { confirmationDialog, destroyDialog } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import type { Route } from "@/generators/routes-generator";
 import { ensureEl } from "../utils";
 
@@ -79,11 +79,11 @@ function addGroup(): void {
       .replace(/ /g, "_")
       .replace(/[^\w\s]/gi, "");
 
-    if (!group) return tip("Invalid group name", false, "error");
+    if (!group) return toast("Invalid group name", "error");
     if (!group.startsWith("route-")) group = `route-${group}`;
     if (document.getElementById(group))
-      return tip("Element with this name already exists. Provide a unique name", false, "error");
-    if (Number.isFinite(+group.charAt(0))) return tip("Group name should start with a letter", false, "error");
+      return toast("Element with this name already exists. Provide a unique name", "error");
+    if (Number.isFinite(+group.charAt(0))) return toast("Group name should start with a letter", "error");
 
     select("#routes")
       .append("g")

--- a/src/controllers/routes-overview.ts
+++ b/src/controllers/routes-overview.ts
@@ -11,7 +11,7 @@ import {
   type TableView
 } from "@/components/dialog/table";
 import { Layers } from "@/components/layers";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { Controllers } from "@/controllers";
 import { type Route, UNNAMED_ROUTE } from "@/generators/routes-generator";
 import { highlightElement } from "@/renderers/overlays/highlight";
@@ -281,9 +281,9 @@ function triggerAllRoutesRemove(): void {
   const toRemove = pack.routes.filter((route: Route) => !route.lock);
   if (!toRemove.length) {
     if (!pack.routes.length) {
-      tip("There are no routes to remove", false, "error");
+      toast("There are no routes to remove", "error");
     } else {
-      tip("All routes are locked. Unlock routes to remove them, or use Lock all to unlock first.", false, "error");
+      toast("All routes are locked. Unlock routes to remove them, or use Lock all to unlock first.", "error");
     }
     return;
   }
@@ -302,9 +302,9 @@ function triggerAllRoutesRemove(): void {
         const routesToRemove = pack.routes.filter((route: Route) => !route.lock);
         if (!routesToRemove.length) {
           if (!pack.routes.length) {
-            tip("There are no routes to remove", false, "error");
+            toast("There are no routes to remove", "error");
           } else {
-            tip("All routes are now locked; nothing was removed.", false, "error");
+            toast("All routes are now locked; nothing was removed.", "error");
           }
           $(this).dialog("close");
           return;

--- a/src/controllers/states-editor.ts
+++ b/src/controllers/states-editor.ts
@@ -12,6 +12,7 @@ import {
 } from "@/components/dialog/table";
 import type { FillBoxElement } from "@/components/fill-box";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { clearMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
@@ -778,7 +779,7 @@ function closeStateNameEditor(): void {
 function changePopulation(stateId: number): void {
   const state = pack.states[stateId];
   if (!state.cells) {
-    tip("State does not have any cells, cannot change population", false, "error");
+    toast("State does not have any cells, cannot change population", "error");
     return;
   }
 
@@ -1065,7 +1066,7 @@ function togglePercentageMode(): void {
 function showStatesChart(): void {
   const statesData = pack.states.filter(s => !s.removed);
   if (statesData.length < 2) {
-    tip("There are no states to show", false, "error");
+    toast("There are no states to show", "error");
     return;
   }
 
@@ -1478,13 +1479,13 @@ function addState(this: SVGElement, event: MouseEvent): void {
   const point = getPointer(event, this);
   const center = findCell(point[0], point[1])!;
   if (cells.h[center] < 20) {
-    tip("You cannot place state into the water. Please click on a land cell", false, "error");
+    toast("You cannot place state into the water. Please click on a land cell", "error");
     return;
   }
 
   let burgId = cells.burg[center];
   if (burgId && burgs[burgId].capital) {
-    tip("Existing capital cannot be selected as a new state capital! Select other cell", false, "error");
+    toast("Existing capital cannot be selected as a new state capital! Select other cell", "error");
     return;
   }
 
@@ -1664,7 +1665,7 @@ function openStateMergeDialog(): void {
 
         const rulingStateId = Number(formData.get("rulingState"));
         if (!rulingStateId) {
-          tip("Please select a state to merge into", false, "error");
+          toast("Please select a state to merge into", "error");
           return;
         }
         const rullingState = pack.states[rulingStateId];
@@ -1674,7 +1675,7 @@ function openStateMergeDialog(): void {
           .map(Number)
           .filter(stateId => stateId !== rulingStateId);
         if (!statesToMerge.length) {
-          tip("Please select several states to merge", false, "error");
+          toast("Please select several states to merge", "error");
           return;
         }
 

--- a/src/controllers/view-3d.ts
+++ b/src/controllers/view-3d.ts
@@ -1,3 +1,4 @@
+import { toast } from "@/components/toast";
 import { tip } from "@/components/tooltips";
 import { timeOfDayPresets } from "@/data/view-3d-options";
 import { ensureEl } from "@/utils";
@@ -471,7 +472,7 @@ function onToggleErosion(): void {
   const enabled = !options.threeD.erosion;
   ensureEl("options3dErosionSection").style.display = enabled ? "block" : "none";
   ensureEl<HTMLInputElement>("options3dSubdivide").disabled = enabled; // dense geometry: subdivision ignored
-  if (enabled) tip("Baking eroded terrain...", false, "warn", 4000);
+  if (enabled) toast("Baking eroded terrain...", "warn", 4000);
   void toggleErosion();
 }
 
@@ -492,7 +493,7 @@ function onChangeErosionRiverDepth(this: HTMLInputElement): void {
 }
 
 function onToggleSatellite(): void {
-  if (!options.threeD.satellite) tip("Baking satellite texture...", false, "warn", 4000);
+  if (!options.threeD.satellite) toast("Baking satellite texture...", "warn", 4000);
   void toggleSatellite();
 }
 

--- a/src/controllers/zones-editor.ts
+++ b/src/controllers/zones-editor.ts
@@ -12,7 +12,7 @@ import {
 } from "@/components/dialog/table";
 import type { FillBoxElement } from "@/components/fill-box";
 import { Layers } from "@/components/layers";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { Controllers } from "@/controllers";
 import type { Zone } from "@/generators/zones-generator";
 import { clearLegend, drawLegend } from "@/renderers/draw-legend";
@@ -385,7 +385,7 @@ function changeType(zone: Zone, value: string): void {
 function changePopulation(zone: Zone): void {
   const landCells = zone.cells.filter(i => pack.cells.h[i] >= 20);
   if (!landCells.length) {
-    tip("Zone does not have any land cells, cannot change population", false, "error");
+    toast("Zone does not have any land cells, cannot change population", "error");
     return;
   }
 

--- a/src/generators/burgs-generator.ts
+++ b/src/generators/burgs-generator.ts
@@ -1,4 +1,5 @@
 import { quadtree } from "d3-quadtree";
+import { toast } from "@/components/toast";
 import { Emblems } from "@/generators/emblems-generator";
 import type { BurgGroup } from "@/types/burg-groups";
 import type { Emblem } from "@/types/emblems";
@@ -869,7 +870,7 @@ class BurgModule {
 
   remove(burgId: number) {
     const burg = pack.burgs[burgId];
-    if (!burg) return window.tip(`Burg ${burgId} not found`, false, "error");
+    if (!burg) return toast(`Burg ${burgId} not found`, "error");
 
     pack.cells.burg[burg.cell] = 0;
     burg.removed = true;

--- a/src/generators/markets-generator.ts
+++ b/src/generators/markets-generator.ts
@@ -1,5 +1,6 @@
 import Alea from "alea";
 import { quadtree } from "d3-quadtree";
+import { toast } from "@/components/toast";
 import { rn } from "@/utils";
 import { minmax } from "../utils";
 import { getColors, getRandomColor } from "../utils/colorUtils";
@@ -261,7 +262,7 @@ export class MarketsModule {
     if (!burg || burg.removed) return null;
 
     if (pack.markets.some(m => m.centerBurgId === burgId)) {
-      window.tip("This burg is already a market center", false, "error");
+      toast("This burg is already a market center", "error");
       return null;
     }
 

--- a/src/generators/names-generator.ts
+++ b/src/generators/names-generator.ts
@@ -1,4 +1,4 @@
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { getDefaultNameBases, type NameBase } from "@/data/name-bases";
 import { stored, unlock } from "@/utils/preferences";
 import { capitalize, isVowel, last, P, ra, rand } from "../utils";
@@ -88,7 +88,7 @@ class NamesGenerator {
 
     const data = this.chains[base];
     if (!data || data[""] === undefined) {
-      tip(`Namesbase ${base} is incorrect. Please check in namesbase editor`, false, "error");
+      toast(`Namesbase ${base} is incorrect. Please check in namesbase editor`, "error");
       ERROR && console.error(`Namebase ${base} is incorrect!`);
       return "ERROR";
     }
@@ -277,7 +277,7 @@ class NamesGenerator {
     if (force && stored("mapName")) unlock("mapName");
     const base = P(0.7) ? 2 : P(0.5) ? rand(0, 6) : rand(0, 31);
     if (!this.nameBases[base]) {
-      tip("Namebase is not found", false, "error");
+      toast("Namebase is not found", "error");
       return "";
     }
     const min = this.nameBases[base].min - 1;

--- a/src/index.html
+++ b/src/index.html
@@ -2564,6 +2564,7 @@
       style="opacity: 0"
       data-main="Сlick the arrow button for options. Zoom in to see the map in details"
     ></div>
+    <toast-container></toast-container>
     <div id="mapOverlay" style="display: none">Drop a map file to open</div>
     <div id="fileInputs" style="display: none">
       <input type="file" accept=".map,.gz" id="mapToLoad" />

--- a/src/renderers/draw-heightmap.ts
+++ b/src/renderers/draw-heightmap.ts
@@ -22,7 +22,7 @@ import {
   range,
   select
 } from "d3";
-import { toast } from "../components/toast";
+import { tip } from "../components/tooltips";
 import { round } from "../utils";
 
 const CURVE_MAP: Record<string, CurveFactory> = {
@@ -46,7 +46,8 @@ const CURVE_MAP: Record<string, CurveFactory> = {
 };
 
 export const drawHeightmap = (): void => {
-  if (customization === 1) return void toast("The Layer control is not available in the heightmap edit mode", "error");
+  // Pinned main tip, not a toast: layer-teardown e2e specs assert on #tooltip's text here.
+  if (customization === 1) return void tip("The Layer control is not available in the heightmap edit mode");
 
   TIME && console.time("drawHeightmap");
 

--- a/src/renderers/draw-heightmap.ts
+++ b/src/renderers/draw-heightmap.ts
@@ -22,7 +22,7 @@ import {
   range,
   select
 } from "d3";
-import { tip } from "../components/tooltips";
+import { toast } from "../components/toast";
 import { round } from "../utils";
 
 const CURVE_MAP: Record<string, CurveFactory> = {
@@ -46,8 +46,7 @@ const CURVE_MAP: Record<string, CurveFactory> = {
 };
 
 export const drawHeightmap = (): void => {
-  if (customization === 1)
-    return void tip("The Layer control is not available in the heightmap edit mode", false, "error");
+  if (customization === 1) return void toast("The Layer control is not available in the heightmap edit mode", "error");
 
   TIME && console.time("drawHeightmap");
 

--- a/src/renderers/view-3d-renderer.ts
+++ b/src/renderers/view-3d-renderer.ts
@@ -1,5 +1,6 @@
 import type * as THREE from "three";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import type { Burg } from "@/generators/burgs-generator";
 import type { State } from "@/generators/states-generator";
 import { Services } from "@/services";
@@ -317,7 +318,7 @@ const saveScreenshot = async () => {
   link.download = `${getFileName()}.jpeg`;
   link.href = URL;
   link.click();
-  window.tip(`Screenshot is saved. Open "Downloads" screen (CTRL + J) to check`, true, "success", 7000);
+  toast(`Screenshot is saved. Open "Downloads" screen (CTRL + J) to check`, "success", 7000);
   window.setTimeout(() => window.URL.revokeObjectURL(URL), 5000);
 };
 
@@ -331,7 +332,7 @@ const saveOBJ = async () => {
 // start 3d view and heightmap edit preview
 async function newMesh(canvas: HTMLCanvasElement) {
   const loaded = await loadTHREE();
-  if (!loaded) return window.tip("Cannot load 3d library", false, "error", 4000);
+  if (!loaded) return toast("Cannot load 3d library", "error", 4000);
   scene = new Three.Scene();
 
   // light
@@ -707,7 +708,7 @@ async function createMesh(width: number, height: number, segmentsX: number, segm
     });
     if (!bakeResult && options.threeD.erosion) {
       console.warn("3D erosion bake failed, falling back to standard mesh");
-      window.tip("Eroded terrain is not supported on this device", false, "warn", 4000);
+      toast("Eroded terrain is not supported on this device", "warn", 4000);
       options.threeD.erosion = false;
       syncErosionUI();
     }
@@ -862,7 +863,7 @@ async function update3dTexture() {
 async function newGlobe(canvas: HTMLCanvasElement) {
   const loaded = await loadTHREE();
   if (!loaded) {
-    window.tip("Cannot load 3d library", false, "error", 4000);
+    toast("Cannot load 3d library", "error", 4000);
     return false;
   }
 

--- a/src/services/autosave.ts
+++ b/src/services/autosave.ts
@@ -1,6 +1,6 @@
 // Background save lifecycle: the autosave timer and the periodic "remember to save" reminder
 
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { Services } from "@/services";
 import { ensureEl, ra } from "@/utils";
 
@@ -15,17 +15,17 @@ export function initiateAutosave(): void {
 
     const diffInMinutes = (Date.now() - lastSavedAt) / MINUTE;
     if (diffInMinutes < timeoutMinutes) return;
-    if (customization) return tip("Autosave: map cannot be saved in edit mode", false, "warn", 2000);
+    if (customization) return toast("Autosave: map cannot be saved in edit mode", "warn", 2000);
 
     try {
-      tip("Autosave: saving map...", false, "warn", 3000);
+      toast("Autosave: saving map...", "warn", 3000);
       await Services.Save.saveToStorage(await Services.Save.prepareMapData());
-      tip("Autosave: map is saved", false, "success", 2000);
+      toast("Autosave: map is saved", "success", 2000);
 
       lastSavedAt = Date.now();
     } catch (error) {
       ERROR && console.error(error);
-      tip(`Autosave failed: ${(error as Error)?.message || "Unknown error"}`, true, "error", 4000);
+      toast(`Autosave failed: ${(error as Error)?.message || "Unknown error"}`, "error", 4000);
     }
   }
 
@@ -52,19 +52,19 @@ function startSaveReminder(): void {
 
   reminderInterval = setInterval(() => {
     if (customization) return;
-    tip(ra(message), true, "warn", 2500);
+    toast(ra(message), "warn", 2500);
   }, interval);
   reminderActive = true;
 }
 
 export function toggleSaveReminder(): void {
   if (reminderActive) {
-    tip("Save reminder is turned off. Press CTRL+Q again to re-initiate", true, "warn", 2000);
+    toast("Save reminder is turned off. Press CTRL+Q again to re-initiate", "warn", 2000);
     clearInterval(reminderInterval);
     localStorage.setItem("noReminder", "true");
     reminderActive = false;
   } else {
-    tip("Save reminder is turned on. Press CTRL+Q to turn off", true, "warn", 2000);
+    toast("Save reminder is turned on. Press CTRL+Q to turn off", "warn", 2000);
     localStorage.removeItem("noReminder");
     startSaveReminder();
   }

--- a/src/services/fonts.ts
+++ b/src/services/fonts.ts
@@ -1,5 +1,5 @@
 import { select } from "d3";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { ensureEl } from "../utils";
 
 declare global {
@@ -367,8 +367,8 @@ export function getUsedFonts(svg: SVGSVGElement): FontDefinition[] {
 
 window.addGoogleFont = async (family: string) => {
   const fontRanges = await fetchGoogleFont(family);
-  if (!fontRanges) return tip("Cannot fetch Google font for this value", true, "error", 4000);
-  tip(`Google font ${family} is loading...`, true, "warn", 4000);
+  if (!fontRanges) return toast("Cannot fetch Google font for this value", "error", 4000);
+  toast(`Google font ${family} is loading...`, "warn", 4000);
 
   const promises = fontRanges.map(range => {
     const { src, unicodeRange } = range;
@@ -385,14 +385,14 @@ window.addGoogleFont = async (family: string) => {
         document.fonts.add(fontFace);
       });
       fonts.push(...fontRanges);
-      tip(`Google font ${family} is added to the list`, true, "success", 4000);
+      toast(`Google font ${family} is added to the list`, "success", 4000);
       addFontOption(family);
       const select = ensureEl<HTMLSelectElement>("styleSelectFont");
       if (select) select.value = family;
       changeFont();
     })
     .catch(err => {
-      tip(`Failed to load Google font ${family}`, true, "error", 4000);
+      toast(`Failed to load Google font ${family}`, "error", 4000);
       ERROR && console.error(err);
     });
 };
@@ -404,7 +404,7 @@ window.addLocalFont = (family: string) => {
     display: "block"
   });
   document.fonts.add(fontFace);
-  tip(`Local font ${family} is added to the fonts list`, true, "success", 4000);
+  toast(`Local font ${family} is added to the fonts list`, "success", 4000);
   addFontOption(family);
   const select = ensureEl<HTMLSelectElement>("styleSelectFont");
   if (select) select.value = family;
@@ -417,7 +417,7 @@ window.addWebFont = (family: string, url: string) => {
 
   const fontFace = new FontFace(family, src, { display: "block" });
   document.fonts.add(fontFace);
-  tip(`Font ${family} is added to the list`, true, "success", 4000);
+  toast(`Font ${family} is added to the list`, "success", 4000);
   addFontOption(family);
   const select = ensureEl<HTMLSelectElement>("styleSelectFont");
   if (select) select.value = family;

--- a/src/services/installation.ts
+++ b/src/services/installation.ts
@@ -1,3 +1,4 @@
+import { toast } from "@/components/toast";
 import { tip } from "@/components/tooltips";
 
 let installButton: HTMLButtonElement | null = null;
@@ -11,7 +12,7 @@ function init(event: Event & { prompt: () => void }): void {
   deferredPrompt = event;
 
   window.addEventListener("appinstalled", () => {
-    tip("Application is installed", false, "success", 8000);
+    toast("Application is installed", "success", 8000);
     cleanup();
   });
 }

--- a/src/services/io/cloud.ts
+++ b/src/services/io/cloud.ts
@@ -7,7 +7,7 @@
 //   getLink(path): get a shareable link for a file
 //   initialize(): restore access tokens from storage if possible, else authenticate
 
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 
 export interface CloudFile {
   name: string;
@@ -170,7 +170,7 @@ const dropbox: DropboxProvider = {
 
   returnError(errorDescription) {
     console.error(errorDescription);
-    tip(errorDescription.replaceAll("+", " "), true, "error", 4000);
+    toast(errorDescription.replaceAll("+", " "), "error", 4000);
   },
 
   async getLink(path) {

--- a/src/services/io/export-json.ts
+++ b/src/services/io/export-json.ts
@@ -1,5 +1,5 @@
 import { closeDialogs } from "@/components/dialog/dialog-helpers";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { VERSION } from "@/services/versioning";
 import { getFileName } from "@/utils";
 
@@ -14,7 +14,7 @@ const typeMap = {
 
 function exportToJson(type: ExportJsonType): void {
   if (customization) {
-    tip("Data cannot be exported when edit mode is active, please exit the mode and retry", false, "error");
+    toast("Data cannot be exported when edit mode is active, please exit the mode and retry", "error");
     return;
   }
   closeDialogs("#alert");
@@ -27,7 +27,7 @@ function exportToJson(type: ExportJsonType): void {
   link.download = `${getFileName(type)}.json`;
   link.href = URL;
   link.click();
-  tip(`${link.download} is saved. Open "Downloads" screen (CTRL + J) to check`, true, "success", 7000);
+  toast(`${link.download} is saved. Open "Downloads" screen (CTRL + J) to check`, "success", 7000);
   window.URL.revokeObjectURL(URL);
   TIME && console.timeEnd("exportToJson");
 }

--- a/src/services/io/export.ts
+++ b/src/services/io/export.ts
@@ -1,7 +1,7 @@
 import type { Selection } from "d3";
 import { select } from "d3";
 import { Layers } from "@/components/layers";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { renderEmblemDefinitions } from "@/renderers/draw-emblems";
 import { drawScaleBar } from "@/renderers/draw-scalebar";
 import { ViewportLayers } from "@/renderers/viewport/viewport-renderer";
@@ -47,10 +47,10 @@ async function exportToSvg(): Promise<void> {
     link.click();
 
     const message = `${link.download} is saved. Open 'Downloads' screen (CTRL + J) to check`;
-    tip(message, true, "success", 5000);
+    toast(message, "success", 5000);
   } catch (error) {
     ERROR && console.error(error);
-    tip(`SVG export failed: ${(error as Error)?.message || "Unknown error"}`, true, "error", 5000);
+    toast(`SVG export failed: ${(error as Error)?.message || "Unknown error"}`, "error", 5000);
   } finally {
     TIME && console.timeEnd("exportToSvg");
   }
@@ -89,10 +89,10 @@ async function exportToPng(): Promise<void> {
     }, 1000);
 
     const message = `${link.download} is saved. Open 'Downloads' screen (CTRL + J) to check. You can set image scale in options`;
-    tip(message, true, "success", 5000);
+    toast(message, "success", 5000);
   } catch (error) {
     ERROR && console.error(error);
-    tip(`PNG export failed: ${(error as Error)?.message || "Unknown error"}`, true, "error", 5000);
+    toast(`PNG export failed: ${(error as Error)?.message || "Unknown error"}`, "error", 5000);
   } finally {
     TIME && console.timeEnd("exportToPng");
   }
@@ -130,11 +130,11 @@ async function exportToJpeg(): Promise<void> {
     link.download = `${getFileName()}.jpeg`;
     link.href = window.URL.createObjectURL(blob);
     link.click();
-    tip(`${link.download} is saved. Open "Downloads" screen (CTRL + J) to check`, true, "success", 7000);
+    toast(`${link.download} is saved. Open "Downloads" screen (CTRL + J) to check`, "success", 7000);
     window.setTimeout(() => window.URL.revokeObjectURL(link.href), 5000);
   } catch (error) {
     ERROR && console.error(error);
-    tip(`JPEG export failed: ${(error as Error)?.message || "Unknown error"}`, true, "error", 5000);
+    toast(`JPEG export failed: ${(error as Error)?.message || "Unknown error"}`, "error", 5000);
   } finally {
     TIME && console.timeEnd("exportToJpeg");
   }
@@ -218,7 +218,7 @@ async function exportToPngTiles(): Promise<void> {
     .catch((error: Error) => {
       ERROR && console.error(error);
       status.innerHTML = "Tiles export failed";
-      tip(`PNG tiles export failed: ${error?.message || "Unknown error"}`, true, "error", 5000);
+      toast(`PNG tiles export failed: ${error?.message || "Unknown error"}`, "error", 5000);
     });
 
   // promisified img.onload

--- a/src/services/io/load.ts
+++ b/src/services/io/load.ts
@@ -1,6 +1,7 @@
 import { select } from "d3";
 import { closeDialogs } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
+import { toast } from "@/components/toast";
 import { clearMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { GraphOverride } from "@/generators/graph-override";
@@ -15,7 +16,7 @@ async function quickLoad(): Promise<void> {
   const blob = await ldb.get("lastMap");
   if (blob) loadMapPrompt(blob);
   else {
-    tip("No map stored. Save map to browser storage first", true, "error", 2000);
+    toast("No map stored. Save map to browser storage first", "error", 2000);
     ERROR && console.error("No map stored");
   }
 }
@@ -43,7 +44,7 @@ async function createSharableDropboxLink(): Promise<void> {
     sharableLinkContainer.style.display = "block";
   } catch (error) {
     ERROR && console.error(error);
-    return tip("Dropbox API error. Can not create link.", true, "error", 2000);
+    return toast("Dropbox API error. Can not create link.", "error", 2000);
   }
 }
 
@@ -76,7 +77,7 @@ function loadMapPrompt(blob: Blob): void {
       uploadMap(blob);
     } catch (error) {
       ERROR && console.error(error);
-      tip("Cannot load last saved map", true, "error", 2000);
+      toast("Cannot load last saved map", "error", 2000);
     }
   }
 }
@@ -717,7 +718,7 @@ async function parseLoadedData(data: string[], mapVersion: string | null): Promi
 
     WARN && console.warn(`TOTAL: ${rn((performance.now() - uploadTimeStart) / 1000, 2)}s`);
     showStatistics();
-    tip("Map is successfully loaded", true, "success", 7000);
+    toast("Map is successfully loaded", "success", 7000);
   } catch (error) {
     ERROR && console.error(error);
     clearMainTip();

--- a/src/services/io/load.ts
+++ b/src/services/io/load.ts
@@ -718,7 +718,9 @@ async function parseLoadedData(data: string[], mapVersion: string | null): Promi
 
     WARN && console.warn(`TOTAL: ${rn((performance.now() - uploadTimeStart) / 1000, 2)}s`);
     showStatistics();
-    toast("Map is successfully loaded", "success", 7000);
+    // Pinned main tip, not a toast: several e2e specs wait on #tooltip's text as the
+    // "map finished loading" signal.
+    tip("Map is successfully loaded", true);
   } catch (error) {
     ERROR && console.error(error);
     clearMainTip();

--- a/src/services/io/save.ts
+++ b/src/services/io/save.ts
@@ -2,7 +2,7 @@
 
 import { closeDialogs } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 import { GraphOverride } from "@/generators/graph-override";
 import { Services } from "@/services";
 import { getUsedFonts } from "@/services/fonts";
@@ -13,7 +13,7 @@ import { ensureEl, getFileName, link, parseError, rn } from "@/utils";
 type SaveMethod = "storage" | "machine" | "dropbox";
 
 async function saveMap(method: SaveMethod): Promise<void> {
-  if (customization) return tip("Map cannot be saved in EDIT mode, please complete the edit and retry", false, "error");
+  if (customization) return toast("Map cannot be saved in EDIT mode, please complete the edit and retry", "error");
   closeDialogs("#alert");
 
   try {
@@ -213,7 +213,7 @@ function prepareMapData(): string {
 async function saveToStorage(mapData: string, showTip = false): Promise<void> {
   const blob = new Blob([mapData], { type: "text/plain" });
   await ldb.set("lastMap", blob);
-  showTip && tip("Map is saved to the browser storage", false, "success");
+  showTip && toast("Map is saved to the browser storage", "success");
 }
 
 // download map file
@@ -226,13 +226,13 @@ function saveToMachine(mapData: string, filename: string): void {
   link.href = URL;
   link.click();
 
-  tip('Map is saved to the "Downloads" folder (CTRL + J to open)', true, "success", 8000);
+  toast('Map is saved to the "Downloads" folder (CTRL + J to open)', "success", 8000);
   setTimeout(() => window.URL.revokeObjectURL(URL), 5000);
 }
 
 async function saveToDropbox(mapData: string, filename: string): Promise<void> {
   await Services.Cloud.save(filename, mapData);
-  tip("Map is saved to your Dropbox", true, "success", 8000);
+  toast("Map is saved to your Dropbox", "success", 8000);
 }
 
 export const Save = { saveMap, prepareMapData, saveToStorage };

--- a/src/services/versioning.ts
+++ b/src/services/versioning.ts
@@ -16,7 +16,7 @@
  */
 
 import { dialogState } from "@/components/dialog/state";
-import { tip } from "@/components/tooltips";
+import { toast } from "@/components/toast";
 
 export const VERSION = "1.148.1";
 
@@ -150,7 +150,7 @@ function announceVersion(): void {
     setTimeout(() => showUpdateWindow(storedVersion), 6000);
   } else if (compareVersions(storedVersion, VERSION).isOlder) {
     localStorage.setItem("version", VERSION);
-    tip(`Updated to v${VERSION}. Reload the page if you get errors`, true, "success", 6000);
+    toast(`Updated to v${VERSION}. Reload the page if you get errors`, "success", 6000);
   }
 }
 

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -31,6 +31,9 @@ if (typeof window.tip === "undefined") {
 if (typeof window.clearMainTip === "undefined") {
   window.clearMainTip = () => {};
 }
+if (typeof window.toast === "undefined") {
+  window.toast = () => {};
+}
 
 // Logging flags declared in public/main.js and referenced bare by bundled modules
 for (const flag of ["INFO", "TIME", "ERROR", "WARN", "DEBUG"]) {

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -22,6 +22,7 @@ declare global {
     clearMainTip: typeof import("../components/tooltips").clearMainTip;
     showDataTip: typeof import("../components/tooltips").showDataTip;
     showElementLockTip: typeof import("../components/tooltips").showElementLockTip;
+    toast: typeof import("../components/toast").toast;
     lock: typeof import("../utils/preferences").lock;
     unlock: typeof import("../utils/preferences").unlock;
     stored: typeof import("../utils/preferences").stored;

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -7,7 +7,7 @@ type DispatchFn = (...args: unknown[]) => unknown;
 let pendingLoads = 0;
 function trackLoad<T>(promise: Promise<T>): Promise<T> {
   pendingLoads++;
-  window.tip("Loading…", false, "info");
+  window.toast("Loading…", "info");
   return promise.finally(() => {
     if (--pendingLoads <= 0) {
       pendingLoads = 0;

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -7,7 +7,9 @@ type DispatchFn = (...args: unknown[]) => unknown;
 let pendingLoads = 0;
 function trackLoad<T>(promise: Promise<T>): Promise<T> {
   pendingLoads++;
-  window.toast("Loading…", "info");
+  // A pinned main tip, not a toast: a toast would auto-expire while a load is still pending,
+  // and each concurrent load would stack its own toast instead of sharing one status line.
+  window.tip("Loading…", true);
   return promise.finally(() => {
     if (--pendingLoads <= 0) {
       pendingLoads = 0;

--- a/tests/e2e/toast.spec.ts
+++ b/tests/e2e/toast.spec.ts
@@ -1,0 +1,65 @@
+import { expect, type Page, test } from "@playwright/test";
+
+async function waitForMapLoad(page: Page) {
+  await page.waitForFunction(() => (window as any).mapId !== undefined, { timeout: 60000 });
+}
+
+test.describe("toast notifications", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/?seed=test-toast&width=1280&height=720");
+    await waitForMapLoad(page);
+  });
+
+  test("shows a toast with the given message and type", async ({ page }) => {
+    await page.evaluate(() => (window as any).toast("Hello there", "success", 0));
+
+    const toast = page.locator("toast-item");
+    await expect(toast).toBeVisible();
+    await expect(toast).toHaveAttribute("data-type", "success");
+    await expect(toast.locator(".toast-message")).toHaveText("Hello there");
+  });
+
+  test("stacks new toasts above older ones", async ({ page }) => {
+    await page.evaluate(() => (window as any).toast("First", "info", 0));
+    await page.evaluate(() => (window as any).toast("Second", "info", 0));
+    await page.evaluate(() => (window as any).toast("Third", "info", 0));
+
+    await expect(page.locator("toast-item")).toHaveCount(3);
+    await expect(page.locator("toast-item .toast-message")).toHaveText(["Third", "Second", "First"]);
+  });
+
+  test("auto-dismisses after its duration", async ({ page }) => {
+    await page.evaluate(() => (window as any).toast("Bye soon", "warn", 1000));
+
+    await expect(page.locator("toast-item")).toHaveCount(1);
+    await expect(page.locator("toast-item")).toHaveCount(0, { timeout: 3000 });
+  });
+
+  test("does not auto-dismiss when duration is 0", async ({ page }) => {
+    await page.evaluate(() => (window as any).toast("Sticks around", "error", 0));
+
+    await page.waitForTimeout(2000);
+    await expect(page.locator("toast-item")).toHaveCount(1);
+  });
+
+  test("dismisses on close button click", async ({ page }) => {
+    await page.evaluate(() => (window as any).toast("Dismiss me", "info", 0));
+
+    await page.locator("toast-item .toast-close").click();
+    await expect(page.locator("toast-item")).toHaveCount(0);
+  });
+
+  test("hovering pauses the auto-dismiss timer", async ({ page }) => {
+    await page.evaluate(() => (window as any).toast("Pause me", "info", 1000));
+
+    const toast = page.locator("toast-item");
+    await toast.hover();
+    // Held well past the original 1s deadline while still hovered.
+    await page.waitForTimeout(2000);
+    await expect(toast).toHaveCount(1);
+
+    // Moving away resumes the (shortened) remaining timer, so it eventually dismisses.
+    await page.mouse.move(0, 0);
+    await expect(toast).toHaveCount(0, { timeout: 3000 });
+  });
+});

--- a/tests/e2e/toast.spec.ts
+++ b/tests/e2e/toast.spec.ts
@@ -49,6 +49,18 @@ test.describe("toast notifications", () => {
     await expect(page.locator("toast-item")).toHaveCount(0);
   });
 
+  test("renders message content as text, not HTML", async ({ page }) => {
+    await page.evaluate(() => (window as any).toast("<b>bold</b> & <script>x</script>", "error", 0));
+
+    const messageEl = page.locator("toast-item .toast-message");
+    await expect(messageEl).toHaveText("<b>bold</b> & <script>x</script>");
+    expect(await messageEl.locator("b, script").count()).toBe(0);
+  });
+
+  test("container is an aria-live region so screen readers announce new toasts", async ({ page }) => {
+    await expect(page.locator("toast-container")).toHaveAttribute("aria-live", "polite");
+  });
+
   test("hovering pauses the auto-dismiss timer", async ({ page }) => {
     await page.evaluate(() => (window as any).toast("Pause me", "info", 1000));
 


### PR DESCRIPTION
The tip() helper was overloaded: it drove both the hover-tooltip line and ad-hoc status notifications (tip(msg, main, type, time)), all funneled through a single-line element, so a new message clobbered whatever was showing and there was no stacking, dismiss button, or queue.

This adds `<toast-item>`/`<toast-container>` custom elements under `src/components/toast/`, following the existing `fill-box`/`slider-input` pattern already in the codebase: stacked, dismissible, auto-expiring toasts with a pause-on-hover timebar, styled to match the app's existing dialog/button look. `tip()` is trimmed back to its original job of driving the hover/main tooltip line.

- `src/components/toast/{item,container,index}.ts` — the two custom elements plus a side-effect-free `toast()` entry point
- `src/components/tooltips.ts` — `tip()` stripped of the `type`/`time` notification behavior it never should have grown
- ~130 call sites across controllers, services, generators, renderers, and legacy `public/*.js` switched from `tip(msg, main, type, time)` to `toast(msg, type, time)`
- `src/types/global.ts`, `src/test-setup.ts` — `window.toast` bridge kept for the one remaining legacy caller (`utils/registry.ts`, which is documented as never importing from `components/`) and for classic non-module `public/` scripts
- `tests/e2e/toast.spec.ts` — coverage for rendering, stacking order, auto-dismiss, persistent (`duration: 0`) toasts, manual dismiss, and hover-to-pause
