### PR TITLE
Preset switches resize relief icons by the ratio, not the target size

### DIFF
--- a/public/modules/ui/style-presets.js
+++ b/public/modules/ui/style-presets.js
@@ -94,7 +94,7 @@ function applyStoredStyles() {
 
 function applyReliefOptions(previousSize) {
   const {set, size} = styles.relief.options;
-  if (size && size / previousSize !== 1) Relief.changeSize(size);
+  if (size && size / previousSize !== 1) Relief.changeSize(size / previousSize);
   if (set) Relief.changeSet(set);
 }
 

--- a/tests/e2e/style-presets.spec.ts
+++ b/tests/e2e/style-presets.spec.ts
@@ -20,6 +20,19 @@ async function switchTo(page: Page, preset: string) {
   }, preset);
 }
 
+// Relief.changeSize (src/generators/relief-generator.ts) writes the resized value into
+// pack.relief[i].s, and the viewport renderer copies that straight into the <use> width/height
+// attrs (src/renderers/draw-relief-icons.ts) - so a stuck-shrunk icon is observable on a specific
+// icon's width attr without forcing a full relief regeneration.
+async function firstReliefIconId(page: Page) {
+  return page.evaluate(() => document.querySelector("#terrain > use")?.getAttribute("data-id") ?? null);
+}
+
+async function reliefIconWidth(page: Page, id: string) {
+  const width = await page.locator(`#terrain > use[data-id="${id}"]`).getAttribute("width");
+  return width == null ? null : Number(width);
+}
+
 // two independently-sourced attributes (ocean vs landmass fill) so a preset apply that silently
 // no-ops can't hide behind the previous preset's leftover value - see the collision check below
 async function readPinnedAttrs(page: Page) {
@@ -79,4 +92,36 @@ test("every shipped preset applies through the store with no console errors", as
 
   expect(consoleErrors, "console errors during preset switching").toEqual([]);
   expect(pageErrors, "page errors during preset switching").toEqual([]);
+});
+
+test("relief icon size round-trips through a preset switch and back", async ({page}) => {
+  await page.goto("/?seed=test-seed&width=1280&height=720");
+  await page.waitForFunction(() => (window as any).mapId !== undefined, {timeout: 60000});
+  await page.waitForSelector("#burgIcons > g", {state: "attached", timeout: 60000});
+  await page.waitForSelector("#labels > g", {state: "attached", timeout: 60000});
+  await page.waitForTimeout(500);
+
+  await page.evaluate(() => sessionStorage.setItem("styleChangeConfirmed", "true"));
+
+  // the "relief" layer is off in the default layers preset - turn it on so the terrain icons render
+  await page.evaluate(() => (window as any).Layers.show("relief"));
+  await page.waitForSelector("#terrain > use", {state: "attached", timeout: 60000});
+
+  await switchTo(page, "default");
+  await page.waitForTimeout(100);
+
+  const id = await firstReliefIconId(page);
+  expect(id, "a relief icon to measure").not.toBeNull();
+  const baselineWidth = await reliefIconWidth(page, id as string);
+  expect(baselineWidth, "baseline relief icon width").toBeGreaterThan(0);
+
+  await switchTo(page, "pale");
+  await page.waitForTimeout(100);
+  const paleWidth = await reliefIconWidth(page, id as string);
+  expect(paleWidth, "relief icon width after switching to pale (size 0.7)").toBeCloseTo(baselineWidth! * 0.7, 1);
+
+  await switchTo(page, "default");
+  await page.waitForTimeout(100);
+  const revertedWidth = await reliefIconWidth(page, id as string);
+  expect(revertedWidth, "relief icon width after switching back to default (size 1)").toBeCloseTo(baselineWidth!, 1);
 });


### PR DESCRIPTION
The behavior fix deliberately left out of #1611.

`Relief.changeSize()` takes a ratio (it multiplies each icon's current size — that's how the style editor calls it), but the preset path has always passed the absolute target size. `default → pale` (1 → 0.7) works only by coincidence; `pale → default` passes 1 — a no-op multiply — so relief icons stay shrunk while the style claims size 1, and later resizes compound from the wrong base.

One line: pass `size / previousSize`.

The new e2e tracks a single relief icon by data-id through `default → pale → default` and asserts its width returns to baseline — it fails on the old code (icon stuck at 0.7×) and passes with the fix. Style parity is unaffected (the committed baselines pin the default preset, ratio 1).

Based on #1611's branch so the diff shows just this fix; when #1611 merges, GitHub retargets this PR to 1.149.0 automatically. Merge order: #1611 first.