### PR TITLE
AI chat: OpenAI-compatible providers, local LLMs, file downloads

### DIFF
--- a/src/controllers/ai-chat.ts
+++ b/src/controllers/ai-chat.ts
@@ -12,7 +12,7 @@ import {
   select,
   touch
 } from "@/services/agent/conversations";
-import { DEFAULT_MODEL, KEY_LINK, KEY_STORAGE, MODELS } from "@/services/agent/providers";
+import { DEFAULT_MODEL, keyStorageFor, PROVIDERS, providerOf } from "@/services/agent/providers";
 import type { RunResult } from "@/services/agent/runtime";
 import { createSession } from "@/services/agent/session";
 import { openURL } from "@/utils";
@@ -75,7 +75,9 @@ function renderDialog(): void {
   });
   ensureEl("aiChatNew").addEventListener("click", startNewConversation);
   ensureEl("aiChatRemove").addEventListener("click", removeConversation);
-  ensureEl("aiChatKeyHelp").addEventListener("click", () => openURL(KEY_LINK));
+  ensureEl("aiChatKeyHelp").addEventListener("click", () =>
+    openURL(providerOf(ensureEl<HTMLSelectElement>("aiChatModel").value).keyLink)
+  );
   ensureEl("aiChatSend").addEventListener("click", () => {
     if (busy) session.cancel();
     else void send();
@@ -178,13 +180,28 @@ function dialogHtml(): string {
 function setInitialValues(): void {
   const select = ensureEl<HTMLSelectElement>("aiChatModel");
   select.options.length = 0;
-  MODELS.forEach(model => {
-    select.options.add(new Option(model, model));
+  PROVIDERS.forEach(provider => {
+    const group = document.createElement("optgroup");
+    group.label = provider.label;
+    provider.models.forEach(model => {
+      group.append(new Option(model, model));
+    });
+    select.append(group);
   });
-  select.value = localStorage.getItem(MODEL_STORAGE) ?? "";
-  if (!MODELS.includes(select.value)) select.value = DEFAULT_MODEL;
+  const stored = localStorage.getItem(MODEL_STORAGE) ?? "";
+  select.value = PROVIDERS.some(provider => provider.models.includes(stored)) ? stored : DEFAULT_MODEL;
 
-  ensureEl<HTMLInputElement>("aiChatKey").value = localStorage.getItem(KEY_STORAGE) ?? "";
+  select.addEventListener("change", loadKeyForModel);
+  loadKeyForModel();
+  updateSendButton();
+}
+
+// Each provider has its own key slot, so switching models swaps the key field with it
+function loadKeyForModel(): void {
+  const model = ensureEl<HTMLSelectElement>("aiChatModel").value;
+  const key = ensureEl<HTMLInputElement>("aiChatKey");
+  key.value = localStorage.getItem(keyStorageFor(model)) ?? "";
+  key.dataset.tip = `${providerOf(model).label} API key. It's stored on your machine only (browser storage) and sent directly to the provider`;
   updateSendButton();
 }
 
@@ -211,8 +228,9 @@ async function send(text?: string): Promise<void> {
     tip("Please enter an API key", true, "error", 4000);
     return;
   }
-  localStorage.setItem(KEY_STORAGE, key);
-  localStorage.setItem(MODEL_STORAGE, ensureEl<HTMLSelectElement>("aiChatModel").value);
+  const model = ensureEl<HTMLSelectElement>("aiChatModel").value;
+  localStorage.setItem(keyStorageFor(model), key);
+  localStorage.setItem(MODEL_STORAGE, model);
 
   input.value = "";
   input.style.height = "auto";

--- a/src/controllers/ai-chat.ts
+++ b/src/controllers/ai-chat.ts
@@ -12,7 +12,15 @@ import {
   select,
   touch
 } from "@/services/agent/conversations";
-import { DEFAULT_MODEL, keyStorageFor, PROVIDERS, providerOf } from "@/services/agent/providers";
+import {
+  DEFAULT_LOCAL_URL,
+  DEFAULT_MODEL,
+  keyStorageFor,
+  LOCAL_MODEL_STORAGE,
+  LOCAL_URL_STORAGE,
+  PROVIDERS,
+  providerOf
+} from "@/services/agent/providers";
 import type { RunResult } from "@/services/agent/runtime";
 import { createSession } from "@/services/agent/session";
 import { openURL } from "@/utils";
@@ -117,6 +125,8 @@ function dialogHtml(): string {
       #aiChatEmpty button { padding: 0.25em 0.7em; border-radius: 1em; cursor: pointer; }
       #aiChatInput { resize: none; overflow-y: auto; }
       #aiChatBottom { display: flex; align-items: center; gap: 0.3em; flex-wrap: wrap; }
+      #aiChatLocal { align-items: center; gap: 0.3em; }
+      #aiChatLocal > input { flex: 1; min-width: 8em; }
       #aiChatBottom > select { flex: 1; min-width: 6em; }
       #aiChatBottom > input { flex: 1; min-width: 5em; }
       #aiChat .aiChatUser { align-self: flex-end; max-width: 85%; padding: 0.3em 0.6em; border-radius: 0.8em 0.8em 0.2em 0.8em; background: rgba(128, 128, 128, 0.18); }
@@ -162,6 +172,21 @@ function dialogHtml(): string {
 
     <textarea id="aiChatInput" rows="2" placeholder="Ask about the map…" data-tip="Type a question. Enter to send, Shift + Enter for a new line"></textarea>
 
+    <div id="aiChatLocal" style="display: none">
+      <input
+        id="aiChatLocalUrl"
+        type="text"
+        placeholder="${DEFAULT_LOCAL_URL}"
+        data-tip="Base URL of an OpenAI-compatible local server (Ollama, llama.cpp, LM Studio). For Ollama outside localhost, allow the app origin via OLLAMA_ORIGINS"
+      />
+      <input
+        id="aiChatLocalModel"
+        type="text"
+        placeholder="model name, e.g. llama3.2"
+        data-tip="Name of the model as your local server knows it (e.g. an installed Ollama model)"
+      />
+    </div>
+
     <div id="aiChatBottom">
       <button id="aiChatSend" class="icon-right-open" data-tip="Send the message"></button>
       <select id="aiChatModel" data-tip="Model to ask. Bigger models reason better and cost more"></select>
@@ -184,7 +209,7 @@ function setInitialValues(): void {
     const group = document.createElement("optgroup");
     group.label = provider.label;
     provider.models.forEach(model => {
-      group.append(new Option(model, model));
+      group.append(new Option(provider.id === "local" ? "custom model…" : model, model));
     });
     select.append(group);
   });
@@ -199,9 +224,19 @@ function setInitialValues(): void {
 // Each provider has its own key slot, so switching models swaps the key field with it
 function loadKeyForModel(): void {
   const model = ensureEl<HTMLSelectElement>("aiChatModel").value;
+  const local = providerOf(model).id === "local";
   const key = ensureEl<HTMLInputElement>("aiChatKey");
   key.value = localStorage.getItem(keyStorageFor(model)) ?? "";
-  key.dataset.tip = `${providerOf(model).label} API key. It's stored on your machine only (browser storage) and sent directly to the provider`;
+  key.placeholder = local ? "API key (optional)" : "API key";
+  key.dataset.tip = local
+    ? "Optional API key — most local servers need none. Sent as a Bearer token when set"
+    : `${providerOf(model).label} API key. It's stored on your machine only (browser storage) and sent directly to the provider`;
+
+  ensureEl("aiChatLocal").style.display = local ? "flex" : "none";
+  if (local) {
+    ensureEl<HTMLInputElement>("aiChatLocalUrl").value = localStorage.getItem(LOCAL_URL_STORAGE) ?? "";
+    ensureEl<HTMLInputElement>("aiChatLocalModel").value = localStorage.getItem(LOCAL_MODEL_STORAGE) ?? "";
+  }
   updateSendButton();
 }
 
@@ -222,13 +257,24 @@ async function send(text?: string): Promise<void> {
   const question = (text ?? input.value).trim();
   if (!question) return;
 
+  const model = ensureEl<HTMLSelectElement>("aiChatModel").value;
+  const local = providerOf(model).id === "local";
   const key = ensureEl<HTMLInputElement>("aiChatKey").value;
-  if (!key) {
+  if (!key && !local) {
     ensureEl("aiChatKey").focus();
     tip("Please enter an API key", true, "error", 4000);
     return;
   }
-  const model = ensureEl<HTMLSelectElement>("aiChatModel").value;
+  if (local) {
+    const localModel = ensureEl<HTMLInputElement>("aiChatLocalModel").value.trim();
+    if (!localModel) {
+      ensureEl("aiChatLocalModel").focus();
+      tip("Please enter the local model name", true, "error", 4000);
+      return;
+    }
+    localStorage.setItem(LOCAL_URL_STORAGE, ensureEl<HTMLInputElement>("aiChatLocalUrl").value.trim());
+    localStorage.setItem(LOCAL_MODEL_STORAGE, localModel);
+  }
   localStorage.setItem(keyStorageFor(model), key);
   localStorage.setItem(MODEL_STORAGE, model);
 

--- a/src/services/agent/context.ts
+++ b/src/services/agent/context.ts
@@ -35,6 +35,9 @@ const RULES = `# Rules
 - Prefer one script that computes the final answer over several exploratory ones, but a quick
   \`describe\` round first is fine when the shape is genuinely unknown.
 - If a script throws, read the stack, fix the script and retry.
+- When the user asks for a file (CSV, JSON, plain text), build the content in a script and call
+  \`downloadFile(content, "name.csv", "text/csv")\` — the browser saves it to the user's machine.
+  This does not count as changing the map. Tell the user the file name you produced.
 - Answer in prose. Do not paste raw JSON at the user unless they ask for it.
 - Your answers render as Markdown, so use it where it earns its place: a table for multi-column
   results, a list for several findings, \`code\` for field and entity names, bold for a headline

--- a/src/services/agent/providers-local.test.ts
+++ b/src/services/agent/providers-local.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { complete, keyStorageFor, LOCAL_MODEL, LOCAL_MODEL_STORAGE, LOCAL_URL_STORAGE, providerOf } from "./providers";
+import { completeOpenAI } from "./providers-openai";
+
+function memoryStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => void data.set(key, value),
+    removeItem: (key: string) => void data.delete(key),
+    clear: () => data.clear(),
+    key: () => null,
+    length: 0
+  } as unknown as Storage;
+}
+
+const globals = globalThis as Record<string, unknown>;
+
+const reply = { choices: [{ message: { content: "ok" }, finish_reason: "stop" }], usage: {} };
+
+function stubFetch(): ReturnType<typeof vi.fn> {
+  const fetchStub = vi.fn(async () => new Response(JSON.stringify(reply), { status: 200 }));
+  globals.fetch = fetchStub;
+  return fetchStub;
+}
+
+const request = { key: "", model: LOCAL_MODEL, system: [], messages: [], tools: [] };
+
+beforeEach(() => {
+  globals.localStorage = memoryStorage();
+});
+
+describe("local provider", () => {
+  it("registers the local sentinel with its own key slot", () => {
+    expect(providerOf(LOCAL_MODEL).id).toBe("local");
+    expect(keyStorageFor(LOCAL_MODEL)).toBe("fmg-ai-kl-local");
+  });
+
+  it("routes completion to the stored base URL with the stored model name", async () => {
+    localStorage.setItem(LOCAL_URL_STORAGE, "http://localhost:8080/v1/");
+    localStorage.setItem(LOCAL_MODEL_STORAGE, "llama3.2");
+    const fetchStub = stubFetch();
+
+    await complete(request);
+
+    const [url, options] = fetchStub.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("http://localhost:8080/v1/chat/completions");
+    expect(JSON.parse(options.body as string).model).toBe("llama3.2");
+  });
+
+  it("defaults the base URL to Ollama's endpoint", async () => {
+    localStorage.setItem(LOCAL_MODEL_STORAGE, "llama3.2");
+    const fetchStub = stubFetch();
+
+    await complete(request);
+
+    expect((fetchStub.mock.calls[0] as unknown as [string])[0]).toBe("http://localhost:11434/v1/chat/completions");
+  });
+
+  it("refuses to run without a model name", async () => {
+    const fetchStub = stubFetch();
+    await expect(complete(request)).rejects.toThrow(/model name/i);
+    expect(fetchStub).not.toHaveBeenCalled();
+  });
+});
+
+describe("completeOpenAI auth header", () => {
+  it("omits Authorization when the key is empty", async () => {
+    const fetchStub = stubFetch();
+    await completeOpenAI("http://localhost:11434/v1", { ...request, model: "llama3.2" });
+    const headers = (fetchStub.mock.calls[0] as unknown as [string, RequestInit])[1].headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it("sends the bearer token when a key is set", async () => {
+    const fetchStub = stubFetch();
+    await completeOpenAI("http://localhost:11434/v1", { ...request, model: "llama3.2", key: "sk-x" });
+    const headers = (fetchStub.mock.calls[0] as unknown as [string, RequestInit])[1].headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer sk-x");
+  });
+});

--- a/src/services/agent/providers-openai.test.ts
+++ b/src/services/agent/providers-openai.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import type { SystemBlock } from "./context";
+import type { Message, ToolDefinition } from "./providers";
+import { keyStorageFor, providerOf } from "./providers";
+import { fromChatResponse, toChatMessages, toChatTools } from "./providers-openai";
+
+const system: SystemBlock[] = [
+  { type: "text", text: "static prefix", cache_control: { type: "ephemeral" } },
+  { type: "text", text: "current map" }
+];
+
+describe("toChatMessages", () => {
+  it("flattens system blocks into one system message without cache markers", () => {
+    const result = toChatMessages(system, []);
+    expect(result).toEqual([{ role: "system", content: "static prefix\n\ncurrent map" }]);
+  });
+
+  it("maps user and assistant text blocks to plain chat messages", () => {
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "how many burgs?" }] },
+      { role: "assistant", content: [{ type: "text", text: "Let me check." }] }
+    ];
+    const [, user, assistant] = toChatMessages(system, messages);
+    expect(user).toEqual({ role: "user", content: "how many burgs?" });
+    expect(assistant).toEqual({ role: "assistant", content: "Let me check." });
+  });
+
+  it("maps assistant tool_use blocks to tool_calls with JSON-encoded arguments", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Running a script." },
+          { type: "tool_use", id: "call_1", name: "run", input: { code: "return 1;" } }
+        ]
+      }
+    ];
+    const [, assistant] = toChatMessages(system, messages);
+    expect(assistant).toEqual({
+      role: "assistant",
+      content: "Running a script.",
+      tool_calls: [{ id: "call_1", type: "function", function: { name: "run", arguments: '{"code":"return 1;"}' } }]
+    });
+  });
+
+  it("maps tool_result blocks to one tool message each", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "call_1", content: "result (1 ms):\n1" },
+          { type: "tool_result", tool_use_id: "call_2", content: "threw", is_error: true }
+        ]
+      }
+    ];
+    const [, first, second] = toChatMessages(system, messages);
+    expect(first).toEqual({ role: "tool", tool_call_id: "call_1", content: "result (1 ms):\n1" });
+    expect(second).toEqual({ role: "tool", tool_call_id: "call_2", content: "threw" });
+  });
+});
+
+describe("toChatTools", () => {
+  it("wraps tool definitions in the function envelope with parameters", () => {
+    const tools: ToolDefinition[] = [
+      { name: "run", description: "Run JS", input_schema: { type: "object", properties: {} } }
+    ];
+    expect(toChatTools(tools)).toEqual([
+      {
+        type: "function",
+        function: { name: "run", description: "Run JS", parameters: { type: "object", properties: {} } }
+      }
+    ]);
+  });
+});
+
+describe("toChatMessages content null", () => {
+  it("sends null content when an assistant turn has only tool calls", () => {
+    const messages: Message[] = [
+      { role: "assistant", content: [{ type: "tool_use", id: "c", name: "run", input: {} }] }
+    ];
+    const [, assistant] = toChatMessages(system, messages);
+    expect(assistant.content).toBeNull();
+  });
+});
+
+describe("fromChatResponse", () => {
+  it("maps a text answer with usage and end_turn stop reason", () => {
+    const completion = fromChatResponse({
+      choices: [{ message: { content: "42 burgs" }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1000, completion_tokens: 20, prompt_tokens_details: { cached_tokens: 800 } }
+    });
+    expect(completion.content).toEqual([{ type: "text", text: "42 burgs" }]);
+    expect(completion.stopReason).toBe("end_turn");
+    expect(completion.usage).toEqual({ input: 200, output: 20, cached: 800 });
+  });
+
+  it("maps tool_calls to tool_use blocks with parsed arguments", () => {
+    const completion = fromChatResponse({
+      choices: [
+        {
+          message: {
+            content: null,
+            tool_calls: [{ id: "call_9", function: { name: "run", arguments: '{"code":"return 2;"}' } }]
+          },
+          finish_reason: "tool_calls"
+        }
+      ],
+      usage: { prompt_tokens: 10, completion_tokens: 5 }
+    });
+    expect(completion.content).toEqual([{ type: "tool_use", id: "call_9", name: "run", input: { code: "return 2;" } }]);
+    expect(completion.stopReason).toBe("tool_use");
+    expect(completion.usage).toEqual({ input: 10, output: 5, cached: 0 });
+  });
+
+  it("survives malformed tool arguments by passing an empty input", () => {
+    const completion = fromChatResponse({
+      choices: [
+        {
+          message: { tool_calls: [{ id: "c", function: { name: "run", arguments: "{broken" } }] },
+          finish_reason: "tool_calls"
+        }
+      ]
+    });
+    expect(completion.content).toEqual([{ type: "tool_use", id: "c", name: "run", input: {} }]);
+  });
+
+  it("reads DeepSeek's cache-hit token field", () => {
+    const completion = fromChatResponse({
+      choices: [{ message: { content: "ok" }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 500, completion_tokens: 1, prompt_cache_hit_tokens: 400 }
+    });
+    expect(completion.usage).toEqual({ input: 100, output: 1, cached: 400 });
+  });
+});
+
+describe("provider routing", () => {
+  it("resolves each model to its provider and key storage slot", () => {
+    expect(providerOf("qwen-flash").id).toBe("qwen");
+    expect(providerOf("mistral-small-latest").id).toBe("mistral");
+    expect(providerOf("deepseek-chat").id).toBe("deepseek");
+    expect(providerOf("gpt-5.6-luna").id).toBe("openai");
+    expect(providerOf("claude-haiku-4-5").id).toBe("anthropic");
+    expect(keyStorageFor("qwen-flash")).toBe("fmg-ai-kl-qwen");
+  });
+
+  it("throws a clear error for an unknown model", () => {
+    expect(() => providerOf("gpt-2")).toThrow(/unknown model/i);
+  });
+});

--- a/src/services/agent/providers-openai.ts
+++ b/src/services/agent/providers-openai.ts
@@ -94,10 +94,14 @@ export async function completeOpenAI(
   baseUrl: string,
   { key, model, system, messages, tools, signal }: CompletionRequest
 ): Promise<Completion> {
+  // Local servers commonly run without auth, so the header is only sent when there is a key
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (key) headers.Authorization = `Bearer ${key}`;
+
   const response = await fetch(`${baseUrl}/chat/completions`, {
     method: "POST",
     signal,
-    headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
+    headers,
     body: JSON.stringify({
       model,
       messages: toChatMessages(system, messages),

--- a/src/services/agent/providers-openai.ts
+++ b/src/services/agent/providers-openai.ts
@@ -1,0 +1,120 @@
+// Translates the agent's Anthropic-shaped conversation into the OpenAI chat/completions format
+// spoken by OpenAI, Mistral, Qwen (DashScope compatible mode) and DeepSeek, and back.
+
+import type { SystemBlock } from "./context";
+import type { Completion, CompletionRequest, Message, TextBlock, ToolDefinition, ToolUseBlock } from "./providers";
+
+type ChatMessage = Record<string, unknown>;
+
+export function toChatMessages(system: SystemBlock[], messages: Message[]): ChatMessage[] {
+  const chat: ChatMessage[] = [{ role: "system", content: system.map(block => block.text).join("\n\n") }];
+
+  for (const message of messages) {
+    if (message.role === "assistant") {
+      const text = message.content
+        .filter(block => block.type === "text")
+        .map(block => block.text)
+        .join("\n\n");
+      const toolCalls = message.content
+        .filter(block => block.type === "tool_use")
+        .map(block => ({
+          id: block.id,
+          type: "function",
+          function: { name: block.name, arguments: JSON.stringify(block.input) }
+        }));
+
+      const entry: ChatMessage = { role: "assistant", content: text || null };
+      if (toolCalls.length) entry.tool_calls = toolCalls;
+      chat.push(entry);
+      continue;
+    }
+
+    for (const block of message.content) {
+      if (block.type === "text") chat.push({ role: "user", content: block.text });
+      else if (block.type === "tool_result") {
+        chat.push({ role: "tool", tool_call_id: block.tool_use_id, content: block.content });
+      }
+    }
+  }
+
+  return chat;
+}
+
+export function toChatTools(tools: ToolDefinition[]): ChatMessage[] {
+  return tools.map(tool => ({
+    type: "function",
+    function: { name: tool.name, description: tool.description, parameters: tool.input_schema }
+  }));
+}
+
+export function fromChatResponse(json: {
+  choices?: {
+    message?: { content?: string | null; tool_calls?: { id: string; function: { name: string; arguments: string } }[] };
+    finish_reason?: string;
+  }[];
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    prompt_tokens_details?: { cached_tokens?: number };
+    prompt_cache_hit_tokens?: number;
+  };
+}): Completion {
+  const message = json.choices?.[0]?.message ?? {};
+  const content: (TextBlock | ToolUseBlock)[] = [];
+
+  if (message.content) content.push({ type: "text", text: message.content });
+  for (const call of message.tool_calls ?? []) {
+    content.push({
+      type: "tool_use",
+      id: call.id,
+      name: call.function.name,
+      input: parseArguments(call.function.arguments)
+    });
+  }
+
+  const finishReason = json.choices?.[0]?.finish_reason ?? "stop";
+  const cached = json.usage?.prompt_tokens_details?.cached_tokens ?? json.usage?.prompt_cache_hit_tokens ?? 0;
+
+  return {
+    content,
+    stopReason: finishReason === "tool_calls" ? "tool_use" : finishReason === "stop" ? "end_turn" : finishReason,
+    usage: { input: (json.usage?.prompt_tokens ?? 0) - cached, output: json.usage?.completion_tokens ?? 0, cached }
+  };
+}
+
+function parseArguments(raw: string): { code?: string } {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+export async function completeOpenAI(
+  baseUrl: string,
+  { key, model, system, messages, tools, signal }: CompletionRequest
+): Promise<Completion> {
+  const response = await fetch(`${baseUrl}/chat/completions`, {
+    method: "POST",
+    signal,
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
+    body: JSON.stringify({
+      model,
+      messages: toChatMessages(system, messages),
+      tools: toChatTools(tools),
+      max_tokens: 4096
+    })
+  });
+
+  if (!response.ok) throw new Error(await readChatError(response));
+  return fromChatResponse(await response.json());
+}
+
+async function readChatError(response: Response): Promise<string> {
+  try {
+    const json = await response.json();
+    return json.error?.message || json.message || `${response.status} ${response.statusText}`;
+  } catch {
+    return `${response.status} ${response.statusText}`;
+  }
+}

--- a/src/services/agent/providers.ts
+++ b/src/services/agent/providers.ts
@@ -58,7 +58,7 @@ export interface Completion {
 }
 
 export interface ProviderSpec {
-  id: "anthropic" | "openai" | "mistral" | "qwen" | "deepseek";
+  id: "anthropic" | "openai" | "mistral" | "qwen" | "deepseek" | "local";
   label: string;
   models: string[];
   keyLink: string;
@@ -99,10 +99,23 @@ export const PROVIDERS: ProviderSpec[] = [
     models: ["deepseek-chat"],
     keyLink: "https://platform.deepseek.com/api_keys",
     baseUrl: "https://api.deepseek.com/v1"
+  },
+  {
+    id: "local",
+    label: "Local",
+    models: ["local"],
+    keyLink: "https://ollama.com"
   }
 ];
 
 export const DEFAULT_MODEL = "claude-sonnet-5";
+
+// Local OpenAI-compatible servers (Ollama, llama.cpp, LM Studio…). The dropdown holds one
+// sentinel entry; the endpoint and model name are the user's own and live in storage.
+export const LOCAL_MODEL = "local";
+export const LOCAL_URL_STORAGE = "fmg-ai-local-url";
+export const LOCAL_MODEL_STORAGE = "fmg-ai-local-model";
+export const DEFAULT_LOCAL_URL = "http://localhost:11434/v1";
 
 export function providerOf(model: string): ProviderSpec {
   const provider = PROVIDERS.find(candidate => candidate.models.includes(model));
@@ -114,6 +127,13 @@ export const keyStorageFor = (model: string): string => `fmg-ai-kl-${providerOf(
 
 export async function complete(request: CompletionRequest): Promise<Completion> {
   const provider = providerOf(request.model);
+  if (provider.id === "local") {
+    const baseUrl = (localStorage.getItem(LOCAL_URL_STORAGE) || DEFAULT_LOCAL_URL).replace(/\/+$/, "");
+    const model = localStorage.getItem(LOCAL_MODEL_STORAGE) ?? "";
+    if (!model) throw new Error("Enter a local model name (e.g. llama3.2)");
+    const { completeOpenAI } = await import("./providers-openai");
+    return completeOpenAI(baseUrl, { ...request, model });
+  }
   if (!provider.baseUrl) return completeAnthropic(request);
   const { completeOpenAI } = await import("./providers-openai");
   return completeOpenAI(provider.baseUrl, request);

--- a/src/services/agent/providers.ts
+++ b/src/services/agent/providers.ts
@@ -57,12 +57,69 @@ export interface Completion {
   usage: Usage;
 }
 
-export const MODELS = ["claude-sonnet-5", "claude-opus-4-8", "claude-haiku-4-5"];
-export const DEFAULT_MODEL = "claude-sonnet-5";
-export const KEY_STORAGE = "fmg-ai-kl-anthropic";
-export const KEY_LINK = "https://console.anthropic.com/account/keys";
+export interface ProviderSpec {
+  id: "anthropic" | "openai" | "mistral" | "qwen" | "deepseek";
+  label: string;
+  models: string[];
+  keyLink: string;
+  baseUrl?: string; // OpenAI-compatible endpoints only; absent for the native Anthropic adapter
+}
 
-export async function complete({
+export const PROVIDERS: ProviderSpec[] = [
+  {
+    id: "anthropic",
+    label: "Anthropic",
+    models: ["claude-sonnet-5", "claude-opus-4-8", "claude-haiku-4-5"],
+    keyLink: "https://console.anthropic.com/account/keys"
+  },
+  {
+    id: "openai",
+    label: "OpenAI",
+    models: ["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5-mini"],
+    keyLink: "https://platform.openai.com/account/api-keys",
+    baseUrl: "https://api.openai.com/v1"
+  },
+  {
+    id: "mistral",
+    label: "Mistral",
+    models: ["mistral-small-latest", "mistral-medium-latest"],
+    keyLink: "https://console.mistral.ai/api-keys",
+    baseUrl: "https://api.mistral.ai/v1"
+  },
+  {
+    id: "qwen",
+    label: "Qwen",
+    models: ["qwen-flash", "qwen-plus"],
+    keyLink: "https://modelstudio.console.alibabacloud.com/?tab=playground#/api-key",
+    baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+  },
+  {
+    id: "deepseek",
+    label: "DeepSeek",
+    models: ["deepseek-chat"],
+    keyLink: "https://platform.deepseek.com/api_keys",
+    baseUrl: "https://api.deepseek.com/v1"
+  }
+];
+
+export const DEFAULT_MODEL = "claude-sonnet-5";
+
+export function providerOf(model: string): ProviderSpec {
+  const provider = PROVIDERS.find(candidate => candidate.models.includes(model));
+  if (!provider) throw new Error(`Unknown model: ${model}`);
+  return provider;
+}
+
+export const keyStorageFor = (model: string): string => `fmg-ai-kl-${providerOf(model).id}`;
+
+export async function complete(request: CompletionRequest): Promise<Completion> {
+  const provider = providerOf(request.model);
+  if (!provider.baseUrl) return completeAnthropic(request);
+  const { completeOpenAI } = await import("./providers-openai");
+  return completeOpenAI(provider.baseUrl, request);
+}
+
+async function completeAnthropic({
   key,
   model,
   system,


### PR DESCRIPTION
Great POC — the `run(code)` + `describe()` design is the right call, and it held up well in testing. This builds on the `ai-interface` branch with three additions aimed at the MVP's provider-parity goal:

## 1. OpenAI-compatible provider adapter

One translation layer (`providers-openai.ts`) covers **OpenAI, Mistral, Qwen (DashScope compatible mode) and DeepSeek** alongside the native Anthropic adapter: the Anthropic-shaped conversation is mapped to the `chat/completions` `tools`/`tool_calls` format and back, with cached-token usage read from both the OpenAI (`prompt_tokens_details.cached_tokens`) and DeepSeek (`prompt_cache_hit_tokens`) response dialects. The model selector groups models by provider and the key field swaps between per-provider slots (`fmg-ai-kl-${provider}`, same convention as the AI Text Generator, so existing keys are picked up).

Verified with a live key: `mistral-small-latest` handled a real multi-question session browser-direct (Mistral's API allows browser CORS) — composed queries including an all-pairs burg-distance search and a 50-row trade aggregation, ~$0.02 for the whole session at Mistral Small rates. Notes for the cheap-model question: GPT-5.6 Luna and DeepSeek V4 Flash both sit behind this same adapter; Mistral additionally has workspace-level hard spending caps and a free rate-limited tier.

## 2. Local LLM support (Ollama, llama.cpp, LM Studio)

A **Local** entry in the selector reveals two fields: base URL (defaults to `http://localhost:11434/v1`) and model name. No key required — the `Authorization` header is only sent when one is set, so unauthenticated local servers get no stray header while `llama.cpp --api-key` setups still work. Ollama users on a non-localhost origin need `OLLAMA_ORIGINS` set; the tooltip says so.

## 3. File downloads

The model kept apologizing that it cannot produce files, but its scripts already run in page scope where `downloadFile()` lives. One prompt rule turns "copy this table into a spreadsheet" into an actual CSV download.

## Tests

18 new unit tests on the translation layer (message/tool mapping both directions, malformed tool-JSON tolerance, usage dialects, provider routing, local dispatch, auth-header behavior); all existing agent tests untouched and green; `tsc` and Biome clean.