### PR TITLE
Add <ui-slider> web component

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,7 +1,7 @@
 name: Playwright Tests
 on:
   pull_request:
-    branches: [master]
+    branches: [master, "[0-9]*.[0-9]*.[0-9]*"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,7 +1,7 @@
 name: Unit Tests
 on:
   pull_request:
-    branches: [master]
+    branches: [master, "[0-9]*.[0-9]*.[0-9]*"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/package-lock.json
+++ b/package-lock.json
@@ -361,7 +361,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -410,7 +409,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -454,6 +452,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1194,7 +1193,6 @@
       "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.21.0"
       }
@@ -1264,7 +1262,6 @@
       "integrity": "sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.1.10",
         "@vitest/mocker": "4.1.10",
@@ -1779,7 +1776,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2037,7 +2033,6 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -2447,7 +2442,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2461,7 +2455,6 @@
       "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.60.0"
       },
@@ -2842,7 +2835,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2936,7 +2928,6 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.10",
         "@vitest/mocker": "4.1.10",

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -12,3 +12,4 @@ import "./dialog/dialog-helpers";
 import "./dialog/sorting";
 import "./fill-box";
 import "./slider-input";
+import "./ui-slider/ui-slider";

--- a/src/components/ui-slider/ui-slider.css
+++ b/src/components/ui-slider/ui-slider.css
@@ -1,0 +1,38 @@
+:host {
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+}
+
+input[type="range"] {
+  padding: 0;
+  height: 2px;
+  background: #d4d4d4;
+  position: relative;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  border-radius: 15%;
+  width: 1em;
+  height: 1em;
+  background: #e9e9e9;
+  border: 1px solid #9b9b9b;
+  cursor: pointer;
+}
+
+input[type="range"]::-moz-range-thumb {
+  appearance: none;
+  border-radius: 15%;
+  width: 1em;
+  height: 1em;
+  background: #e9e9e9;
+  border: 1px solid #9b9b9b;
+  cursor: pointer;
+}
+
+input[type="number"] {
+  width: 4.5em;
+}

--- a/src/components/ui-slider/ui-slider.ts
+++ b/src/components/ui-slider/ui-slider.ts
@@ -1,0 +1,74 @@
+// <ui-slider> — a range slider paired with a number input, kept in sync;
+// re-dispatches "input"/"change" as CustomEvents with {detail: {value}}
+
+import style from "./ui-slider.css?raw";
+
+const template = document.createElement("template");
+template.innerHTML = /* html */ `<style>${style}</style><slot></slot><input type="range" /><input type="number" />`;
+
+class UiSlider extends HTMLElement {
+  private built = false;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" }).appendChild(template.content.cloneNode(true));
+  }
+
+  connectedCallback() {
+    if (this.built) return;
+    this.built = true;
+
+    const { range, number } = this;
+    range.value = number.value = this.getAttribute("value") || "50";
+    range.min = number.min = this.getAttribute("min") || "0";
+    range.max = number.max = this.getAttribute("max") || "100";
+    range.step = number.step = this.getAttribute("step") || "1";
+
+    range.addEventListener("input", this.handleEvent.bind(this));
+    number.addEventListener("input", this.handleEvent.bind(this));
+    range.addEventListener("change", this.handleEvent.bind(this));
+    number.addEventListener("change", this.handleEvent.bind(this));
+  }
+
+  private get range(): HTMLInputElement {
+    return this.shadowRoot!.querySelector("input[type=range]")!;
+  }
+
+  private get number(): HTMLInputElement {
+    return this.shadowRoot!.querySelector("input[type=number]")!;
+  }
+
+  private handleEvent(e: Event) {
+    e.stopPropagation();
+
+    const value = (e.target as HTMLInputElement).value;
+    const isInvalid = Number.isNaN(Number(value));
+    if (isInvalid || value === "") return;
+
+    this.range.value = this.number.value = value;
+
+    this.dispatchEvent(
+      new CustomEvent(e.type, {
+        detail: { value },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  set value(value: string) {
+    this.range.value = this.number.value = value;
+  }
+
+  get value(): string {
+    return this.number.value;
+  }
+
+  get valueAsNumber(): number {
+    return this.number.valueAsNumber;
+  }
+}
+
+customElements.define("ui-slider", UiSlider);
+
+export type UiSliderElement = InstanceType<typeof UiSlider>;


### PR DESCRIPTION
Adds `<ui-slider>`, a range-slider-plus-number-input pair rebuilt as a shadow-DOM web component in the same style as `<ui-dialog>`. It owns the thumb/track styling that previously had to be injected globally via `<ui-dialog>`'s slotted-content stylesheet whenever a slider lived inside a dialog. Keeps the same public API as the existing `<slider-input>` (value/valueAsNumber getters/setters, composed input/change CustomEvents) so it's a drop-in replacement wherever a control is migrated to it.

This is one of three standalone form-control components (`<ui-checkbox>`, `<ui-slider>`, `<ui-input>`) split out for individual review:
- `<ui-checkbox>`: #1619
- `<ui-input>`: #1621

- `src/components/ui-slider/ui-slider.ts`
- `src/components/ui-slider/ui-slider.css`
- `src/components/index.ts`