### PR TITLE
Add <ui-input> web component

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,7 +1,7 @@
 name: Playwright Tests
 on:
   pull_request:
-    branches: [master]
+    branches: [master, "[0-9]*.[0-9]*.[0-9]*"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,7 +1,7 @@
 name: Unit Tests
 on:
   pull_request:
-    branches: [master]
+    branches: [master, "[0-9]*.[0-9]*.[0-9]*"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/package-lock.json
+++ b/package-lock.json
@@ -361,7 +361,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -410,7 +409,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -454,6 +452,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1194,7 +1193,6 @@
       "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.21.0"
       }
@@ -1264,7 +1262,6 @@
       "integrity": "sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.1.10",
         "@vitest/mocker": "4.1.10",
@@ -1779,7 +1776,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2037,7 +2033,6 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -2447,7 +2442,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2461,7 +2455,6 @@
       "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.60.0"
       },
@@ -2842,7 +2835,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2936,7 +2928,6 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.10",
         "@vitest/mocker": "4.1.10",

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -12,3 +12,4 @@ import "./dialog/dialog-helpers";
 import "./dialog/sorting";
 import "./fill-box";
 import "./slider-input";
+import "./ui-input/ui-input";

--- a/src/components/ui-input/ui-input.css
+++ b/src/components/ui-input/ui-input.css
@@ -1,0 +1,9 @@
+:host {
+  display: inline-block;
+}
+
+input {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: var(--sans-serif);
+}

--- a/src/components/ui-input/ui-input.ts
+++ b/src/components/ui-input/ui-input.ts
@@ -1,0 +1,48 @@
+// <ui-input> — a styled text input; re-dispatches "input"/"change" as CustomEvents with {detail: {value}}
+
+import style from "./ui-input.css?raw";
+
+const template = document.createElement("template");
+template.innerHTML = /* html */ `<style>${style}</style><input type="text" />`;
+
+class UiInput extends HTMLElement {
+  private built = false;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" }).appendChild(template.content.cloneNode(true));
+  }
+
+  connectedCallback() {
+    if (this.built) return;
+    this.built = true;
+
+    this.input.value = this.getAttribute("value") || "";
+    if (this.hasAttribute("placeholder")) this.input.placeholder = this.getAttribute("placeholder")!;
+
+    for (const type of ["input", "change"]) {
+      this.input.addEventListener(type, (e: Event) => {
+        e.stopPropagation();
+        this.dispatchEvent(
+          new CustomEvent(type, { detail: { value: this.input.value }, bubbles: true, composed: true })
+        );
+      });
+    }
+  }
+
+  private get input(): HTMLInputElement {
+    return this.shadowRoot!.querySelector("input")!;
+  }
+
+  get value(): string {
+    return this.input.value;
+  }
+
+  set value(value: string) {
+    this.input.value = value;
+  }
+}
+
+customElements.define("ui-input", UiInput);
+
+export type UiInputElement = InstanceType<typeof UiInput>;


### PR DESCRIPTION
Adds `<ui-input>`, a styled text input as a shadow-DOM web component, following the same pattern as `<ui-dialog>`. It owns its own styling instead of relying on ambient page CSS, and exposes a value getter/setter plus composed input/change CustomEvents so it's a drop-in replacement for a bare `<input type="text">` wherever a control is migrated to it.

This is one of three standalone form-control components (`<ui-checkbox>`, `<ui-slider>`, `<ui-input>`) split out for individual review:
- `<ui-checkbox>`: #1619
- `<ui-slider>`: #1620

- `src/components/ui-input/ui-input.ts`
- `src/components/ui-input/ui-input.css`
- `src/components/index.ts`