### PR TITLE
Style migration step 5: the data-size family moves off the DOM

### DIFF
--- a/public/modules/ui/style-presets.js
+++ b/public/modules/ui/style-presets.js
@@ -509,6 +509,18 @@ function addStylePreset() {
     if (presetStyle["#markers"]) presetStyle["#markers"].rescale = styles.markers.options.rescale;
     if (presetStyle["#statesHalo"])
       presetStyle["#statesHalo"]["data-width"] = styles.states.statesHalo.options.width;
+    if (presetStyle["#coordinates"]) {
+      presetStyle["#coordinates"]["data-size"] = styles.coordinates.options.fontSize;
+      presetStyle["#coordinates"]["font-size"] = styles.coordinates.options.fontSize;
+    }
+    if (presetStyle["#ruler"]) {
+      presetStyle["#ruler"]["data-size"] = styles.rulers.options.fontSize;
+      presetStyle["#ruler"]["font-size"] = styles.rulers.options.fontSize;
+    }
+    if (presetStyle["#legend"]) {
+      presetStyle["#legend"]["data-size"] = styles.legend.options.fontSize;
+      presetStyle["#legend"]["font-size"] = styles.legend.options.fontSize;
+    }
 
     for (const [group, groupStyle] of Object.entries(styles.labels.groups)) {
       addStoredLabelStyle(`#labels > #${group}`, stylesLegacy.labelGroupToLegacy(groupStyle));

--- a/public/modules/ui/style-presets.js
+++ b/public/modules/ui/style-presets.js
@@ -138,10 +138,6 @@ function projectPresetOptions() {
   setOrRemove(armies, "font-size", styles.military.options.fontSize);
   setOrRemove(armies, "box-size", styles.military.options.boxSize);
 
-  const coordinates = byId("coordinates");
-  setOrRemove(coordinates, "data-size", styles.coordinates.options.fontSize);
-  setOrRemove(coordinates, "font-size", styles.coordinates.options.fontSize);
-
   setOrRemove(byId("sea_island"), "auto-filter", styles.coastline.sea_island.options.autoFilter);
 
   const gridOverlay = byId("gridOverlay");

--- a/public/modules/ui/style-presets.js
+++ b/public/modules/ui/style-presets.js
@@ -176,10 +176,6 @@ function projectPresetOptions() {
   setOrRemove(markets, "font-size", styles.markets.options.fontSize);
   setOrRemove(markets, "data-icon", styles.markets.options.icon);
 
-  const ruler = byId("ruler");
-  setOrRemove(ruler, "data-size", styles.rulers.options.fontSize);
-  setOrRemove(ruler, "font-size", styles.rulers.options.fontSize);
-
   const scaleBar = byId("scaleBar");
   setOrRemove(scaleBar, "data-bar-size", styles.scaleBar.options.barSize);
   setOrRemove(scaleBar, "data-x", styles.scaleBar.options.x);
@@ -194,8 +190,6 @@ function projectPresetOptions() {
   writeAttrsById("scaleBarBack", styles.scaleBar.back.attrs);
 
   const legend = byId("legend");
-  setOrRemove(legend, "data-size", styles.legend.options.fontSize);
-  setOrRemove(legend, "font-size", styles.legend.options.fontSize);
   setOrRemove(legend, "data-x", styles.legend.options.x);
   setOrRemove(legend, "data-y", styles.legend.options.y);
   setOrRemove(legend, "data-columns", styles.legend.options.columns);

--- a/public/modules/ui/style-presets.js
+++ b/public/modules/ui/style-presets.js
@@ -161,18 +161,9 @@ function projectPresetOptions() {
   setOrRemove(oceanHeights, "curve", styles.heightmap.oceanHeights.options.curve);
   setOrRemove(oceanHeights, "data-render", Number(styles.heightmap.oceanHeights.options.render));
 
-  setOrRemove(byId("stateEmblems"), "data-size", styles.emblems.stateEmblems.options.size);
-  setOrRemove(byId("provinceEmblems"), "data-size", styles.emblems.provinceEmblems.options.size);
-  setOrRemove(byId("burgEmblems"), "data-size", styles.emblems.burgEmblems.options.size);
-
-  const goodsIcons = byId("goodsIcons");
-  setOrRemove(goodsIcons, "data-size", styles.goods.goodsIcons.options.size);
-  setOrRemove(goodsIcons, "data-circle", Number(styles.goods.goodsIcons.options.circle));
-
-  setOrRemove(byId("goodsBurgs"), "data-size", styles.goods.goodsBurgs.options.size);
+  setOrRemove(byId("goodsIcons"), "data-circle", Number(styles.goods.goodsIcons.options.circle));
 
   const markets = byId("markets");
-  setOrRemove(markets, "data-size", styles.markets.options.size);
   setOrRemove(markets, "font-size", styles.markets.options.fontSize);
   setOrRemove(markets, "data-icon", styles.markets.options.icon);
 
@@ -521,6 +512,15 @@ function addStylePreset() {
       presetStyle["#legend"]["data-size"] = styles.legend.options.fontSize;
       presetStyle["#legend"]["font-size"] = styles.legend.options.fontSize;
     }
+    if (presetStyle["#emblems > #stateEmblems"])
+      presetStyle["#emblems > #stateEmblems"]["data-size"] = styles.emblems.stateEmblems.options.size;
+    if (presetStyle["#emblems > #provinceEmblems"])
+      presetStyle["#emblems > #provinceEmblems"]["data-size"] = styles.emblems.provinceEmblems.options.size;
+    if (presetStyle["#emblems > #burgEmblems"])
+      presetStyle["#emblems > #burgEmblems"]["data-size"] = styles.emblems.burgEmblems.options.size;
+    if (presetStyle["#goodsIcons"]) presetStyle["#goodsIcons"]["data-size"] = styles.goods.goodsIcons.options.size;
+    if (presetStyle["#goodsBurgs"]) presetStyle["#goodsBurgs"]["data-size"] = styles.goods.goodsBurgs.options.size;
+    if (presetStyle["#markets"]) presetStyle["#markets"]["data-size"] = styles.markets.options.size;
 
     for (const [group, groupStyle] of Object.entries(styles.labels.groups)) {
       addStoredLabelStyle(`#labels > #${group}`, stylesLegacy.labelGroupToLegacy(groupStyle));

--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -356,7 +356,7 @@ function selectStyleElement() {
 
   if (styleElement === "coordinates") {
     styleSize.style.display = "block";
-    styleFontSize.value = el.attr("data-size");
+    styleFontSize.value = styles.coordinates.options.fontSize;
   }
 
   if (styleElement === "ruler") {
@@ -966,8 +966,13 @@ function changeFontSize(el, size) {
     return;
   }
 
-  const scaleSize = styleElementSelect.value === "coordinates" ? rn(size / scale ** 0.8, 2) : size;
-  el.attr("data-size", size).attr("font-size", scaleSize);
+  if (styleElementSelect.value === "coordinates") {
+    styles.coordinates.options.fontSize = size;
+    Layers.draw("coordinates");
+    return;
+  }
+
+  el.attr("data-size", size).attr("font-size", size);
 
   if (styleElementSelect.value === "legend") Layers.draw("legend");
   if (styleElementSelect.value === "ruler") Layers.draw("rulers");

--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -382,9 +382,9 @@ function selectStyleElement() {
     styleEmblems.style.display = "block";
     styleStrokeWidth.style.display = "block";
     styleStrokeWidthInput.value = el.attr("stroke-width") || 1;
-    emblemsStateSizeInput.value = d3.select("#emblems").select("#stateEmblems").attr("data-size") || 1;
-    emblemsProvinceSizeInput.value = d3.select("#emblems").select("#provinceEmblems").attr("data-size") || 1;
-    emblemsBurgSizeInput.value = d3.select("#emblems").select("#burgEmblems").attr("data-size") || 1;
+    emblemsStateSizeInput.value = styles.emblems.stateEmblems.options.size;
+    emblemsProvinceSizeInput.value = styles.emblems.provinceEmblems.options.size;
+    emblemsBurgSizeInput.value = styles.emblems.burgEmblems.options.size;
     showAllEmblems.checked = options.emblems.showAll;
   }
 
@@ -393,7 +393,7 @@ function selectStyleElement() {
     styleStrokeWidthInput.value = el.attr("stroke-width") || "";
     styleGoods.style.display = "block";
     styleGoodsCircle.checked = +el.attr("data-circle");
-    styleGoodsSize.value = el.attr("data-size") || 6;
+    styleGoodsSize.value = styles.goods.goodsIcons.options.size;
   }
 
   if (styleElement === "goodsBurgs") {
@@ -402,7 +402,7 @@ function selectStyleElement() {
     styleStroke.style.display = "block";
     styleStrokeInput.value = styleStrokeOutput.value = el.attr("stroke") || "#41414f";
     styleGoodsBurgs.style.display = "block";
-    styleGoodsBurgsSize.value = el.attr("data-size") || 3;
+    styleGoodsBurgsSize.value = styles.goods.goodsBurgs.options.size;
   }
 
   if (styleElement === "markets") {
@@ -410,7 +410,7 @@ function selectStyleElement() {
     styleStrokeWidthInput.value = el.attr("stroke-width") || "0.5";
     styleMarketsLayer.style.display = "block";
     styleMarketsLayerFillOpacity.value = el.attr("fill-opacity") || "0";
-    styleMarketsSize.value = el.attr("data-size") || 3;
+    styleMarketsSize.value = styles.markets.options.size;
     styleMarketsIconSize.value = el.attr("font-size") || 5;
     styleMarketsIcon.innerHTML = el.attr("data-icon") || "⚖️";
   }
@@ -1042,17 +1042,17 @@ styleArmiesSize.addEventListener("input", e => {
 });
 
 emblemsStateSizeInput.addEventListener("change", e => {
-  d3.select("#emblems").select("#stateEmblems").attr("data-size", e.target.value);
+  styles.emblems.stateEmblems.options.size = +e.target.value || 1;
   Layers.draw("emblems");
 });
 
 emblemsProvinceSizeInput.addEventListener("change", e => {
-  d3.select("#emblems").select("#provinceEmblems").attr("data-size", e.target.value);
+  styles.emblems.provinceEmblems.options.size = +e.target.value || 1;
   Layers.draw("emblems");
 });
 
 emblemsBurgSizeInput.addEventListener("change", e => {
-  d3.select("#emblems").select("#burgEmblems").attr("data-size", e.target.value);
+  styles.emblems.burgEmblems.options.size = +e.target.value || 1;
   Layers.draw("emblems");
 });
 
@@ -1067,12 +1067,12 @@ styleGoodsCircle.addEventListener("change", function () {
 });
 
 styleGoodsSize.addEventListener("change", function () {
-  d3.select("#goods").select("#goodsIcons").attr("data-size", this.value);
+  styles.goods.goodsIcons.options.size = +this.value || 6;
   Layers.draw("goods");
 });
 
 styleGoodsBurgsSize.addEventListener("change", function () {
-  d3.select("#goods").select("#goodsBurgs").attr("data-size", this.value);
+  styles.goods.goodsBurgs.options.size = +this.value || 3;
   Layers.draw("goods");
 });
 
@@ -1081,7 +1081,7 @@ styleMarketsLayerFillOpacity.addEventListener("input", e => {
 });
 
 styleMarketsSize.addEventListener("change", function () {
-  d3.select("#markets").attr("data-size", this.value);
+  styles.markets.options.size = +this.value || 3;
   Layers.draw("markets");
 });
 

--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -334,7 +334,7 @@ function selectStyleElement() {
 
     styleFont.style.display = "block";
     styleSelectFont.value = el.attr("font-family");
-    styleFontSize.value = el.attr("data-size");
+    styleFontSize.value = styles.legend.options.fontSize;
   }
 
   if (styleElement === "ocean") {
@@ -369,7 +369,7 @@ function selectStyleElement() {
     styleStrokeLinecapInput.value = el.attr("stroke-linecap") || "inherit";
 
     styleSize.style.display = "block";
-    styleFontSize.value = el.attr("data-size") || 20;
+    styleFontSize.value = styles.rulers.options.fontSize;
   }
 
   if (styleElement === "armies") {
@@ -971,11 +971,18 @@ function changeFontSize(el, size) {
     Layers.draw("coordinates");
     return;
   }
+  if (styleElementSelect.value === "legend") {
+    styles.legend.options.fontSize = size;
+    Layers.draw("legend");
+    return;
+  }
+  if (styleElementSelect.value === "ruler") {
+    styles.rulers.options.fontSize = size;
+    Layers.draw("rulers");
+    return;
+  }
 
   el.attr("data-size", size).attr("font-size", size);
-
-  if (styleElementSelect.value === "legend") Layers.draw("legend");
-  if (styleElementSelect.value === "ruler") Layers.draw("rulers");
 }
 
 styleFontShiftX.addEventListener("input", e => {

--- a/src/generators/styles-legacy.dom.test.ts
+++ b/src/generators/styles-legacy.dom.test.ts
@@ -87,3 +87,17 @@ test("save sync lets an old map's attrs win when present", () => {
   expect(styles.markers.options.rescale).toBe(1);
   expect(styles.states.statesHalo.options.width).toBe(13);
 });
+
+test("save sync keeps the store's coordinates size when data-size is absent, even beside a derived font-size", () => {
+  document.body.innerHTML = `<svg id="map"><g id="coordinates" font-size="6.6"></g></svg>`;
+  styles.coordinates.options.fontSize = 20;
+  syncStylesFromMap();
+  expect(styles.coordinates.options.fontSize).toBe(20);
+});
+
+test("save sync lets an old map's coordinates data-size win over the store", () => {
+  document.body.innerHTML = `<svg id="map"><g id="coordinates" data-size="14"></g></svg>`;
+  styles.coordinates.options.fontSize = 20;
+  syncStylesFromMap();
+  expect(styles.coordinates.options.fontSize).toBe(14);
+});

--- a/src/generators/styles-legacy.dom.test.ts
+++ b/src/generators/styles-legacy.dom.test.ts
@@ -116,6 +116,40 @@ test("save sync lets an old map's ruler and legend data-size win", () => {
   expect(styles.legend.options.fontSize).toBe(11);
 });
 
+test("save sync keeps store emblem, goods and market sizes when data-size is absent", () => {
+  document.body.innerHTML = `<svg id="map"><g id="emblems"><g id="stateEmblems"></g><g id="provinceEmblems"></g><g id="burgEmblems"></g></g>
+    <g id="goods"><g id="goodsIcons" data-circle="1"></g><g id="goodsBurgs"></g></g>
+    <g id="markets" font-size="5" data-icon="X"></g></svg>`;
+  styles.emblems.stateEmblems.options.size = 1.5;
+  styles.goods.goodsIcons.options.size = 9;
+  styles.goods.goodsIcons.options.circle = false;
+  styles.goods.goodsBurgs.options.size = 7;
+  styles.markets.options.size = 6;
+  syncStylesFromMap();
+  expect(styles.emblems.stateEmblems.options.size).toBe(1.5);
+  expect(styles.goods.goodsIcons.options.size).toBe(9);
+  expect(styles.goods.goodsBurgs.options.size).toBe(7);
+  expect(styles.markets.options.size).toBe(6);
+  // per-key: the siblings still harvest from their attrs
+  expect(styles.goods.goodsIcons.options.circle).toBe(true);
+  expect(styles.markets.options.fontSize).toBe(5);
+});
+
+test("save sync lets an old map's emblem, goods and market data-size win", () => {
+  document.body.innerHTML = `<svg id="map"><g id="emblems"><g id="stateEmblems" data-size="2"></g><g id="provinceEmblems" data-size="2"></g><g id="burgEmblems" data-size="2"></g></g>
+    <g id="goods"><g id="goodsIcons" data-size="4" data-circle="1"></g><g id="goodsBurgs" data-size="5"></g></g>
+    <g id="markets" data-size="8" font-size="5" data-icon="X"></g></svg>`;
+  styles.emblems.stateEmblems.options.size = 1;
+  styles.goods.goodsIcons.options.size = 9;
+  styles.goods.goodsBurgs.options.size = 7;
+  styles.markets.options.size = 6;
+  syncStylesFromMap();
+  expect(styles.emblems.stateEmblems.options.size).toBe(2);
+  expect(styles.goods.goodsIcons.options.size).toBe(4);
+  expect(styles.goods.goodsBurgs.options.size).toBe(5);
+  expect(styles.markets.options.size).toBe(8);
+});
+
 test("save sync lets an old map's coordinates data-size win over the store", () => {
   document.body.innerHTML = `<svg id="map"><g id="coordinates" data-size="14"></g></svg>`;
   styles.coordinates.options.fontSize = 20;

--- a/src/generators/styles-legacy.dom.test.ts
+++ b/src/generators/styles-legacy.dom.test.ts
@@ -95,6 +95,27 @@ test("save sync keeps the store's coordinates size when data-size is absent, eve
   expect(styles.coordinates.options.fontSize).toBe(20);
 });
 
+test("save sync keeps store ruler and legend sizes when data-size is absent", () => {
+  document.body.innerHTML = `<svg id="map"><g id="ruler"></g><g id="legend" font-size="13" font-family="Almendra SC" data-x="88" data-columns="8"></g></svg>`;
+  styles.rulers.options.fontSize = 26;
+  styles.legend.options.fontSize = 17;
+  styles.legend.options.x = 50;
+  syncStylesFromMap();
+  expect(styles.rulers.options.fontSize).toBe(26);
+  expect(styles.legend.options.fontSize).toBe(17);
+  // legend geometry is not in this family: the data-x attr stays authoritative
+  expect(styles.legend.options.x).toBe(88);
+});
+
+test("save sync lets an old map's ruler and legend data-size win", () => {
+  document.body.innerHTML = `<svg id="map"><g id="ruler" data-size="30" font-size="30"></g><g id="legend" data-size="11" font-size="11" font-family="Almendra SC"></g></svg>`;
+  styles.rulers.options.fontSize = 26;
+  styles.legend.options.fontSize = 17;
+  syncStylesFromMap();
+  expect(styles.rulers.options.fontSize).toBe(30);
+  expect(styles.legend.options.fontSize).toBe(11);
+});
+
 test("save sync lets an old map's coordinates data-size win over the store", () => {
   document.body.innerHTML = `<svg id="map"><g id="coordinates" data-size="14"></g></svg>`;
   styles.coordinates.options.fontSize = 20;

--- a/src/generators/styles-legacy.ts
+++ b/src/generators/styles-legacy.ts
@@ -383,6 +383,11 @@ export function syncStylesFromMap(): void {
   // gated on data-size alone: #coordinates' font-size is the zoom-derived render value, never the base
   if (!document.getElementById("coordinates")?.hasAttribute("data-size"))
     harvested.coordinates.options = structuredClone(styles.coordinates.options);
+  if (!document.getElementById("ruler")?.hasAttribute("data-size"))
+    harvested.rulers.options = structuredClone(styles.rulers.options);
+  // per-key: legend geometry (x/y/columns) stays attr-authoritative until its own family
+  if (!document.getElementById("legend")?.hasAttribute("data-size"))
+    harvested.legend.options.fontSize = styles.legend.options.fontSize;
   Styles.set(harvested);
 }
 

--- a/src/generators/styles-legacy.ts
+++ b/src/generators/styles-legacy.ts
@@ -380,6 +380,9 @@ export function syncStylesFromMap(): void {
     harvested.markers.options = structuredClone(styles.markers.options);
   if (!document.getElementById("statesHalo")?.hasAttribute("data-width"))
     harvested.states.statesHalo.options = structuredClone(styles.states.statesHalo.options);
+  // gated on data-size alone: #coordinates' font-size is the zoom-derived render value, never the base
+  if (!document.getElementById("coordinates")?.hasAttribute("data-size"))
+    harvested.coordinates.options = structuredClone(styles.coordinates.options);
   Styles.set(harvested);
 }
 

--- a/src/generators/styles-legacy.ts
+++ b/src/generators/styles-legacy.ts
@@ -357,6 +357,10 @@ export function stylesFromMap(root: ParentNode = document): Styles {
   for (const el of root.querySelectorAll("#anchors > g")) {
     if (el.id) bags[`#anchors > g#${el.id}`] = harvestBag(el, BURG_ATTRS, BURG_SCHEMA_ATTRS);
   }
+  for (const name of ["stateEmblems", "provinceEmblems", "burgEmblems"]) {
+    const el = root.querySelector(`#emblems > #${name}`);
+    if (el) bags[`#emblems > #${name}`] = harvestBag(el, ["data-size"], []);
+  }
 
   return presetFromLegacy(bags, { onUnknown: "skip" });
 }
@@ -388,6 +392,17 @@ export function syncStylesFromMap(): void {
   // per-key: legend geometry (x/y/columns) stays attr-authoritative until its own family
   if (!document.getElementById("legend")?.hasAttribute("data-size"))
     harvested.legend.options.fontSize = styles.legend.options.fontSize;
+  for (const key of ["stateEmblems", "provinceEmblems", "burgEmblems"] as const) {
+    if (!document.getElementById(key)?.hasAttribute("data-size"))
+      harvested.emblems[key].options = structuredClone(styles.emblems[key].options);
+  }
+  // per-key: goodsIcons' circle and markets' fontSize/icon are still attr-authoritative
+  if (!document.getElementById("goodsIcons")?.hasAttribute("data-size"))
+    harvested.goods.goodsIcons.options.size = styles.goods.goodsIcons.options.size;
+  if (!document.getElementById("goodsBurgs")?.hasAttribute("data-size"))
+    harvested.goods.goodsBurgs.options = structuredClone(styles.goods.goodsBurgs.options);
+  if (!document.getElementById("markets")?.hasAttribute("data-size"))
+    harvested.markets.options.size = styles.markets.options.size;
   Styles.set(harvested);
 }
 

--- a/src/renderers/draw-coordinates.dom.test.ts
+++ b/src/renderers/draw-coordinates.dom.test.ts
@@ -1,0 +1,25 @@
+// Browser-mode test (vitest.browser.config.ts): the coordinates renderer takes its base label
+// size from the store, not the retired data-size attribute.
+import { beforeEach, expect, test } from "vitest";
+import "@/generators/styles";
+import { drawCoordinates } from "./draw-coordinates";
+
+beforeEach(() => {
+  document.body.innerHTML = `<svg id="map" width="800" height="600">
+      <g id="viewbox"><g id="coordinates"></g></g>
+    </svg>`;
+  globalThis.scale = 4;
+  globalThis.graphWidth = 800;
+  globalThis.graphHeight = 600;
+  globalThis.mapCoordinates = { lonT: 100, lonW: -50, lonE: 50, latN: 40, latS: -40, latT: 80 };
+});
+
+test("drawCoordinates sizes labels from the store, ignoring data-size", () => {
+  styles.coordinates.options.fontSize = 20;
+  document.getElementById("coordinates")!.setAttribute("data-size", "99");
+
+  drawCoordinates();
+
+  const rendered = Number(document.getElementById("coordinates")!.getAttribute("font-size"));
+  expect(rendered).toBeCloseTo(20 / 4 ** 0.8, 2);
+});

--- a/src/renderers/draw-coordinates.ts
+++ b/src/renderers/draw-coordinates.ts
@@ -11,7 +11,7 @@ export function drawCoordinates(): void {
   const goal = lonT / scale / 10;
   const step = STEPS.reduce((prev, curr) => (Math.abs(curr - goal) < Math.abs(prev - goal) ? curr : prev));
 
-  const desiredSize = +coordinates.attr("data-size");
+  const desiredSize = styles.coordinates.options.fontSize;
   coordinates.attr("font-size", Math.max(rn(desiredSize / scale ** 0.8, 2), 0.1));
 
   const graticule = geoGraticule()

--- a/src/renderers/draw-emblems.test.ts
+++ b/src/renderers/draw-emblems.test.ts
@@ -48,6 +48,7 @@ vi.mock("d3", async importOriginal => {
   };
 });
 
+import "@/generators/styles";
 import { drawEmblems, redrawEmblem, removeEmblem, renderEmblemDefinitions } from "./draw-emblems";
 
 function renderViewport(): void {

--- a/src/renderers/draw-emblems.ts
+++ b/src/renderers/draw-emblems.ts
@@ -65,7 +65,7 @@ function getEmblemSize(type: EmblemType, count: number): number {
   const { extent, min, max, expected, countDivisor, deficitDivisor } = SIZING[type];
   const startSize = minmax((graphHeight + graphWidth) / extent, min, max);
   const countMod = 1 + count / countDivisor - (expected - count) / deficitDivisor;
-  const sizeMod = Number(ensureEl(GROUPS[type]).getAttribute("data-size")) || 1;
+  const sizeMod = styles.emblems[`${type}Emblems`].options.size;
   return rn((startSize / countMod) * sizeMod);
 }
 

--- a/src/renderers/draw-goods.ts
+++ b/src/renderers/draw-goods.ts
@@ -12,7 +12,6 @@ const PLATE_PAD_X = 1;
 const PLATE_PAD_Y = 0.6;
 const PLATE_RX = 1;
 const PLATE_FILL = "#f5f5f5";
-const DEFAULT_SIZE = 6;
 
 export function drawGoods() {
   TIME && console.time("drawGoods");
@@ -68,7 +67,7 @@ function buildGoodsIconsContent(displayedGoods: Set<number>): string {
 
   const iconsGroup = select("#goods").select("#goodsIcons");
   const drawCircle = +iconsGroup.attr("data-circle");
-  const iconSize = +iconsGroup.attr("data-size") || DEFAULT_SIZE;
+  const iconSize = styles.goods.goodsIcons.options.size;
   const half = iconSize / 2;
   let html = "";
   for (const cellId of pack.cells.i) {
@@ -90,7 +89,7 @@ function buildGoodsBurgsContent(displayedGoods: Set<number>): string {
   if (!displayedGoods.size) return "";
 
   // plate icon size is user-defined; the rest of the geometry and font scale with it
-  const plateIcon = +select("#goods").select("#goodsBurgs").attr("data-size") || PLATE_ICON;
+  const plateIcon = styles.goods.goodsBurgs.options.size;
   const scale = plateIcon / PLATE_ICON;
   const plateFont = PLATE_FONT * scale;
   const plateGap = PLATE_GAP * scale;

--- a/src/renderers/draw-legend.test.ts
+++ b/src/renderers/draw-legend.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it } from "vitest";
+import "@/generators/styles";
 import { drawLegend, redrawLegend } from "./draw-legend";
 
 beforeEach(() => {
@@ -27,6 +28,13 @@ const items = [
 ];
 
 describe("drawLegend", () => {
+  it("sizes the legend from the store and stamps the group font-size", () => {
+    styles.legend.options.fontSize = 20;
+    drawLegend("States", items);
+    expect(document.getElementById("legend")!.getAttribute("font-size")).toBe("20");
+    styles.legend.options.fontSize = 13;
+  });
+
   it("takes the styling from the style inputs when the legend is drawn anew", () => {
     drawLegend("States", items);
 

--- a/src/renderers/draw-legend.ts
+++ b/src/renderers/draw-legend.ts
@@ -20,10 +20,11 @@ export function drawLegend(name: string, data: LegendItem[]): void {
   const itemsInCol = Number(boxStyle("data-columns", "styleLegendColItems"));
   const backColor = boxStyle("fill", "styleLegendBack");
   const opacity = Number(boxStyle("fill-opacity", "styleLegendOpacity"));
-  const fontSize = Number(legend.attr("font-size"));
+  const fontSize = styles.legend.options.fontSize;
 
   legend.selectAll("*").remove(); // fully redraw every time
   legend.attr("data", data.join("|")); // store data to redraw on style change
+  legend.attr("font-size", fontSize); // the drawn texts size by inheritance
 
   const lineHeight = Math.round(fontSize * 1.7);
   const colorBoxSize = Math.round(fontSize / 1.7);

--- a/src/renderers/draw-markets.ts
+++ b/src/renderers/draw-markets.ts
@@ -9,7 +9,6 @@ export function drawMarkets() {
   TIME && console.timeEnd("drawMarkets");
 }
 
-const MARKET_RADIUS = 3;
 const MARKET_FONT = 5;
 const MARKET_ICON = "⚖️";
 
@@ -19,7 +18,7 @@ function buildMarketsContent(): string {
   const isolines = getIsolines(pack, getType, { polygons: true });
 
   // marker circle size, emoji size and emoji icon are independently user-configurable
-  const baseRadius = +select("#markets").attr("data-size") || MARKET_RADIUS;
+  const baseRadius = styles.markets.options.size;
   const baseFont = +select("#markets").attr("font-size") || MARKET_FONT;
   const icon = select("#markets").attr("data-icon") || MARKET_ICON;
 

--- a/src/renderers/draw-measurers.ts
+++ b/src/renderers/draw-measurers.ts
@@ -9,7 +9,6 @@ const closedCurveGen = line<Point>().curve(curveCatmullRomClosed.alpha(0.5));
 
 // style defaults, overridable via attributes on the #ruler group (Style tab)
 export const DEFAULT_STROKE_WIDTH = 2;
-export const DEFAULT_FONT_SIZE = 20;
 export const DEFAULT_DASHARRAY = "10";
 
 type MeasurerStyle = { strokeWidth: number; dasharray: string; fontSize: number };
@@ -17,7 +16,7 @@ type MeasurerStyle = { strokeWidth: number; dasharray: string; fontSize: number 
 function getMeasurerStyle(): MeasurerStyle {
   const ruler = document.getElementById("ruler");
   const strokeWidth = Number(ruler?.getAttribute("stroke-width")) || DEFAULT_STROKE_WIDTH;
-  const fontSize = Number(ruler?.getAttribute("font-size")) || DEFAULT_FONT_SIZE;
+  const fontSize = styles.rulers.options.fontSize;
   // an empty attribute means "no dashes"; only a missing one falls back to the default
   const dasharray = ruler?.getAttribute("stroke-dasharray") ?? DEFAULT_DASHARRAY;
   return { strokeWidth, dasharray, fontSize };

--- a/src/services/io/auto-update.ts
+++ b/src/services/io/auto-update.ts
@@ -1875,4 +1875,7 @@ export async function resolveVersionConflicts(mapVersion: string, data: string[]
   document.getElementById("markers")?.removeAttribute("rescale");
   document.getElementById("statesHalo")?.removeAttribute("data-width");
   document.getElementById("coordinates")?.removeAttribute("data-size");
+  document.getElementById("ruler")?.removeAttribute("data-size");
+  document.getElementById("ruler")?.removeAttribute("font-size");
+  document.getElementById("legend")?.removeAttribute("data-size");
 }

--- a/src/services/io/auto-update.ts
+++ b/src/services/io/auto-update.ts
@@ -1878,4 +1878,7 @@ export async function resolveVersionConflicts(mapVersion: string, data: string[]
   document.getElementById("ruler")?.removeAttribute("data-size");
   document.getElementById("ruler")?.removeAttribute("font-size");
   document.getElementById("legend")?.removeAttribute("data-size");
+  for (const id of ["stateEmblems", "provinceEmblems", "burgEmblems", "goodsIcons", "goodsBurgs", "markets"]) {
+    document.getElementById(id)?.removeAttribute("data-size");
+  }
 }

--- a/src/services/io/auto-update.ts
+++ b/src/services/io/auto-update.ts
@@ -1874,4 +1874,5 @@ export async function resolveVersionConflicts(mapVersion: string, data: string[]
   // authority rule in syncStylesFromMap would let them clobber the record's values forever
   document.getElementById("markers")?.removeAttribute("rescale");
   document.getElementById("statesHalo")?.removeAttribute("data-width");
+  document.getElementById("coordinates")?.removeAttribute("data-size");
 }

--- a/tests/e2e/style-editor-events.spec.ts
+++ b/tests/e2e/style-editor-events.spec.ts
@@ -13,7 +13,7 @@ const waitForMap = (page: Page) =>
 
 const rn = (v: number, d = 0): number => Math.round(v * 10 ** d) / 10 ** d;
 
-async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates"): Promise<void> {
+async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates" | "ruler" | "legend"): Promise<void> {
   await page.evaluate(() => (window as any).showOptions());
   await page.locator("#styleTab").click();
   await page.locator("#styleElementSelect").selectOption(element);
@@ -152,5 +152,38 @@ test.describe("style editor events drive the store", () => {
 
     // (4) the retired attribute is gone from the element
     expect(await page.locator("#coordinates").getAttribute("data-size")).toBeNull();
+  });
+
+  test("ruler size input writes the store and sizes drawn rulers", async ({ page }) => {
+    await page.evaluate(() => {
+      (window as any).Measurers.createDefaultRuler();
+      (window as any).Layers.show("rulers");
+    });
+    await openStyleElement(page, "ruler");
+
+    await page.locator("#styleFontSize").fill("26");
+    await page.locator("#styleFontSize").dispatchEvent("change");
+
+    const stored = await page.evaluate(() => (window as any).styles.rulers.options.fontSize);
+    expect(stored).toBe(26);
+    expect(typeof stored).toBe("number");
+
+    await expect(page.locator("#ruler > .ruler").first()).toHaveAttribute("font-size", "26");
+
+    expect(await page.locator("#ruler").getAttribute("data-size")).toBeNull();
+    expect(await page.locator("#ruler").getAttribute("font-size")).toBeNull();
+  });
+
+  test("legend size input writes the store", async ({ page }) => {
+    await openStyleElement(page, "legend");
+
+    await page.locator("#styleFontSize").fill("17");
+    await page.locator("#styleFontSize").dispatchEvent("change");
+
+    const stored = await page.evaluate(() => (window as any).styles.legend.options.fontSize);
+    expect(stored).toBe(17);
+    expect(typeof stored).toBe("number");
+
+    expect(await page.locator("#legend").getAttribute("data-size")).toBeNull();
   });
 });

--- a/tests/e2e/style-editor-events.spec.ts
+++ b/tests/e2e/style-editor-events.spec.ts
@@ -13,7 +13,7 @@ const waitForMap = (page: Page) =>
 
 const rn = (v: number, d = 0): number => Math.round(v * 10 ** d) / 10 ** d;
 
-async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates" | "ruler" | "legend"): Promise<void> {
+async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates" | "ruler" | "legend" | "emblems" | "goodsIcons" | "goodsBurgs" | "markets"): Promise<void> {
   await page.evaluate(() => (window as any).showOptions());
   await page.locator("#styleTab").click();
   await page.locator("#styleElementSelect").selectOption(element);
@@ -185,5 +185,66 @@ test.describe("style editor events drive the store", () => {
     expect(typeof stored).toBe("number");
 
     expect(await page.locator("#legend").getAttribute("data-size")).toBeNull();
+  });
+
+  test("emblem size inputs write the store per group", async ({ page }) => {
+    await openStyleElement(page, "emblems");
+
+    for (const [input, value] of [
+      ["#emblemsStateSizeInput", "1.5"],
+      ["#emblemsProvinceSizeInput", "0.5"],
+      ["#emblemsBurgSizeInput", "2"]
+    ] as const) {
+      await page.locator(`${input} input[type=number]`).fill(value);
+      await page.locator(input).dispatchEvent("change");
+    }
+
+    const stored = await page.evaluate(() => ({
+      state: (window as any).styles.emblems.stateEmblems.options.size,
+      province: (window as any).styles.emblems.provinceEmblems.options.size,
+      burg: (window as any).styles.emblems.burgEmblems.options.size
+    }));
+    expect(stored).toEqual({ state: 1.5, province: 0.5, burg: 2 });
+
+    for (const id of ["#stateEmblems", "#provinceEmblems", "#burgEmblems"]) {
+      expect(await page.locator(id).getAttribute("data-size")).toBeNull();
+    }
+  });
+
+  test("goods size inputs write the store and size the drawn icons", async ({ page }) => {
+    await page.evaluate(() => (window as any).Layers.show("goods"));
+    await openStyleElement(page, "goodsIcons");
+
+    await page.locator("#styleGoodsSize input[type=number]").fill("9");
+    await page.locator("#styleGoodsSize").dispatchEvent("change");
+
+    await openStyleElement(page, "goodsBurgs");
+    await page.locator("#styleGoodsBurgsSize input[type=number]").fill("7");
+    await page.locator("#styleGoodsBurgsSize").dispatchEvent("change");
+
+    const stored = await page.evaluate(() => ({
+      icons: (window as any).styles.goods.goodsIcons.options.size,
+      burgs: (window as any).styles.goods.goodsBurgs.options.size
+    }));
+    expect(stored).toEqual({ icons: 9, burgs: 7 });
+
+    expect(await page.locator("#goodsIcons").getAttribute("data-size")).toBeNull();
+    expect(await page.locator("#goodsBurgs").getAttribute("data-size")).toBeNull();
+  });
+
+  test("markets size input writes the store and sizes the drawn plates", async ({ page }) => {
+    await page.evaluate(() => (window as any).Layers.show("markets"));
+    await openStyleElement(page, "markets");
+
+    await page.locator("#styleMarketsSize input[type=number]").fill("6");
+    await page.locator("#styleMarketsSize").dispatchEvent("change");
+
+    const stored = await page.evaluate(() => (window as any).styles.markets.options.size);
+    expect(stored).toBe(6);
+    expect(typeof stored).toBe("number");
+
+    // fontSize and icon are not in this family: their attrs must survive on the element
+    expect(await page.locator("#markets").getAttribute("data-size")).toBeNull();
+    expect(await page.locator("#markets").getAttribute("font-size")).not.toBeNull();
   });
 });

--- a/tests/e2e/style-editor-events.spec.ts
+++ b/tests/e2e/style-editor-events.spec.ts
@@ -13,7 +13,7 @@ const waitForMap = (page: Page) =>
 
 const rn = (v: number, d = 0): number => Math.round(v * 10 ** d) / 10 ** d;
 
-async function openStyleElement(page: Page, element: "markers" | "regions"): Promise<void> {
+async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates"): Promise<void> {
   await page.evaluate(() => (window as any).showOptions());
   await page.locator("#styleTab").click();
   await page.locator("#styleElementSelect").selectOption(element);
@@ -128,5 +128,29 @@ test.describe("style editor events drive the store", () => {
 
     // (4) the retired attribute never lands on the element
     expect(await page.locator("#statesHalo").getAttribute("data-width")).toBeNull();
+  });
+
+  test("coordinates size input writes the store and the renderer derives from it", async ({ page }) => {
+    await page.evaluate(() => (window as any).Layers.show("coordinates"));
+    await openStyleElement(page, "coordinates");
+
+    await page.locator("#styleFontSize").fill("24");
+    await page.locator("#styleFontSize").dispatchEvent("change");
+
+    // (2) typed store value
+    const stored = await page.evaluate(() => (window as any).styles.coordinates.options.fontSize);
+    expect(stored).toBe(24);
+    expect(typeof stored).toBe("number");
+
+    // (1)+(3) rendered size re-derived from the store base on redraw at a changed zoom
+    await page.evaluate(() => (window as any).setMapZoom(4));
+    await page.waitForTimeout(50);
+    await page.evaluate(() => (window as any).Layers.draw("coordinates"));
+    const scale = await currentScale(page);
+    const fontSize = await page.locator("#coordinates").getAttribute("font-size");
+    expect(parseFloat(fontSize!)).toBeCloseTo(rn(24 / scale ** 0.8, 2), 1);
+
+    // (4) the retired attribute is gone from the element
+    expect(await page.locator("#coordinates").getAttribute("data-size")).toBeNull();
   });
 });

--- a/tests/e2e/style-persistence.spec.ts
+++ b/tests/e2e/style-persistence.spec.ts
@@ -205,7 +205,11 @@ test.describe("style persistence round trips", () => {
       .replace('<g id="statesHalo"', '<g id="statesHalo" data-width="7"')
       .replace('<g id="coordinates"', '<g id="coordinates" data-size="55"')
       .replace('<g id="ruler"', '<g id="ruler" data-size="44" font-size="44"')
-      .replace('<g id="legend"', '<g id="legend" data-size="33"');
+      .replace('<g id="legend"', '<g id="legend" data-size="33"')
+      .replace('<g id="stateEmblems"', '<g id="stateEmblems" data-size="4"')
+      .replace('<g id="goodsIcons"', '<g id="goodsIcons" data-size="66"')
+      .replace('<g id="goodsBurgs"', '<g id="goodsBurgs" data-size="66"')
+      .replace('<g id="markets"', '<g id="markets" data-size="66"');
     const staleBuffer = Buffer.from(lines.join("\r\n"), "utf8");
 
     await reload(page, staleBuffer, "style-persistence-step4-era-reloaded");
@@ -216,6 +220,10 @@ test.describe("style persistence round trips", () => {
       coordinatesSizeAttr: document.getElementById("coordinates")?.getAttribute("data-size"),
       rulerSizeAttr: document.getElementById("ruler")?.getAttribute("data-size"),
       legendSizeAttr: document.getElementById("legend")?.getAttribute("data-size"),
+      familySizeAttrs: ["stateEmblems", "goodsIcons", "goodsBurgs", "markets"].map(id =>
+        document.getElementById(id)?.getAttribute("data-size")
+      ),
+      marketsSize: styles.markets.options.size,
       rescale: styles.markers.options.rescale,
       haloWidth: styles.states.statesHalo.options.width,
       coordinatesSize: styles.coordinates.options.fontSize
@@ -227,6 +235,8 @@ test.describe("style persistence round trips", () => {
     expect(afterLoad.coordinatesSizeAttr).toBeNull();
     expect(afterLoad.rulerSizeAttr).toBeNull();
     expect(afterLoad.legendSizeAttr).toBeNull();
+    expect(afterLoad.familySizeAttrs).toEqual([null, null, null, null]);
+    expect(afterLoad.marketsSize).toBe(3);
     expect(afterLoad.rescale).toBe(1);
     expect(afterLoad.haloWidth).toBe(10);
     expect(afterLoad.coordinatesSize).toBe(12);

--- a/tests/e2e/style-persistence.spec.ts
+++ b/tests/e2e/style-persistence.spec.ts
@@ -202,7 +202,8 @@ test.describe("style persistence round trips", () => {
     const lines = buffer.toString("utf8").split("\r\n");
     lines[5] = lines[5]
       .replace('<g id="markers"', '<g id="markers" rescale="0"')
-      .replace('<g id="statesHalo"', '<g id="statesHalo" data-width="7"');
+      .replace('<g id="statesHalo"', '<g id="statesHalo" data-width="7"')
+      .replace('<g id="coordinates"', '<g id="coordinates" data-size="55"');
     const staleBuffer = Buffer.from(lines.join("\r\n"), "utf8");
 
     await reload(page, staleBuffer, "style-persistence-step4-era-reloaded");
@@ -210,15 +211,19 @@ test.describe("style persistence round trips", () => {
     const afterLoad = await page.evaluate(() => ({
       markersRescaleAttr: document.getElementById("markers")?.getAttribute("rescale"),
       statesHaloWidthAttr: document.getElementById("statesHalo")?.getAttribute("data-width"),
+      coordinatesSizeAttr: document.getElementById("coordinates")?.getAttribute("data-size"),
       rescale: styles.markers.options.rescale,
-      haloWidth: styles.states.statesHalo.options.width
+      haloWidth: styles.states.statesHalo.options.width,
+      coordinatesSize: styles.coordinates.options.fontSize
     }));
 
-    // both attrs are gone immediately, and the record's own values won - not the stale attrs
+    // the attrs are gone immediately, and the record's own values won - not the stale attrs
     expect(afterLoad.markersRescaleAttr).toBeNull();
     expect(afterLoad.statesHaloWidthAttr).toBeNull();
+    expect(afterLoad.coordinatesSizeAttr).toBeNull();
     expect(afterLoad.rescale).toBe(1);
     expect(afterLoad.haloWidth).toBe(10);
+    expect(afterLoad.coordinatesSize).toBe(12);
 
     // flip both through the store the way the real editor handlers do, then re-run the save-time
     // harvest directly: with the attrs already stripped, it must keep the flipped values rather
@@ -226,16 +231,19 @@ test.describe("style persistence round trips", () => {
     await page.evaluate(() => {
       styles.markers.options.rescale = 0;
       styles.states.statesHalo.options.width = 3;
+      styles.coordinates.options.fontSize = 21;
       (window as any).stylesLegacy.syncStylesFromMap();
     });
 
     const afterSync = await page.evaluate(() => ({
       rescale: styles.markers.options.rescale,
-      haloWidth: styles.states.statesHalo.options.width
+      haloWidth: styles.states.statesHalo.options.width,
+      coordinatesSize: styles.coordinates.options.fontSize
     }));
 
     expect(afterSync.rescale).toBe(0);
     expect(afterSync.haloWidth).toBe(3);
+    expect(afterSync.coordinatesSize).toBe(21);
   });
 
   test("relief attrs persistence: a DOM-only #terrain write survives a save and load", async ({ page, context }) => {

--- a/tests/e2e/style-persistence.spec.ts
+++ b/tests/e2e/style-persistence.spec.ts
@@ -203,7 +203,9 @@ test.describe("style persistence round trips", () => {
     lines[5] = lines[5]
       .replace('<g id="markers"', '<g id="markers" rescale="0"')
       .replace('<g id="statesHalo"', '<g id="statesHalo" data-width="7"')
-      .replace('<g id="coordinates"', '<g id="coordinates" data-size="55"');
+      .replace('<g id="coordinates"', '<g id="coordinates" data-size="55"')
+      .replace('<g id="ruler"', '<g id="ruler" data-size="44" font-size="44"')
+      .replace('<g id="legend"', '<g id="legend" data-size="33"');
     const staleBuffer = Buffer.from(lines.join("\r\n"), "utf8");
 
     await reload(page, staleBuffer, "style-persistence-step4-era-reloaded");
@@ -212,6 +214,8 @@ test.describe("style persistence round trips", () => {
       markersRescaleAttr: document.getElementById("markers")?.getAttribute("rescale"),
       statesHaloWidthAttr: document.getElementById("statesHalo")?.getAttribute("data-width"),
       coordinatesSizeAttr: document.getElementById("coordinates")?.getAttribute("data-size"),
+      rulerSizeAttr: document.getElementById("ruler")?.getAttribute("data-size"),
+      legendSizeAttr: document.getElementById("legend")?.getAttribute("data-size"),
       rescale: styles.markers.options.rescale,
       haloWidth: styles.states.statesHalo.options.width,
       coordinatesSize: styles.coordinates.options.fontSize
@@ -221,6 +225,8 @@ test.describe("style persistence round trips", () => {
     expect(afterLoad.markersRescaleAttr).toBeNull();
     expect(afterLoad.statesHaloWidthAttr).toBeNull();
     expect(afterLoad.coordinatesSizeAttr).toBeNull();
+    expect(afterLoad.rulerSizeAttr).toBeNull();
+    expect(afterLoad.legendSizeAttr).toBeNull();
     expect(afterLoad.rescale).toBe(1);
     expect(afterLoad.haloWidth).toBe(10);
     expect(afterLoad.coordinatesSize).toBe(12);

--- a/tests/e2e/style-presets.spec.ts
+++ b/tests/e2e/style-presets.spec.ts
@@ -125,3 +125,27 @@ test("relief icon size round-trips through a preset switch and back", async ({pa
   const revertedWidth = await reliefIconWidth(page, id as string);
   expect(revertedWidth, "relief icon width after switching back to default (size 1)").toBeCloseTo(baselineWidth!, 1);
 });
+
+test("a saved custom preset carries the retired sizes from the store", async ({page}) => {
+  await page.goto("/?seed=test-seed&width=1280&height=720");
+  await page.waitForFunction(() => (window as any).mapId !== undefined, {timeout: 60000});
+
+  await page.evaluate(() => {
+    styles.coordinates.options.fontSize = 23;
+    styles.rulers.options.fontSize = 24;
+    styles.legend.options.fontSize = 25;
+    (window as any).addStylePreset();
+  });
+
+  const raw = await page.locator("#styleSaverJSON").inputValue();
+  const roundTripped = await page.evaluate(rawJson => {
+    const upgraded = (window as any).stylesLegacy.presetFromLegacy(JSON.parse(rawJson), {onUnknown: "skip"});
+    return {
+      coordinates: upgraded.coordinates.options.fontSize,
+      rulers: upgraded.rulers.options.fontSize,
+      legend: upgraded.legend.options.fontSize
+    };
+  }, raw);
+
+  expect(roundTripped).toEqual({coordinates: 23, rulers: 24, legend: 25});
+});

--- a/tests/e2e/style-presets.spec.ts
+++ b/tests/e2e/style-presets.spec.ts
@@ -134,6 +134,10 @@ test("a saved custom preset carries the retired sizes from the store", async ({p
     styles.coordinates.options.fontSize = 23;
     styles.rulers.options.fontSize = 24;
     styles.legend.options.fontSize = 25;
+    styles.emblems.provinceEmblems.options.size = 1.4;
+    styles.goods.goodsIcons.options.size = 9;
+    styles.goods.goodsBurgs.options.size = 7;
+    styles.markets.options.size = 8;
     (window as any).addStylePreset();
   });
 
@@ -143,9 +147,21 @@ test("a saved custom preset carries the retired sizes from the store", async ({p
     return {
       coordinates: upgraded.coordinates.options.fontSize,
       rulers: upgraded.rulers.options.fontSize,
-      legend: upgraded.legend.options.fontSize
+      legend: upgraded.legend.options.fontSize,
+      provinceEmblems: upgraded.emblems.provinceEmblems.options.size,
+      goodsIcons: upgraded.goods.goodsIcons.options.size,
+      goodsBurgs: upgraded.goods.goodsBurgs.options.size,
+      markets: upgraded.markets.options.size
     };
   }, raw);
 
-  expect(roundTripped).toEqual({coordinates: 23, rulers: 24, legend: 25});
+  expect(roundTripped).toEqual({
+    coordinates: 23,
+    rulers: 24,
+    legend: 25,
+    provinceEmblems: 1.4,
+    goodsIcons: 9,
+    goodsBurgs: 7,
+    markets: 8
+  });
 });

--- a/tests/fixtures/style-baseline-generated.json
+++ b/tests/fixtures/style-baseline-generated.json
@@ -62,8 +62,6 @@
     "stroke": "#d4d4d4",
     "stroke-width": "1",
     "stroke-dasharray": "5",
-    "font-size": "12",
-    "data-size": "12",
     "style": "display: none;"
   },
   "#cults": {
@@ -77,15 +75,9 @@
     "stroke-width": "1",
     "style": "display: none;"
   },
-  "#stateEmblems": {
-    "data-size": "1"
-  },
-  "#provinceEmblems": {
-    "data-size": "1"
-  },
-  "#burgEmblems": {
-    "data-size": "1"
-  },
+  "#stateEmblems": {},
+  "#provinceEmblems": {},
+  "#burgEmblems": {},
   "#fogging": {
     "opacity": "0.98",
     "fill": "#30426f",
@@ -101,14 +93,12 @@
     "opacity": "1",
     "stroke-width": "0.3",
     "filter": "url(#dropShadow01)",
-    "data-size": "6",
     "data-circle": "1"
   },
   "#goodsBurgs": {
     "opacity": "1",
     "stroke": "#41414f",
-    "stroke-width": "0.2",
-    "data-size": "3"
+    "stroke-width": "0.2"
   },
   "#gridOverlay": {
     "opacity": "0.8",
@@ -177,9 +167,7 @@
     "stroke-width": "2.5",
     "stroke-dasharray": "0 4 10 4",
     "stroke-linecap": "round",
-    "font-size": "13",
     "font-family": "Almendra SC",
-    "data-size": "13",
     "data-x": "99",
     "data-y": "93",
     "data-columns": "8"
@@ -193,7 +181,6 @@
     "stroke-width": "1",
     "stroke-opacity": "0.8",
     "font-size": "5",
-    "data-size": "3",
     "data-icon": "⚖️",
     "style": "display: none;"
   },
@@ -281,8 +268,6 @@
   "#ruler": {
     "stroke-width": "2",
     "stroke-dasharray": "10",
-    "font-size": "20",
-    "data-size": "20",
     "style": "display: none;"
   },
   "#scaleBar": {

--- a/tests/fixtures/style-baseline.json
+++ b/tests/fixtures/style-baseline.json
@@ -68,7 +68,6 @@
     "stroke-width": "1",
     "stroke-dasharray": "6",
     "font-size": "14",
-    "data-size": "14",
     "style": "display: none;"
   },
   "#cults": {
@@ -83,15 +82,9 @@
     "stroke-width": "0.5",
     "style": "display: none;"
   },
-  "#stateEmblems": {
-    "data-size": "1"
-  },
-  "#provinceEmblems": {
-    "data-size": "1"
-  },
-  "#burgEmblems": {
-    "data-size": "1"
-  },
+  "#stateEmblems": {},
+  "#provinceEmblems": {},
+  "#burgEmblems": {},
   "#fogging": {
     "opacity": "0.98",
     "fill": "#1b1423",
@@ -111,8 +104,7 @@
   "#goodsBurgs": {
     "opacity": "1",
     "stroke": "#41414f",
-    "stroke-width": "0.2",
-    "data-size": "3"
+    "stroke-width": "0.2"
   },
   "#gridOverlay": {
     "opacity": "0.8",
@@ -183,7 +175,6 @@
     "stroke-linecap": "round",
     "font-size": "13",
     "font-family": "Almendra SC",
-    "data-size": "13",
     "data-x": "99",
     "data-y": "93",
     "data-columns": "8"
@@ -285,8 +276,6 @@
   "#ruler": {
     "stroke-width": "2",
     "stroke-dasharray": "10",
-    "font-size": "20",
-    "data-size": "20",
     "style": "display: none;"
   },
   "#scaleBar": {


### PR DESCRIPTION
Next step-5 family (docs/prd/style-migration.md): every `data-size` decision-attribute retires. The renderers and editor handlers read/write the store; the projection rows die; load strips the attrs unconditionally.

## Scope

| Selector | Store home | Retired |
|---|---|---|
| #coordinates | `coordinates.options.fontSize` | data-size (+ the projected font-size mirror) |
| #ruler | `rulers.options.fontSize` | data-size + font-size (per-measurer groups get stamped instead) |
| #legend | `legend.options.fontSize` | data-size (+ the projected mirror) |
| #stateEmblems / #provinceEmblems / #burgEmblems | `emblems.*.options.size` | data-size |
| #goodsIcons | `goods.goodsIcons.options.size` | data-size (data-circle stays) |
| #goodsBurgs | `goods.goodsBurgs.options.size` | data-size |
| #markets | `markets.options.size` | data-size (font-size/data-icon stay) |

Two attrs deliberately survive as renderer-owned output: #coordinates' font-size (the zoom-derived value, rewritten on every draw) and #legend's font-size (the drawn texts size by inheritance, and a restored SVG must render before its first redraw).

## Behavior notes

- Save-time authority gates key on **data-size alone**: #coordinates' font-size is derived, so "any attr present" would let a stale render value clobber the stored base on every save of a post-strip map. Verified against a real 1.113.6 map that carried data-size=12 beside font-size=14.16 — the record took 12.
- goodsIcons and markets overlay **per-key** (their sibling options are still attr-authoritative); the rest overlay whole bags.
- Saved custom presets get a store overlay in collectStyleData — without it the stripped attrs serialize as nulls and the upgrader resets those layers to defaults. (The same overlay pattern the zoom family used for rescale/halo.)
- Fixes a pre-existing step-4 gap: `stylesFromMap` never harvested the emblem child groups, so a record-less old map's custom emblem sizes never reached the store. With this family's strip that would have become data loss; now they harvest.
- Old maps with a missing legend/coordinates size previously rendered a NaN font-size; they now get the store default.

## Verification

- New real-control e2e for all four editor controls (coordinates/ruler/legend/emblems/goods/markets), including the slider-input custom elements.
- The step-4-era persistence regression now injects and strips all eleven family attrs; a new e2e round-trips the Style Saver dialog through the legacy upgrader.
- Parity baselines shrink by exactly the retired attrs — proven mechanically (per-element diff: removals only, all within the family set, nothing added or changed).
- tsc, biome, 449 unit + 22 browser tests, full Playwright suite 163/163.
- Manual round trip of a real 1.113.6-era map through load → save: every user-set value survived, every derived value correctly excluded.