### PR TITLE
Style migration step 5: heightmap options move off the DOM

### DIFF
--- a/public/modules/ui/style-presets.js
+++ b/public/modules/ui/style-presets.js
@@ -146,21 +146,6 @@ function projectPresetOptions() {
   setOrRemove(gridOverlay, "dx", styles.grid.options.dx);
   setOrRemove(gridOverlay, "dy", styles.grid.options.dy);
 
-  const landHeights = byId("landHeights");
-  setOrRemove(landHeights, "scheme", styles.heightmap.landHeights.options.scheme);
-  setOrRemove(landHeights, "terracing", styles.heightmap.landHeights.options.terracing);
-  setOrRemove(landHeights, "skip", styles.heightmap.landHeights.options.skip);
-  setOrRemove(landHeights, "relax", styles.heightmap.landHeights.options.relax);
-  setOrRemove(landHeights, "curve", styles.heightmap.landHeights.options.curve);
-
-  const oceanHeights = byId("oceanHeights");
-  setOrRemove(oceanHeights, "scheme", styles.heightmap.oceanHeights.options.scheme);
-  setOrRemove(oceanHeights, "terracing", styles.heightmap.oceanHeights.options.terracing);
-  setOrRemove(oceanHeights, "skip", styles.heightmap.oceanHeights.options.skip);
-  setOrRemove(oceanHeights, "relax", styles.heightmap.oceanHeights.options.relax);
-  setOrRemove(oceanHeights, "curve", styles.heightmap.oceanHeights.options.curve);
-  setOrRemove(oceanHeights, "data-render", Number(styles.heightmap.oceanHeights.options.render));
-
   setOrRemove(byId("goodsIcons"), "data-circle", Number(styles.goods.goodsIcons.options.circle));
 
   const markets = byId("markets");
@@ -521,6 +506,14 @@ function addStylePreset() {
     if (presetStyle["#goodsIcons"]) presetStyle["#goodsIcons"]["data-size"] = styles.goods.goodsIcons.options.size;
     if (presetStyle["#goodsBurgs"]) presetStyle["#goodsBurgs"]["data-size"] = styles.goods.goodsBurgs.options.size;
     if (presetStyle["#markets"]) presetStyle["#markets"]["data-size"] = styles.markets.options.size;
+    for (const [selector, heights] of [
+      ["#terrs #landHeights", styles.heightmap.landHeights.options],
+      ["#terrs #oceanHeights", styles.heightmap.oceanHeights.options]
+    ]) {
+      if (!presetStyle[selector]) continue;
+      for (const key of ["scheme", "terracing", "skip", "relax", "curve"]) presetStyle[selector][key] = heights[key];
+      if (selector === "#terrs #oceanHeights") presetStyle[selector]["data-render"] = Number(heights.render);
+    }
 
     for (const [group, groupStyle] of Object.entries(styles.labels.groups)) {
       addStoredLabelStyle(`#labels > #${group}`, stylesLegacy.labelGroupToLegacy(groupStyle));

--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -199,13 +199,13 @@ function selectStyleElement() {
   if (styleElement === "terrs") {
     styleHeightmap.style.display = "block";
     styleHeightmapRenderOceanOption.style.display = el.attr("id") === "oceanHeights" ? "block" : "none";
-    styleHeightmapRenderOcean.checked = +el.attr("data-render");
-
-    styleHeightmapScheme.value = el.attr("scheme");
-    styleHeightmapTerracing.value = el.attr("terracing");
-    styleHeightmapSkip.value = el.attr("skip");
-    styleHeightmapSimplification.value = el.attr("relax");
-    styleHeightmapCurve.value = el.attr("curve");
+    const heights = styles.heightmap[el.attr("id")].options;
+    styleHeightmapRenderOcean.checked = heights.render;
+    styleHeightmapScheme.value = heights.scheme;
+    styleHeightmapTerracing.value = heights.terracing;
+    styleHeightmapSkip.value = heights.skip;
+    styleHeightmapSimplification.value = heights.relax;
+    styleHeightmapCurve.value = heights.curve;
   }
 
   if (styleElement === "markers") {
@@ -651,14 +651,16 @@ outlineLayers.addEventListener("change", function () {
   Layers.draw("ocean");
 });
 
+const heightsOptions = () => styles.heightmap[getEl().attr("id")].options;
+
 styleHeightmapScheme.addEventListener("change", function () {
-  getEl().attr("scheme", this.value);
+  heightsOptions().scheme = this.value;
   Layers.draw("heightmap");
 });
 
 openCreateHeightmapSchemeButton.addEventListener("click", function () {
   // start with current scheme
-  const scheme = getEl().attr("scheme");
+  const scheme = heightsOptions().scheme;
   this.dataset.stops = scheme.startsWith("#")
     ? scheme
     : (() => [0, 0.25, 0.5, 0.75, 1].map(heightmapColorSchemes[scheme]).map(toHEX).join(","))();
@@ -753,7 +755,7 @@ openCreateHeightmapSchemeButton.addEventListener("click", function () {
     if (stops in heightmapColorSchemes) return tip("This scheme already exists", false, "error");
 
     addCustomColorScheme(stops);
-    getEl().attr("scheme", stops);
+    heightsOptions().scheme = stops;
     Layers.draw("heightmap");
 
     handleClose();
@@ -776,28 +778,27 @@ openCreateHeightmapSchemeButton.addEventListener("click", function () {
 });
 
 styleHeightmapRenderOcean.addEventListener("change", e => {
-  const checked = +e.target.checked;
-  getEl().attr("data-render", checked);
+  heightsOptions().render = e.target.checked;
   Layers.draw("heightmap");
 });
 
 styleHeightmapTerracing.addEventListener("input", e => {
-  getEl().attr("terracing", e.target.value);
+  heightsOptions().terracing = +e.target.value || 0;
   Layers.draw("heightmap");
 });
 
 styleHeightmapSkip.addEventListener("input", e => {
-  getEl().attr("skip", e.target.value);
+  heightsOptions().skip = +e.target.value || 0;
   Layers.draw("heightmap");
 });
 
 styleHeightmapSimplification.addEventListener("input", e => {
-  getEl().attr("relax", e.target.value);
+  heightsOptions().relax = +e.target.value || 0;
   Layers.draw("heightmap");
 });
 
 styleHeightmapCurve.addEventListener("change", e => {
-  getEl().attr("curve", e.target.value);
+  heightsOptions().curve = e.target.value;
   Layers.draw("heightmap");
 });
 

--- a/src/generators/styles-legacy.dom.test.ts
+++ b/src/generators/styles-legacy.dom.test.ts
@@ -150,6 +150,27 @@ test("save sync lets an old map's emblem, goods and market data-size win", () =>
   expect(styles.markets.options.size).toBe(8);
 });
 
+test("save sync keeps store heightmap options when the scheme attr is absent", () => {
+  document.body.innerHTML = `<svg id="map"><g id="terrs"><g id="landHeights"></g><g id="oceanHeights"></g></g></svg>`;
+  styles.heightmap.landHeights.options.scheme = "#001122,#334455";
+  styles.heightmap.landHeights.options.terracing = 4;
+  styles.heightmap.oceanHeights.options.render = true;
+  syncStylesFromMap();
+  expect(styles.heightmap.landHeights.options.scheme).toBe("#001122,#334455");
+  expect(styles.heightmap.landHeights.options.terracing).toBe(4);
+  expect(styles.heightmap.oceanHeights.options.render).toBe(true);
+});
+
+test("save sync lets an old map's heightmap attrs win when scheme is present", () => {
+  document.body.innerHTML = `<svg id="map"><g id="terrs"><g id="landHeights" scheme="olive" terracing="2" skip="1" relax="1" curve="curveLinear"></g><g id="oceanHeights" scheme="bright" terracing="0" skip="0" relax="0" curve="curveBasisClosed" data-render="1"></g></g></svg>`;
+  styles.heightmap.landHeights.options.scheme = "monochrome";
+  styles.heightmap.oceanHeights.options.render = false;
+  syncStylesFromMap();
+  expect(styles.heightmap.landHeights.options.scheme).toBe("olive");
+  expect(styles.heightmap.landHeights.options.terracing).toBe(2);
+  expect(styles.heightmap.oceanHeights.options.render).toBe(true);
+});
+
 test("save sync lets an old map's coordinates data-size win over the store", () => {
   document.body.innerHTML = `<svg id="map"><g id="coordinates" data-size="14"></g></svg>`;
   styles.coordinates.options.fontSize = 20;

--- a/src/generators/styles-legacy.ts
+++ b/src/generators/styles-legacy.ts
@@ -403,6 +403,10 @@ export function syncStylesFromMap(): void {
     harvested.goods.goodsBurgs.options = structuredClone(styles.goods.goodsBurgs.options);
   if (!document.getElementById("markets")?.hasAttribute("data-size"))
     harvested.markets.options.size = styles.markets.options.size;
+  for (const key of ["landHeights", "oceanHeights"] as const) {
+    if (!document.getElementById(key)?.hasAttribute("scheme"))
+      harvested.heightmap[key].options = structuredClone(styles.heightmap[key].options);
+  }
   Styles.set(harvested);
 }
 

--- a/src/renderers/draw-heightmap.ts
+++ b/src/renderers/draw-heightmap.ts
@@ -62,13 +62,15 @@ export const drawHeightmap = (): void => {
   const used = new Uint8Array(cells.i.length);
   const heights = Array.from(cells.i as number[]).sort((a, b) => cells.h[a] - cells.h[b]);
 
+  const landOptions = styles.heightmap.landHeights.options;
+  const oceanOptions = styles.heightmap.oceanHeights.options;
+
   // ocean cells
-  const renderOceanCells = Boolean(+ocean.attr("data-render"));
+  const renderOceanCells = oceanOptions.render;
   if (renderOceanCells) {
-    const skip = +ocean.attr("skip") + 1 || 1;
-    const relax = +ocean.attr("relax") || 0;
-    const curveType = ocean.attr("curve") || "curveBasisClosed";
-    const lineGen = line().curve(CURVE_MAP[curveType] ?? curveBasisClosed);
+    const skip = oceanOptions.skip + 1 || 1;
+    const relax = oceanOptions.relax;
+    const lineGen = line().curve(CURVE_MAP[oceanOptions.curve] ?? curveBasisClosed);
 
     let currentLayer = 0;
     for (const i of heights) {
@@ -90,10 +92,9 @@ export const drawHeightmap = (): void => {
 
   // land cells
   {
-    const skip = +land.attr("skip") + 1 || 1;
-    const relax = +land.attr("relax") || 0;
-    const curveType = land.attr("curve") || "curveBasisClosed";
-    const lineGen = line().curve(CURVE_MAP[curveType] ?? curveBasisClosed);
+    const skip = landOptions.skip + 1 || 1;
+    const relax = landOptions.relax;
+    const lineGen = line().curve(CURVE_MAP[landOptions.curve] ?? curveBasisClosed);
 
     let currentLayer = 20;
     for (const i of heights) {
@@ -118,7 +119,8 @@ export const drawHeightmap = (): void => {
   // render paths
   for (const height of range(0, 101)) {
     const group = height < 20 ? ocean : land;
-    const scheme = getColorScheme(group.attr("scheme"));
+    const options = height < 20 ? oceanOptions : landOptions;
+    const scheme = getColorScheme(options.scheme);
 
     if (height === 0 && renderOceanCells) {
       // draw base ocean layer
@@ -143,7 +145,7 @@ export const drawHeightmap = (): void => {
     }
 
     if (paths[height] && paths[height]!.length >= 10) {
-      const terracing = +group.attr("terracing") / 10 || 0;
+      const terracing = options.terracing / 10 || 0;
       const fillColor = getColor(height, scheme);
 
       if (terracing) {

--- a/src/services/io/auto-update.ts
+++ b/src/services/io/auto-update.ts
@@ -1881,4 +1881,10 @@ export async function resolveVersionConflicts(mapVersion: string, data: string[]
   for (const id of ["stateEmblems", "provinceEmblems", "burgEmblems", "goodsIcons", "goodsBurgs", "markets"]) {
     document.getElementById(id)?.removeAttribute("data-size");
   }
+  for (const id of ["landHeights", "oceanHeights"]) {
+    for (const attr of ["scheme", "terracing", "skip", "relax", "curve"]) {
+      document.getElementById(id)?.removeAttribute(attr);
+    }
+  }
+  document.getElementById("oceanHeights")?.removeAttribute("data-render");
 }

--- a/src/services/io/export.ts
+++ b/src/services/io/export.ts
@@ -538,7 +538,7 @@ function removeUnusedElements(clone: MapSelection): void {
 function updateMeshCells(clone: MapSelection): void {
   const renderOcean = ensureEl<HTMLInputElement>("renderOcean").checked;
   const data = renderOcean ? grid.cells.i : grid.cells.i.filter((i: number) => grid.cells.h[i] >= 20);
-  const scheme = getColorScheme(select("#terrs").select("#landHeights").attr("scheme"));
+  const scheme = getColorScheme(styles.heightmap.landHeights.options.scheme);
   clone.select("#heights").attr("filter", "url(#blur1)");
   clone
     .select("#heights")

--- a/src/services/io/load.ts
+++ b/src/services/io/load.ts
@@ -459,12 +459,9 @@ async function parseLoadedData(data: string[], mapVersion: string | null): Promi
 
     // add custom heightmap color scheme if any
     if (heightmapColorSchemes) {
-      const oceanHeights = document.getElementById("oceanHeights");
-      const oceanScheme = oceanHeights?.getAttribute("scheme");
-      if (oceanScheme && !(oceanScheme in heightmapColorSchemes)) addCustomColorScheme(oceanScheme);
-      const landHeights = document.getElementById("landHeights");
-      const landScheme = landHeights?.getAttribute("scheme");
-      if (landScheme && !(landScheme in heightmapColorSchemes)) addCustomColorScheme(landScheme);
+      for (const { scheme } of [styles.heightmap.oceanHeights.options, styles.heightmap.landHeights.options]) {
+        if (scheme && !(scheme in heightmapColorSchemes)) addCustomColorScheme(scheme);
+      }
     }
 
     {

--- a/src/utils/debugUtils.ts
+++ b/src/utils/debugUtils.ts
@@ -26,10 +26,10 @@ export const drawCellsValue = (data: unknown[], points: Point[]): void => {
  * @param {number[]} data - Array of numerical values corresponding to each cell
  * @param {any} terrs - The SVG group element where the polygons will be drawn
  */
-export const drawPolygons = (data: number[], terrs: any, grid: any): void => {
+export const drawPolygons = (data: number[], _terrs: any, grid: any): void => {
   const maximum: number = max(data) as number;
   const minimum: number = min(data) as number;
-  const scheme = window.getColorScheme(terrs.select("#landHeights").attr("scheme"));
+  const scheme = window.getColorScheme(styles.heightmap.landHeights.options.scheme);
 
   data = data.map(d => 1 - normalize(d, minimum, maximum));
   select("#debug").selectAll("polygon").remove();

--- a/tests/e2e/style-editor-events.spec.ts
+++ b/tests/e2e/style-editor-events.spec.ts
@@ -13,7 +13,7 @@ const waitForMap = (page: Page) =>
 
 const rn = (v: number, d = 0): number => Math.round(v * 10 ** d) / 10 ** d;
 
-async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates" | "ruler" | "legend" | "emblems" | "goodsIcons" | "goodsBurgs" | "markets"): Promise<void> {
+async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates" | "ruler" | "legend" | "emblems" | "goodsIcons" | "goodsBurgs" | "markets" | "terrs"): Promise<void> {
   await page.evaluate(() => (window as any).showOptions());
   await page.locator("#styleTab").click();
   await page.locator("#styleElementSelect").selectOption(element);
@@ -246,5 +246,49 @@ test.describe("style editor events drive the store", () => {
     // fontSize and icon are not in this family: their attrs must survive on the element
     expect(await page.locator("#markets").getAttribute("data-size")).toBeNull();
     expect(await page.locator("#markets").getAttribute("font-size")).not.toBeNull();
+  });
+
+  test("heightmap controls write the store per group and the renderer derives from it", async ({ page }) => {
+    await page.evaluate(() => (window as any).Layers.show("heightmap"));
+    await openStyleElement(page, "terrs");
+
+    // ocean group: scheme select, terracing slider, render-ocean checkbox
+    await page.locator("#styleGroupSelect").selectOption("oceanHeights");
+    await page.locator("#styleHeightmapScheme").selectOption("monochrome");
+    await page.locator("#styleHeightmapTerracing input[type=number]").fill("3");
+    await page.locator('label[for="styleHeightmapRenderOcean"]').click();
+
+    // land group: skip, relax, curve
+    await page.locator("#styleGroupSelect").selectOption("landHeights");
+    await page.locator("#styleHeightmapSkip input[type=number]").fill("2");
+    await page.locator("#styleHeightmapSimplification input[type=number]").fill("1");
+    await page.locator("#styleHeightmapCurve").selectOption("curveLinear");
+
+    const stored = await page.evaluate(() => ({
+      oceanScheme: (window as any).styles.heightmap.oceanHeights.options.scheme,
+      oceanTerracing: (window as any).styles.heightmap.oceanHeights.options.terracing,
+      oceanRender: (window as any).styles.heightmap.oceanHeights.options.render,
+      landSkip: (window as any).styles.heightmap.landHeights.options.skip,
+      landRelax: (window as any).styles.heightmap.landHeights.options.relax,
+      landCurve: (window as any).styles.heightmap.landHeights.options.curve
+    }));
+    expect(stored).toEqual({
+      oceanScheme: "monochrome",
+      oceanTerracing: 3,
+      oceanRender: true,
+      landSkip: 2,
+      landRelax: 1,
+      landCurve: "curveLinear"
+    });
+
+    // renderer derives from the store: render=true draws the ocean base rect
+    expect(await page.locator("#oceanHeights rect").count()).toBeGreaterThan(0);
+
+    // the retired attrs are gone from both groups
+    for (const id of ["#landHeights", "#oceanHeights"]) {
+      for (const attr of ["scheme", "terracing", "skip", "relax", "curve", "data-render"]) {
+        expect(await page.locator(id).getAttribute(attr), `${id} ${attr}`).toBeNull();
+      }
+    }
   });
 });

--- a/tests/e2e/style-persistence.spec.ts
+++ b/tests/e2e/style-persistence.spec.ts
@@ -209,7 +209,9 @@ test.describe("style persistence round trips", () => {
       .replace('<g id="stateEmblems"', '<g id="stateEmblems" data-size="4"')
       .replace('<g id="goodsIcons"', '<g id="goodsIcons" data-size="66"')
       .replace('<g id="goodsBurgs"', '<g id="goodsBurgs" data-size="66"')
-      .replace('<g id="markets"', '<g id="markets" data-size="66"');
+      .replace('<g id="markets"', '<g id="markets" data-size="66"')
+      .replace('<g id="landHeights"', '<g id="landHeights" scheme="olive" terracing="2" skip="1" relax="1" curve="curveLinear"')
+      .replace('<g id="oceanHeights"', '<g id="oceanHeights" scheme="bright" terracing="0" skip="0" relax="0" curve="curveBasisClosed" data-render="1"');
     const staleBuffer = Buffer.from(lines.join("\r\n"), "utf8");
 
     await reload(page, staleBuffer, "style-persistence-step4-era-reloaded");
@@ -224,6 +226,11 @@ test.describe("style persistence round trips", () => {
         document.getElementById(id)?.getAttribute("data-size")
       ),
       marketsSize: styles.markets.options.size,
+      landHeightsAttrs: ["scheme", "terracing", "skip", "relax", "curve"].map(a =>
+        document.getElementById("landHeights")?.getAttribute(a)
+      ),
+      oceanRenderAttr: document.getElementById("oceanHeights")?.getAttribute("data-render"),
+      landScheme: styles.heightmap.landHeights.options.scheme,
       rescale: styles.markers.options.rescale,
       haloWidth: styles.states.statesHalo.options.width,
       coordinatesSize: styles.coordinates.options.fontSize
@@ -237,6 +244,10 @@ test.describe("style persistence round trips", () => {
     expect(afterLoad.legendSizeAttr).toBeNull();
     expect(afterLoad.familySizeAttrs).toEqual([null, null, null, null]);
     expect(afterLoad.marketsSize).toBe(3);
+    expect(afterLoad.landHeightsAttrs).toEqual([null, null, null, null, null]);
+    expect(afterLoad.oceanRenderAttr).toBeNull();
+    // the record's own scheme won, not the stale injected attr
+    expect(afterLoad.landScheme).not.toBe("olive");
     expect(afterLoad.rescale).toBe(1);
     expect(afterLoad.haloWidth).toBe(10);
     expect(afterLoad.coordinatesSize).toBe(12);

--- a/tests/e2e/style-presets.spec.ts
+++ b/tests/e2e/style-presets.spec.ts
@@ -138,6 +138,8 @@ test("a saved custom preset carries the retired sizes from the store", async ({p
     styles.goods.goodsIcons.options.size = 9;
     styles.goods.goodsBurgs.options.size = 7;
     styles.markets.options.size = 8;
+    styles.heightmap.landHeights.options.terracing = 5;
+    styles.heightmap.oceanHeights.options.render = true;
     (window as any).addStylePreset();
   });
 
@@ -151,7 +153,9 @@ test("a saved custom preset carries the retired sizes from the store", async ({p
       provinceEmblems: upgraded.emblems.provinceEmblems.options.size,
       goodsIcons: upgraded.goods.goodsIcons.options.size,
       goodsBurgs: upgraded.goods.goodsBurgs.options.size,
-      markets: upgraded.markets.options.size
+      markets: upgraded.markets.options.size,
+      landTerracing: upgraded.heightmap.landHeights.options.terracing,
+      oceanRender: upgraded.heightmap.oceanHeights.options.render
     };
   }, raw);
 
@@ -162,6 +166,8 @@ test("a saved custom preset carries the retired sizes from the store", async ({p
     provinceEmblems: 1.4,
     goodsIcons: 9,
     goodsBurgs: 7,
-    markets: 8
+    markets: 8,
+    landTerracing: 5,
+    oceanRender: true
   });
 });

--- a/tests/fixtures/style-baseline-generated.json
+++ b/tests/fixtures/style-baseline-generated.json
@@ -308,20 +308,10 @@
   },
   "#landHeights": {
     "opacity": "1",
-    "mask": "url(#land)",
-    "scheme": "bright",
-    "terracing": "0",
-    "skip": "5",
-    "relax": "0",
-    "curve": "curveBasisClosed"
+    "mask": "url(#land)"
   },
   "#oceanHeights": {
-    "opacity": "1",
-    "scheme": "bright",
-    "terracing": "0",
-    "skip": "0",
-    "relax": "1",
-    "curve": "curveBasisClosed"
+    "opacity": "1"
   },
   "#texture": {
     "mask": "url(#land)",

--- a/tests/fixtures/style-baseline.json
+++ b/tests/fixtures/style-baseline.json
@@ -319,20 +319,10 @@
   "#terrs": {},
   "#landHeights": {
     "opacity": "0.8",
-    "mask": "url(#land)",
-    "scheme": "livid",
-    "terracing": "6",
-    "skip": "0",
-    "relax": "2",
-    "curve": "curveBasisClosed"
+    "mask": "url(#land)"
   },
   "#oceanHeights": {
-    "opacity": "1",
-    "scheme": "olive",
-    "terracing": "0",
-    "skip": "0",
-    "relax": "1",
-    "curve": "curveBasisClosed"
+    "opacity": "1"
   },
   "#texture": {
     "opacity": "0.2",


### PR DESCRIPTION
Next step-5 family (docs/prd/style-migration.md): `scheme`/`terracing`/`skip`/`relax`/`curve` on both heights groups, plus `data-render` on #oceanHeights, retire from the DOM. `styles.heightmap.{landHeights,oceanHeights}.options` is the single source; projection rows die; load strips the attrs unconditionally.

## Consumers converted beyond the renderer and editor

- **load.ts custom-scheme registration** — it read the scheme attrs off the DOM to re-register `#stops` custom gradients on load, and would have gone blind after the strip.
- **export.ts mesh export** and the debug polygon helper (land scheme reads).
- The editor routes store writes through the selected group element's id, which is exactly the store key.

## Behavior notes

- auto-update's version-gated migrations (the ancient `#terrs`-parent → child-group attr split) keep writing the child attrs deliberately: they run before the record-less harvest, which feeds the store, and the end-of-load strip then removes them.
- Save-time authority gates are whole-bag per group, keyed on the `scheme` attr — present on every old map, never rewritten at render time.
- Saved custom presets carry the options via the collectStyleData store overlay (same pattern as the previous families).

## Verification

- New two-group real-control e2e (scheme select, terracing/skip/simplification sliders, curve select, render-ocean checkbox) including a render-effect assertion: enabling ocean render must draw the base rect from the store.
- Authority-gate browser tests and the step-4-era strip regression extended with all eleven attrs — each RED-verified against the code without the change.
- Style Saver round-trip extended (terracing + ocean render survive the legacy dialect).
- Parity baselines shrink by exactly the five attrs × two groups on both baselines, proven mechanically (removals only, nothing added or changed).
- tsc, biome, 449 unit + 24 browser tests, full Playwright suite 163/163.
- Manual validation on a real 1.113.6-era map: the terrs-split migration → harvest → strip pipeline preserves the styling, and custom schemes re-register from the store on load.