### PR TITLE
Style migration step 5: armies, grid, map filter and coastline auto-filter move off the DOM

### DIFF
--- a/public/modules/ui/style-presets.js
+++ b/public/modules/ui/style-presets.js
@@ -132,20 +132,6 @@ function writeAttrsById(id, attrs) {
 function projectPresetOptions() {
   const byId = id => document.getElementById(id);
 
-  setOrRemove(byId("map"), "data-filter", styles.map.options.dataFilter);
-
-  const armies = byId("armies");
-  setOrRemove(armies, "font-size", styles.military.options.fontSize);
-  setOrRemove(armies, "box-size", styles.military.options.boxSize);
-
-  setOrRemove(byId("sea_island"), "auto-filter", styles.coastline.sea_island.options.autoFilter);
-
-  const gridOverlay = byId("gridOverlay");
-  setOrRemove(gridOverlay, "type", styles.grid.options.type);
-  setOrRemove(gridOverlay, "scale", styles.grid.options.scale);
-  setOrRemove(gridOverlay, "dx", styles.grid.options.dx);
-  setOrRemove(gridOverlay, "dy", styles.grid.options.dy);
-
   setOrRemove(byId("goodsIcons"), "data-circle", Number(styles.goods.goodsIcons.options.circle));
 
   const markets = byId("markets");
@@ -514,6 +500,16 @@ function addStylePreset() {
       for (const key of ["scheme", "terracing", "skip", "relax", "curve"]) presetStyle[selector][key] = heights[key];
       if (selector === "#terrs #oceanHeights") presetStyle[selector]["data-render"] = Number(heights.render);
     }
+    if (presetStyle["#armies"]) {
+      presetStyle["#armies"]["box-size"] = styles.military.options.boxSize;
+      presetStyle["#armies"]["font-size"] = styles.military.options.fontSize;
+    }
+    if (presetStyle["#gridOverlay"]) {
+      for (const key of ["type", "scale", "dx", "dy"]) presetStyle["#gridOverlay"][key] = styles.grid.options[key];
+    }
+    if (presetStyle["#map"]) presetStyle["#map"]["data-filter"] = styles.map.options.dataFilter;
+    if (presetStyle["#sea_island"])
+      presetStyle["#sea_island"]["auto-filter"] = styles.coastline.sea_island.options.autoFilter;
 
     for (const [group, groupStyle] of Object.entries(styles.labels.groups)) {
       addStoredLabelStyle(`#labels > #${group}`, stylesLegacy.labelGroupToLegacy(groupStyle));
@@ -619,7 +615,7 @@ function removeStylePreset() {
 }
 
 function updateMapFilter() {
-  const filter = d3.select("#map").attr("data-filter");
+  const filter = styles.map.options.dataFilter;
   mapFilters.querySelectorAll(".pressed").forEach(button => button.classList.remove("pressed"));
   if (!filter) return;
   mapFilters.querySelector("#" + filter).classList.add("pressed");

--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -215,10 +215,10 @@ function selectStyleElement() {
 
   if (styleElement === "gridOverlay") {
     styleGrid.style.display = "block";
-    styleGridType.value = el.attr("type");
-    styleGridScale.value = el.attr("scale") || 1;
-    styleGridShiftX.value = el.attr("dx") || 0;
-    styleGridShiftY.value = el.attr("dy") || 0;
+    styleGridType.value = styles.grid.options.type;
+    styleGridScale.value = styles.grid.options.scale;
+    styleGridShiftX.value = styles.grid.options.dx;
+    styleGridShiftY.value = styles.grid.options.dy;
     calculateFriendlyGridSize();
   }
 
@@ -375,7 +375,7 @@ function selectStyleElement() {
   if (styleElement === "armies") {
     styleArmies.style.display = "block";
     styleArmiesFillOpacity.value = el.attr("fill-opacity");
-    styleArmiesSize.value = el.attr("box-size");
+    styleArmiesSize.value = styles.military.options.boxSize;
   }
 
   if (styleElement === "emblems") {
@@ -601,13 +601,13 @@ styleClippingInput.addEventListener("change", function () {
 });
 
 styleGridType.addEventListener("change", function () {
-  getEl().attr("type", this.value);
+  styles.grid.options.type = this.value;
   Layers.draw("grid");
   calculateFriendlyGridSize();
 });
 
 styleGridScale.addEventListener("input", function () {
-  getEl().attr("scale", this.value);
+  styles.grid.options.scale = +this.value || 1;
   Layers.draw("grid");
   calculateFriendlyGridSize();
 });
@@ -619,12 +619,12 @@ function calculateFriendlyGridSize() {
 }
 
 styleGridShiftX.addEventListener("input", function () {
-  getEl().attr("dx", this.value);
+  styles.grid.options.dx = +this.value || 0;
   Layers.draw("grid");
 });
 
 styleGridShiftY.addEventListener("input", function () {
-  getEl().attr("dy", this.value);
+  styles.grid.options.dy = +this.value || 0;
   Layers.draw("grid");
 });
 
@@ -1035,10 +1035,8 @@ styleArmiesFillOpacity.addEventListener("input", e => {
 
 styleArmiesSize.addEventListener("input", e => {
   const value = Number(e.target.value);
-  d3.select("#armies")
-    .attr("box-size", value)
-    .attr("font-size", value * 2);
-
+  styles.military.options.boxSize = value;
+  styles.military.options.fontSize = value * 2;
   Layers.draw("military");
 });
 
@@ -1237,12 +1235,12 @@ mapFilters.addEventListener("click", applyMapFilter);
 function applyMapFilter(event) {
   if (event.target.tagName !== "BUTTON") return;
   const button = event.target;
-  d3.select("#map").attr("data-filter", null).attr("filter", null);
+  styles.map.options.dataFilter = null;
+  d3.select("#map").attr("filter", null);
   if (button.classList.contains("pressed")) return button.classList.remove("pressed");
 
   mapFilters.querySelectorAll(".pressed").forEach(button => button.classList.remove("pressed"));
   button.classList.add("pressed");
-  d3.select("#map")
-    .attr("data-filter", button.id)
-    .attr("filter", "url(#filter-" + button.id + ")");
+  styles.map.options.dataFilter = button.id;
+  d3.select("#map").attr("filter", "url(#filter-" + button.id + ")");
 }

--- a/src/controllers/regiment-editor.ts
+++ b/src/controllers/regiment-editor.ts
@@ -203,7 +203,7 @@ function changeType(): void {
   reg.n = +!reg.n;
   ensureEl("regimentType").className = reg.n ? "icon-anchor" : "icon-users";
 
-  const size = +select<SVGGElement, unknown>("#armies").attr("box-size");
+  const size = styles.military.options.boxSize;
   const baseRect = selectedRegiment.querySelectorAll("rect")[0];
   const iconRect = selectedRegiment.querySelectorAll("rect")[1];
   const icon = selectedRegiment.querySelector(".regimentIcon")!;
@@ -284,7 +284,7 @@ function splitRegiment(): void {
   selectedRegiment.querySelector("text")!.innerHTML = String(Military.getTotal(reg));
 
   // create new regiment
-  const shift = +select<SVGGElement, unknown>("#armies").attr("box-size") * 2;
+  const shift = styles.military.options.boxSize * 2;
   const findY = (x: number, startY: number): number => {
     let y = startY;
     do {
@@ -544,7 +544,7 @@ function dragRegiment(this: SVGGElement, event: D3DragEvent<SVGGElement, unknown
 
   const reg = pack.states[+this.dataset.state!].military!.find(r => r.i === +this.dataset.id!);
   if (!reg) return;
-  const size = +select<SVGGElement, unknown>("#armies").attr("box-size");
+  const size = styles.military.options.boxSize;
   const w = reg.n ? size * 4 : size * 6;
   const h = size * 2;
 

--- a/src/generators/styles-legacy.dom.test.ts
+++ b/src/generators/styles-legacy.dom.test.ts
@@ -171,6 +171,33 @@ test("save sync lets an old map's heightmap attrs win when scheme is present", (
   expect(styles.heightmap.oceanHeights.options.render).toBe(true);
 });
 
+test("save sync keeps store armies, grid, map-filter and auto-filter options when their marker attrs are absent", () => {
+  document.body.innerHTML = `<svg id="map"><g id="armies" font-size="8"></g><g id="gridOverlay"></g><g id="sea_island"></g></svg>`;
+  styles.military.options.boxSize = 4;
+  styles.military.options.fontSize = 8;
+  styles.grid.options.scale = 2;
+  styles.map.options.dataFilter = "sepia";
+  styles.coastline.sea_island.options.autoFilter = 0;
+  syncStylesFromMap();
+  expect(styles.military.options.boxSize).toBe(4);
+  expect(styles.grid.options.scale).toBe(2);
+  expect(styles.map.options.dataFilter).toBe("sepia");
+  expect(styles.coastline.sea_island.options.autoFilter).toBe(0);
+});
+
+test("save sync lets an old map's armies, grid, map-filter and auto-filter attrs win", () => {
+  document.body.innerHTML = `<svg id="map" data-filter="tint"><g id="armies" box-size="5" font-size="10"></g><g id="gridOverlay" type="square" scale="3" dx="1" dy="2"></g><g id="sea_island" auto-filter="1"></g></svg>`;
+  styles.military.options.boxSize = 4;
+  styles.grid.options.scale = 2;
+  styles.map.options.dataFilter = null;
+  styles.coastline.sea_island.options.autoFilter = 0;
+  syncStylesFromMap();
+  expect(styles.military.options.boxSize).toBe(5);
+  expect(styles.grid.options).toEqual({ type: "square", scale: 3, dx: 1, dy: 2 });
+  expect(styles.map.options.dataFilter).toBe("tint");
+  expect(styles.coastline.sea_island.options.autoFilter).toBe(1);
+});
+
 test("save sync lets an old map's coordinates data-size win over the store", () => {
   document.body.innerHTML = `<svg id="map"><g id="coordinates" data-size="14"></g></svg>`;
   styles.coordinates.options.fontSize = 20;

--- a/src/generators/styles-legacy.ts
+++ b/src/generators/styles-legacy.ts
@@ -407,6 +407,14 @@ export function syncStylesFromMap(): void {
     if (!document.getElementById(key)?.hasAttribute("scheme"))
       harvested.heightmap[key].options = structuredClone(styles.heightmap[key].options);
   }
+  if (!document.getElementById("armies")?.hasAttribute("box-size"))
+    harvested.military.options = structuredClone(styles.military.options);
+  if (!document.getElementById("gridOverlay")?.hasAttribute("type"))
+    harvested.grid.options = structuredClone(styles.grid.options);
+  if (!document.getElementById("map")?.hasAttribute("data-filter"))
+    harvested.map.options.dataFilter = styles.map.options.dataFilter;
+  if (!document.getElementById("sea_island")?.hasAttribute("auto-filter"))
+    harvested.coastline.sea_island.options.autoFilter = styles.coastline.sea_island.options.autoFilter;
   Styles.set(harvested);
 }
 

--- a/src/renderers/draw-grid.ts
+++ b/src/renderers/draw-grid.ts
@@ -5,10 +5,8 @@ export function drawGrid(): void {
   const gridOverlay = select(ensureEl<SVGGElement>("gridOverlay"));
   gridOverlay.selectAll("*").remove();
 
-  const pattern = `#pattern_${gridOverlay.attr("type") || "pointyHex"}`;
-  const scale = gridOverlay.attr("scale") || 1;
-  const dx = gridOverlay.attr("dx") || 0;
-  const dy = gridOverlay.attr("dy") || 0;
+  const { type, scale, dx, dy } = styles.grid.options;
+  const pattern = `#pattern_${type || "pointyHex"}`;
 
   select(pattern)
     .attr("stroke", gridOverlay.attr("stroke") || "#808080")

--- a/src/renderers/draw-military.ts
+++ b/src/renderers/draw-military.ts
@@ -6,6 +6,8 @@ export const drawMilitary = (): void => {
   TIME && console.time("drawMilitary");
 
   select<SVGGElement, unknown>("#armies").selectAll("g").remove();
+  // regiment labels size by inheritance from the group
+  select<SVGGElement, unknown>("#armies").attr("font-size", styles.military.options.fontSize);
   for (const state of pack.states) {
     if (!state.i || state.removed) continue;
     drawRegimentsRenderer(state.military || [], state.i);
@@ -15,7 +17,7 @@ export const drawMilitary = (): void => {
 };
 
 const drawRegimentsRenderer = (regiments: Regiment[], s: number): void => {
-  const size = +select<SVGGElement, unknown>("#armies").attr("box-size");
+  const size = styles.military.options.boxSize;
   const w = (d: Regiment) => (d.n ? size * 4 : size * 6);
   const h = size * 2;
   const x = (d: Regiment) => rn(d.x - w(d) / 2, 2);
@@ -73,7 +75,7 @@ const drawRegimentsRenderer = (regiments: Regiment[], s: number): void => {
 };
 
 export const drawRegiment = (reg: Regiment, stateId: number): void => {
-  const size = +select<SVGGElement, unknown>("#armies").attr("box-size");
+  const size = styles.military.options.boxSize;
   const w = reg.n ? size * 4 : size * 6;
   const h = size * 2;
   const x1 = rn(reg.x - w / 2, 2);
@@ -136,7 +138,7 @@ export const moveRegiment = (reg: Regiment, x: number, y: number): void => {
   const duration = Math.hypot(reg.x - x, reg.y - y) * 8;
   reg.x = x;
   reg.y = y;
-  const size = +select<SVGGElement, unknown>("#armies").attr("box-size");
+  const size = styles.military.options.boxSize;
   const w = reg.n ? size * 4 : size * 6;
   const h = size * 2;
   const x1 = (x: number) => rn(x - w / 2, 2);

--- a/src/services/io/auto-update.ts
+++ b/src/services/io/auto-update.ts
@@ -1887,4 +1887,8 @@ export async function resolveVersionConflicts(mapVersion: string, data: string[]
     }
   }
   document.getElementById("oceanHeights")?.removeAttribute("data-render");
+  document.getElementById("armies")?.removeAttribute("box-size");
+  for (const attr of ["type", "scale", "dx", "dy"]) document.getElementById("gridOverlay")?.removeAttribute(attr);
+  document.getElementById("map")?.removeAttribute("data-filter");
+  document.getElementById("sea_island")?.removeAttribute("auto-filter");
 }

--- a/tests/e2e/style-editor-events.spec.ts
+++ b/tests/e2e/style-editor-events.spec.ts
@@ -13,7 +13,7 @@ const waitForMap = (page: Page) =>
 
 const rn = (v: number, d = 0): number => Math.round(v * 10 ** d) / 10 ** d;
 
-async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates" | "ruler" | "legend" | "emblems" | "goodsIcons" | "goodsBurgs" | "markets" | "terrs"): Promise<void> {
+async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates" | "ruler" | "legend" | "emblems" | "goodsIcons" | "goodsBurgs" | "markets" | "terrs" | "armies" | "gridOverlay"): Promise<void> {
   await page.evaluate(() => (window as any).showOptions());
   await page.locator("#styleTab").click();
   await page.locator("#styleElementSelect").selectOption(element);
@@ -290,5 +290,68 @@ test.describe("style editor events drive the store", () => {
         expect(await page.locator(id).getAttribute(attr), `${id} ${attr}`).toBeNull();
       }
     }
+  });
+
+  test("armies size input writes the store and the renderer derives from it", async ({ page }) => {
+    await page.evaluate(() => (window as any).Layers.show("military"));
+    await openStyleElement(page, "armies");
+
+    await page.locator("#styleArmiesSize input[type=number]").fill("4");
+
+    const stored = await page.evaluate(() => ({
+      boxSize: (window as any).styles.military.options.boxSize,
+      fontSize: (window as any).styles.military.options.fontSize
+    }));
+    expect(stored).toEqual({ boxSize: 4, fontSize: 8 });
+
+    // renderer derives from the store: a regiment box is 2x boxSize tall
+    const boxHeight = await page.locator("#armies > g > g rect").first().getAttribute("height");
+    expect(Number(boxHeight)).toBe(8);
+
+    expect(await page.locator("#armies").getAttribute("box-size")).toBeNull();
+    // font-size is renderer-stamped from the store (regiment labels size by inheritance)
+    expect(await page.locator("#armies").getAttribute("font-size")).toBe("8");
+  });
+
+  test("grid controls write the store and restyle the pattern", async ({ page }) => {
+    await page.evaluate(() => (window as any).Layers.show("grid"));
+    await openStyleElement(page, "gridOverlay");
+
+    await page.locator("#styleGridType").selectOption("pointyHex");
+    for (const [input, value] of [
+      ["#styleGridScale", "2"],
+      ["#styleGridShiftX", "10"],
+      ["#styleGridShiftY", "5"]
+    ] as const) {
+      await page.locator(input).fill(value);
+      await page.locator(input).dispatchEvent("input");
+    }
+
+    const stored = await page.evaluate(() => (window as any).styles.grid.options);
+    expect(stored).toEqual({ type: "pointyHex", scale: 2, dx: 10, dy: 5 });
+
+    await expect(page.locator("#pattern_pointyHex")).toHaveAttribute(
+      "patternTransform",
+      "scale(2) translate(10 5)"
+    );
+
+    for (const attr of ["type", "scale", "dx", "dy"]) {
+      expect(await page.locator("#gridOverlay").getAttribute(attr), attr).toBeNull();
+    }
+  });
+
+  test("map filter buttons write the store and only the filter attr lands on #map", async ({ page }) => {
+    await page.evaluate(() => (window as any).showOptions());
+    await page.locator("#styleTab").click();
+    await page.locator("#mapFilters #sepia").click();
+
+    expect(await page.evaluate(() => (window as any).styles.map.options.dataFilter)).toBe("sepia");
+    expect(await page.locator("#map").getAttribute("filter")).toBe("url(#filter-sepia)");
+    expect(await page.locator("#map").getAttribute("data-filter")).toBeNull();
+
+    // toggling off clears the store
+    await page.locator("#mapFilters #sepia").click();
+    expect(await page.evaluate(() => (window as any).styles.map.options.dataFilter)).toBeNull();
+    expect(await page.locator("#map").getAttribute("filter")).toBeNull();
   });
 });

--- a/tests/e2e/style-persistence.spec.ts
+++ b/tests/e2e/style-persistence.spec.ts
@@ -211,7 +211,10 @@ test.describe("style persistence round trips", () => {
       .replace('<g id="goodsBurgs"', '<g id="goodsBurgs" data-size="66"')
       .replace('<g id="markets"', '<g id="markets" data-size="66"')
       .replace('<g id="landHeights"', '<g id="landHeights" scheme="olive" terracing="2" skip="1" relax="1" curve="curveLinear"')
-      .replace('<g id="oceanHeights"', '<g id="oceanHeights" scheme="bright" terracing="0" skip="0" relax="0" curve="curveBasisClosed" data-render="1"');
+      .replace('<g id="oceanHeights"', '<g id="oceanHeights" scheme="bright" terracing="0" skip="0" relax="0" curve="curveBasisClosed" data-render="1"')
+      .replace('<g id="armies"', '<g id="armies" box-size="9"')
+      .replace('<g id="gridOverlay"', '<g id="gridOverlay" type="square" scale="9" dx="9" dy="9"')
+      .replace('<g id="sea_island"', '<g id="sea_island" auto-filter="0"');
     const staleBuffer = Buffer.from(lines.join("\r\n"), "utf8");
 
     await reload(page, staleBuffer, "style-persistence-step4-era-reloaded");
@@ -231,6 +234,13 @@ test.describe("style persistence round trips", () => {
       ),
       oceanRenderAttr: document.getElementById("oceanHeights")?.getAttribute("data-render"),
       landScheme: styles.heightmap.landHeights.options.scheme,
+      smallFamilyAttrs: [
+        document.getElementById("armies")?.getAttribute("box-size"),
+        document.getElementById("gridOverlay")?.getAttribute("type"),
+        document.getElementById("gridOverlay")?.getAttribute("scale"),
+        document.getElementById("sea_island")?.getAttribute("auto-filter")
+      ],
+      gridScale: styles.grid.options.scale,
       rescale: styles.markers.options.rescale,
       haloWidth: styles.states.statesHalo.options.width,
       coordinatesSize: styles.coordinates.options.fontSize
@@ -248,6 +258,8 @@ test.describe("style persistence round trips", () => {
     expect(afterLoad.oceanRenderAttr).toBeNull();
     // the record's own scheme won, not the stale injected attr
     expect(afterLoad.landScheme).not.toBe("olive");
+    expect(afterLoad.smallFamilyAttrs).toEqual([null, null, null, null]);
+    expect(afterLoad.gridScale).toBe(1);
     expect(afterLoad.rescale).toBe(1);
     expect(afterLoad.haloWidth).toBe(10);
     expect(afterLoad.coordinatesSize).toBe(12);

--- a/tests/e2e/style-presets.spec.ts
+++ b/tests/e2e/style-presets.spec.ts
@@ -140,6 +140,8 @@ test("a saved custom preset carries the retired sizes from the store", async ({p
     styles.markets.options.size = 8;
     styles.heightmap.landHeights.options.terracing = 5;
     styles.heightmap.oceanHeights.options.render = true;
+    styles.military.options.boxSize = 4;
+    styles.grid.options.scale = 2;
     (window as any).addStylePreset();
   });
 
@@ -155,7 +157,9 @@ test("a saved custom preset carries the retired sizes from the store", async ({p
       goodsBurgs: upgraded.goods.goodsBurgs.options.size,
       markets: upgraded.markets.options.size,
       landTerracing: upgraded.heightmap.landHeights.options.terracing,
-      oceanRender: upgraded.heightmap.oceanHeights.options.render
+      oceanRender: upgraded.heightmap.oceanHeights.options.render,
+      armiesBox: upgraded.military.options.boxSize,
+      gridScale: upgraded.grid.options.scale
     };
   }, raw);
 
@@ -168,6 +172,8 @@ test("a saved custom preset carries the retired sizes from the store", async ({p
     goodsBurgs: 7,
     markets: 8,
     landTerracing: 5,
-    oceanRender: true
+    oceanRender: true,
+    armiesBox: 4,
+    gridScale: 2
   });
 });

--- a/tests/fixtures/style-baseline-generated.json
+++ b/tests/fixtures/style-baseline-generated.json
@@ -8,8 +8,6 @@
     "fill-opacity": "1",
     "stroke": "#000",
     "stroke-width": "0.3",
-    "font-size": "6",
-    "box-size": "3",
     "style": "display: none;"
   },
   "#anchors": {},
@@ -104,10 +102,6 @@
     "opacity": "0.8",
     "stroke": "#777777",
     "stroke-width": "0.5",
-    "type": "pointyHex",
-    "scale": "1",
-    "dx": "0",
-    "dy": "0",
     "style": "display: none;"
   },
   "#ice": {

--- a/tests/fixtures/style-baseline.json
+++ b/tests/fixtures/style-baseline.json
@@ -9,7 +9,6 @@
     "stroke": "#000000",
     "stroke-width": "0.6",
     "font-size": "8",
-    "box-size": "4",
     "style": "display: none;"
   },
   "#anchors": {},
@@ -110,10 +109,6 @@
     "opacity": "0.8",
     "stroke": "#808080",
     "stroke-width": "0.5",
-    "type": "pointyHex",
-    "scale": "1",
-    "dx": "0",
-    "dy": "0",
     "style": "display: none;"
   },
   "#ice": {


### PR DESCRIPTION
Four small step-5 families (docs/prd/style-migration.md) in one pass — each with its own authority gate, load-time strip, and saver overlay.

| Selector | Store home | Retired |
|---|---|---|
| #armies | `military.options.{boxSize,fontSize}` | box-size (font-size becomes renderer-stamped) |
| #gridOverlay | `grid.options.{type,scale,dx,dy}` | all four |
| #map | `map.options.dataFilter` | data-filter (the `filter` attr stays — it is the presentation) |
| #sea_island | `coastline.sea_island.options.autoFilter` | auto-filter |

## Behavior notes

- **auto-filter is dead cargo**: nothing at runtime reads it anymore — the zoom-driven coastline filter pick it once fed no longer exists. The attr and projection row are removed; the store option and the upgrader route stay so old files and presets keep converting.
- **#armies mirrors the legend**: regiment labels size by group font-size inheritance, so drawMilitary stamps font-size from the store on every draw; only box-size is stripped. The regiment editor's three drag-geometry reads move to the store too.
- **Map filter**: the filter buttons write the store option plus the real `filter` attr; the pressed-button restore reads the store instead of the retired attr.
- Gates: whole-bag for military (keyed on box-size) and grid (keyed on type); per-key for map dataFilter and coastline autoFilter.

## Verification

- Three new real-control e2e tests: armies (regiment box height derives from the store), grid (patternTransform from store values), map filter toggle on/off.
- Authority-gate browser tests and the step-4-era strip regression extended — each RED-verified against the code without the change.
- Style Saver round-trip extended (boxSize + grid scale survive the legacy dialect).
- Parity baselines shrink by exactly the family attrs, proven mechanically; the generated baseline also loses #armies' font-size (renderer-stamped, military layer not drawn at generation) while the loaded baseline keeps it — the same asymmetry class as coordinates/legend.
- tsc, biome, 449 unit + 26 browser tests, full Playwright suite 164/164; manual validation of all four families including old-map round trips.