### PR TITLE
Style migration step 5: markets icon/size, goods circle, texture and ocean outline move off the DOM

### DIFF
--- a/public/modules/ui/style-presets.js
+++ b/public/modules/ui/style-presets.js
@@ -132,12 +132,6 @@ function writeAttrsById(id, attrs) {
 function projectPresetOptions() {
   const byId = id => document.getElementById(id);
 
-  setOrRemove(byId("goodsIcons"), "data-circle", Number(styles.goods.goodsIcons.options.circle));
-
-  const markets = byId("markets");
-  setOrRemove(markets, "font-size", styles.markets.options.fontSize);
-  setOrRemove(markets, "data-icon", styles.markets.options.icon);
-
   const scaleBar = byId("scaleBar");
   setOrRemove(scaleBar, "data-bar-size", styles.scaleBar.options.barSize);
   setOrRemove(scaleBar, "data-x", styles.scaleBar.options.x);
@@ -167,20 +161,9 @@ function projectPresetOptions() {
   setOrRemove(vignetteRect, "ry", styles.vignette.options.ry);
   setOrRemove(vignetteRect, "filter", styles.vignette.options.filter);
 
-  setOrRemove(byId("oceanLayers"), "layers", styles.ocean.oceanLayers.options.outline);
-
   const oceanicPattern = byId("oceanicPattern");
   setOrRemove(oceanicPattern, "href", styles.ocean.options.pattern);
   setOrRemove(oceanicPattern, "opacity", styles.ocean.options.patternOpacity);
-
-  const texture = byId("texture");
-  setOrRemove(texture, "data-href", styles.texture.options.href);
-  setOrRemove(texture, "data-x", styles.texture.options.x);
-  setOrRemove(texture, "data-y", styles.texture.options.y);
-  const textureImage = texture ? texture.querySelector("image") : null;
-  setOrRemove(textureImage, "href", styles.texture.options.href);
-  setOrRemove(textureImage, "x", styles.texture.options.x);
-  setOrRemove(textureImage, "y", styles.texture.options.y);
 
   for (const [group, style] of Object.entries(styles.labels.groups)) {
     const el = document.querySelector(`#labels > [data-group="${CSS.escape(group)}"]`);
@@ -510,6 +493,18 @@ function addStylePreset() {
     if (presetStyle["#map"]) presetStyle["#map"]["data-filter"] = styles.map.options.dataFilter;
     if (presetStyle["#sea_island"])
       presetStyle["#sea_island"]["auto-filter"] = styles.coastline.sea_island.options.autoFilter;
+    if (presetStyle["#markets"]) {
+      presetStyle["#markets"]["font-size"] = styles.markets.options.fontSize;
+      presetStyle["#markets"]["data-icon"] = styles.markets.options.icon;
+    }
+    if (presetStyle["#goodsIcons"])
+      presetStyle["#goodsIcons"]["data-circle"] = Number(styles.goods.goodsIcons.options.circle);
+    if (presetStyle["#texture"]) {
+      presetStyle["#texture"]["data-href"] = styles.texture.options.href;
+      presetStyle["#texture"]["data-x"] = styles.texture.options.x;
+      presetStyle["#texture"]["data-y"] = styles.texture.options.y;
+    }
+    if (presetStyle["#oceanLayers"]) presetStyle["#oceanLayers"]["layers"] = styles.ocean.oceanLayers.options.outline;
 
     for (const [group, groupStyle] of Object.entries(styles.labels.groups)) {
       addStoredLabelStyle(`#labels > #${group}`, stylesLegacy.labelGroupToLegacy(groupStyle));

--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -1073,12 +1073,12 @@ styleMarketsLayerFillOpacity.addEventListener("input", e => {
   d3.select("#markets").attr("fill-opacity", e.target.value);
 });
 
-styleMarketsSize.addEventListener("change", function () {
+styleMarketsSize.addEventListener("input", function () {
   styles.markets.options.size = +this.value || 3;
   Layers.draw("markets");
 });
 
-styleMarketsIconSize.addEventListener("change", function () {
+styleMarketsIconSize.addEventListener("input", function () {
   styles.markets.options.fontSize = +this.value || 5;
   Layers.draw("markets");
 });

--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -1059,12 +1059,12 @@ styleGoodsCircle.addEventListener("change", function () {
   Layers.draw("goods");
 });
 
-styleGoodsSize.addEventListener("change", function () {
+styleGoodsSize.addEventListener("input", function () {
   styles.goods.goodsIcons.options.size = +this.value || 6;
   Layers.draw("goods");
 });
 
-styleGoodsBurgsSize.addEventListener("change", function () {
+styleGoodsBurgsSize.addEventListener("input", function () {
   styles.goods.goodsBurgs.options.size = +this.value || 3;
   Layers.draw("goods");
 });

--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -191,9 +191,9 @@ function selectStyleElement() {
   // show specific sections
   if (styleElement === "texture") {
     styleTexture.style.display = "block";
-    styleTextureShiftX.value = el.attr("data-x") || 0;
-    styleTextureShiftY.value = el.attr("data-y") || 0;
-    updateTextureSelectValue(el.attr("data-href"));
+    styleTextureShiftX.value = styles.texture.options.x;
+    styleTextureShiftY.value = styles.texture.options.y;
+    updateTextureSelectValue(styles.texture.options.href);
   }
 
   if (styleElement === "terrs") {
@@ -342,7 +342,7 @@ function selectStyleElement() {
     styleOceanFill.value = styleOceanFillOutput.value = d3.select("#oceanLayers").select("#oceanBase").attr("fill");
     styleOceanPattern.value = ensureEl("oceanicPattern").getAttribute("href");
     styleOceanPatternOpacity.value = ensureEl("oceanicPattern").getAttribute("opacity") || 1;
-    outlineLayers.value = d3.select("#oceanLayers").attr("layers");
+    outlineLayers.value = styles.ocean.oceanLayers.options.outline;
   }
 
   if (styleElement === "temperature") {
@@ -392,7 +392,7 @@ function selectStyleElement() {
     styleStrokeWidth.style.display = "block";
     styleStrokeWidthInput.value = el.attr("stroke-width") || "";
     styleGoods.style.display = "block";
-    styleGoodsCircle.checked = +el.attr("data-circle");
+    styleGoodsCircle.checked = styles.goods.goodsIcons.options.circle;
     styleGoodsSize.value = styles.goods.goodsIcons.options.size;
   }
 
@@ -411,8 +411,8 @@ function selectStyleElement() {
     styleMarketsLayer.style.display = "block";
     styleMarketsLayerFillOpacity.value = el.attr("fill-opacity") || "0";
     styleMarketsSize.value = styles.markets.options.size;
-    styleMarketsIconSize.value = el.attr("font-size") || 5;
-    styleMarketsIcon.innerHTML = el.attr("data-icon") || "⚖️";
+    styleMarketsIconSize.value = styles.markets.options.fontSize;
+    styleMarketsIcon.innerHTML = styles.markets.options.icon;
   }
 
   // update group options
@@ -566,8 +566,8 @@ styleTextureInput.addEventListener("change", function () {
 });
 
 function changeTexture(href) {
-  d3.select("#texture").attr("data-href", href);
-  d3.select("#texture").select("image").attr("href", href);
+  styles.texture.options.href = href;
+  Layers.draw("texture");
 }
 
 function updateTextureSelectValue(href) {
@@ -581,19 +581,13 @@ function updateTextureSelectValue(href) {
 }
 
 styleTextureShiftX.addEventListener("input", function () {
-  d3.select("#texture").attr("data-x", this.value);
-  d3.select("#texture")
-    .select("image")
-    .attr("x", this.value)
-    .attr("width", graphWidth - this.valueAsNumber);
+  styles.texture.options.x = this.valueAsNumber || 0;
+  Layers.draw("texture");
 });
 
 styleTextureShiftY.addEventListener("input", function () {
-  d3.select("#texture").attr("data-y", this.value);
-  d3.select("#texture")
-    .select("image")
-    .attr("y", this.value)
-    .attr("height", graphHeight - this.valueAsNumber);
+  styles.texture.options.y = this.valueAsNumber || 0;
+  Layers.draw("texture");
 });
 
 styleClippingInput.addEventListener("change", function () {
@@ -647,7 +641,7 @@ styleOceanPatternOpacity.addEventListener("input", e => {
 });
 
 outlineLayers.addEventListener("change", function () {
-  d3.select("#oceanLayers").attr("layers", this.value);
+  styles.ocean.oceanLayers.options.outline = this.value;
   Layers.draw("ocean");
 });
 
@@ -1061,7 +1055,7 @@ showAllEmblems.addEventListener("change", e => {
 });
 
 styleGoodsCircle.addEventListener("change", function () {
-  d3.select("#goods").select("#goodsIcons").attr("data-circle", +this.checked);
+  styles.goods.goodsIcons.options.circle = this.checked;
   Layers.draw("goods");
 });
 
@@ -1085,13 +1079,13 @@ styleMarketsSize.addEventListener("change", function () {
 });
 
 styleMarketsIconSize.addEventListener("change", function () {
-  d3.select("#markets").attr("font-size", this.value);
+  styles.markets.options.fontSize = +this.value || 5;
   Layers.draw("markets");
 });
 
 styleMarketsIcon.addEventListener("click", function () {
-  window.Controllers.IconSelector.open(d3.select("#markets").attr("data-icon") || "⚖️", value => {
-    d3.select("#markets").attr("data-icon", value);
+  window.Controllers.IconSelector.open(styles.markets.options.icon, value => {
+    styles.markets.options.icon = value;
     this.innerHTML = value;
     Layers.draw("markets");
   });

--- a/src/generators/styles-legacy.dom.test.ts
+++ b/src/generators/styles-legacy.dom.test.ts
@@ -198,6 +198,35 @@ test("save sync lets an old map's armies, grid, map-filter and auto-filter attrs
   expect(styles.coastline.sea_island.options.autoFilter).toBe(1);
 });
 
+test("save sync keeps store markets, goods-circle, texture and ocean-outline options when their attrs are absent", () => {
+  document.body.innerHTML = `<svg id="map"><g id="markets"></g><g id="goods"><g id="goodsIcons"></g></g><g id="texture"></g><g id="oceanLayers"></g></svg>`;
+  styles.markets.options.fontSize = 11;
+  styles.markets.options.icon = "X";
+  styles.goods.goodsIcons.options.circle = false;
+  styles.texture.options.x = 40;
+  styles.ocean.oceanLayers.options.outline = "-6,-4,-2";
+  syncStylesFromMap();
+  expect(styles.markets.options.fontSize).toBe(11);
+  expect(styles.markets.options.icon).toBe("X");
+  expect(styles.goods.goodsIcons.options.circle).toBe(false);
+  expect(styles.texture.options.x).toBe(40);
+  expect(styles.ocean.oceanLayers.options.outline).toBe("-6,-4,-2");
+});
+
+test("save sync lets an old map's markets, goods-circle, texture and ocean-outline attrs win", () => {
+  document.body.innerHTML = `<svg id="map"><g id="markets" data-size="3" font-size="7" data-icon="Y"></g><g id="goods"><g id="goodsIcons" data-circle="1"></g></g><g id="texture" data-href="./t.jpg" data-x="5" data-y="6"></g><g id="oceanLayers" layers="-6"></g></svg>`;
+  styles.markets.options.fontSize = 11;
+  styles.goods.goodsIcons.options.circle = false;
+  styles.texture.options.x = 40;
+  styles.ocean.oceanLayers.options.outline = "-6,-4,-2";
+  syncStylesFromMap();
+  expect(styles.markets.options.fontSize).toBe(7);
+  expect(styles.markets.options.icon).toBe("Y");
+  expect(styles.goods.goodsIcons.options.circle).toBe(true);
+  expect(styles.texture.options).toEqual({ href: "./t.jpg", x: 5, y: 6 });
+  expect(styles.ocean.oceanLayers.options.outline).toBe("-6");
+});
+
 test("save sync lets an old map's coordinates data-size win over the store", () => {
   document.body.innerHTML = `<svg id="map"><g id="coordinates" data-size="14"></g></svg>`;
   styles.coordinates.options.fontSize = 20;

--- a/src/generators/styles-legacy.test.ts
+++ b/src/generators/styles-legacy.test.ts
@@ -97,6 +97,16 @@ test("R9: #terrs > #landHeights never legitimately carried data-render, so it st
   ).toBe(false);
 });
 
+test("numeric-looking string options coerce back to strings, not schema-rejected numbers", () => {
+  const styles = presetFromLegacy(
+    { "#oceanLayers": { layers: -6 }, "#scaleBar": { "data-label": 100 }, "#markets": { "data-icon": 8 } } as any,
+    { onUnknown: "skip" }
+  );
+  expect(styles.ocean.oceanLayers.options.outline).toBe("-6");
+  expect(styles.scaleBar.options.label).toBe("100");
+  expect(styles.markets.options.icon).toBe("8");
+});
+
 test("labelGroupFromLegacy keeps font-size when data-size is absent", () => {
   const group = labelGroupFromLegacy({ "font-size": "6%" });
   expect(group.attrs["font-size"]).toBe("6%");

--- a/src/generators/styles-legacy.ts
+++ b/src/generators/styles-legacy.ts
@@ -122,6 +122,9 @@ type PresetRoute = {
   path: string[];
   options?: Record<string, string>;
   bools?: string[];
+  // options that must stay strings: the DOM harvest and legacy preset saver numify
+  // numeric-looking values ("-6", "100"), which the string schema would reject
+  strings?: string[];
   kind?: "label" | "burg";
   drop?: string[];
   ownAttrs?: boolean;
@@ -201,13 +204,18 @@ const PRESET_ROUTES: Record<string, PresetRoute> = {
     bools: ["circle"]
   },
   "#goodsBurgs": { path: ["goods", "goodsBurgs"], options: { "data-size": "size" } },
-  "#markets": { path: ["markets"], options: { "data-size": "size", "font-size": "fontSize", "data-icon": "icon" } },
+  "#markets": {
+    path: ["markets"],
+    options: { "data-size": "size", "font-size": "fontSize", "data-icon": "icon" },
+    strings: ["icon"]
+  },
   "#tradeAnimation": { path: ["trade"] },
   "#markers": { path: ["markers"], options: { rescale: "rescale" } },
   "#ruler": { path: ["rulers"], options: { "data-size": "fontSize", "font-size": "fontSize" } },
   "#scaleBar": {
     path: ["scaleBar"],
-    options: { "data-bar-size": "barSize", "data-x": "x", "data-y": "y", "data-label": "label" }
+    options: { "data-bar-size": "barSize", "data-x": "x", "data-y": "y", "data-label": "label" },
+    strings: ["label"]
   },
   "#scaleBarBack": {
     path: ["scaleBar", "back"],
@@ -231,7 +239,7 @@ const PRESET_ROUTES: Record<string, PresetRoute> = {
     options: { x: "x", y: "y", width: "width", height: "height", rx: "rx", ry: "ry", filter: "filter" },
     ownAttrs: false
   },
-  "#oceanLayers": { path: ["ocean", "oceanLayers"], options: { layers: "outline" } },
+  "#oceanLayers": { path: ["ocean", "oceanLayers"], options: { layers: "outline" }, strings: ["outline"] },
   "#oceanBase": { path: ["ocean", "base"] },
   "#oceanicPattern": { path: ["ocean"], options: { href: "pattern", opacity: "patternOpacity" } },
   "#landmass": { path: ["landmass"] }
@@ -280,7 +288,11 @@ function applyPresetBag(
       continue;
     }
     seen[optionKey] = value;
-    node.options[optionKey] = route.bools?.includes(optionKey) ? Boolean(Number(value)) : value;
+    node.options[optionKey] = route.bools?.includes(optionKey)
+      ? Boolean(Number(value))
+      : route.strings?.includes(optionKey) && value != null
+        ? String(value)
+        : value;
   }
 
   if (node.attrs && route.ownAttrs !== false) {
@@ -415,6 +427,16 @@ export function syncStylesFromMap(): void {
     harvested.map.options.dataFilter = styles.map.options.dataFilter;
   if (!document.getElementById("sea_island")?.hasAttribute("auto-filter"))
     harvested.coastline.sea_island.options.autoFilter = styles.coastline.sea_island.options.autoFilter;
+  if (!document.getElementById("markets")?.hasAttribute("font-size"))
+    harvested.markets.options.fontSize = styles.markets.options.fontSize;
+  if (!document.getElementById("markets")?.hasAttribute("data-icon"))
+    harvested.markets.options.icon = styles.markets.options.icon;
+  if (!document.getElementById("goodsIcons")?.hasAttribute("data-circle"))
+    harvested.goods.goodsIcons.options.circle = styles.goods.goodsIcons.options.circle;
+  if (!document.getElementById("texture")?.hasAttribute("data-href"))
+    harvested.texture.options = structuredClone(styles.texture.options);
+  if (!document.getElementById("oceanLayers")?.hasAttribute("layers"))
+    harvested.ocean.oceanLayers.options.outline = styles.ocean.oceanLayers.options.outline;
   Styles.set(harvested);
 }
 

--- a/src/renderers/draw-goods.ts
+++ b/src/renderers/draw-goods.ts
@@ -65,8 +65,7 @@ function buildGoodsCellsContent(displayedGoods: Set<number>): string {
 function buildGoodsIconsContent(displayedGoods: Set<number>): string {
   if (!displayedGoods.size || !pack.cells.good) return "";
 
-  const iconsGroup = select("#goods").select("#goodsIcons");
-  const drawCircle = +iconsGroup.attr("data-circle");
+  const drawCircle = styles.goods.goodsIcons.options.circle;
   const iconSize = styles.goods.goodsIcons.options.size;
   const half = iconSize / 2;
   let html = "";

--- a/src/renderers/draw-markets.ts
+++ b/src/renderers/draw-markets.ts
@@ -9,9 +9,6 @@ export function drawMarkets() {
   TIME && console.timeEnd("drawMarkets");
 }
 
-const MARKET_FONT = 5;
-const MARKET_ICON = "⚖️";
-
 function buildMarketsContent(): string {
   const linegen = line().curve(curveBasisClosed);
   const getType = (cellId: number) => pack.cells.market[cellId];
@@ -19,8 +16,8 @@ function buildMarketsContent(): string {
 
   // marker circle size, emoji size and emoji icon are independently user-configurable
   const baseRadius = styles.markets.options.size;
-  const baseFont = +select("#markets").attr("font-size") || MARKET_FONT;
-  const icon = select("#markets").attr("data-icon") || MARKET_ICON;
+  const baseFont = styles.markets.options.fontSize;
+  const icon = styles.markets.options.icon;
 
   return pack.markets
     .map(market => {

--- a/src/renderers/draw-ocean.ts
+++ b/src/renderers/draw-ocean.ts
@@ -7,7 +7,7 @@ export function drawOcean(): void {
   const oceanLayers = ensureEl<SVGGElement>("oceanLayers");
   removeOcean();
 
-  const limits = Ocean.getLimits(oceanLayers.getAttribute("layers") ?? "");
+  const limits = Ocean.getLimits(styles.ocean.oceanLayers.options.outline);
   if (!limits.length) return;
 
   TIME && console.time("drawOcean");

--- a/src/renderers/draw-texture.ts
+++ b/src/renderers/draw-texture.ts
@@ -2,11 +2,8 @@ import type { Layer } from "@/components/layers";
 
 export function drawTexture(layer: Layer): void {
   const element = layer.getEl();
-  const href = element.getAttribute("data-href");
+  const { href, x, y } = styles.texture.options;
   if (!href) return void element.replaceChildren();
-
-  const x = Number(element.getAttribute("data-x") || 0);
-  const y = Number(element.getAttribute("data-y") || 0);
 
   element.innerHTML = /* html */ `<image preserveAspectRatio="xMidYMid slice"
     x="${x}" y="${y}" width="${graphWidth - x}" height="${graphHeight - y}" href="${href}"></image>`;

--- a/src/services/io/auto-update.ts
+++ b/src/services/io/auto-update.ts
@@ -1891,4 +1891,9 @@ export async function resolveVersionConflicts(mapVersion: string, data: string[]
   for (const attr of ["type", "scale", "dx", "dy"]) document.getElementById("gridOverlay")?.removeAttribute(attr);
   document.getElementById("map")?.removeAttribute("data-filter");
   document.getElementById("sea_island")?.removeAttribute("auto-filter");
+  document.getElementById("markets")?.removeAttribute("font-size");
+  document.getElementById("markets")?.removeAttribute("data-icon");
+  document.getElementById("goodsIcons")?.removeAttribute("data-circle");
+  for (const attr of ["data-href", "data-x", "data-y"]) document.getElementById("texture")?.removeAttribute(attr);
+  document.getElementById("oceanLayers")?.removeAttribute("layers");
 }

--- a/src/services/io/load.ts
+++ b/src/services/io/load.ts
@@ -466,7 +466,7 @@ async function parseLoadedData(data: string[], mapVersion: string | null): Promi
 
     {
       // add custom texture if any
-      const textureHref = select("#texture").attr("data-href");
+      const textureHref = styles.texture.options.href;
       if (textureHref) updateTextureSelectValue(textureHref);
     }
 

--- a/tests/e2e/style-editor-events.spec.ts
+++ b/tests/e2e/style-editor-events.spec.ts
@@ -13,7 +13,7 @@ const waitForMap = (page: Page) =>
 
 const rn = (v: number, d = 0): number => Math.round(v * 10 ** d) / 10 ** d;
 
-async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates" | "ruler" | "legend" | "emblems" | "goodsIcons" | "goodsBurgs" | "markets" | "terrs" | "armies" | "gridOverlay"): Promise<void> {
+async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates" | "ruler" | "legend" | "emblems" | "goodsIcons" | "goodsBurgs" | "markets" | "terrs" | "armies" | "gridOverlay" | "texture" | "ocean"): Promise<void> {
   await page.evaluate(() => (window as any).showOptions());
   await page.locator("#styleTab").click();
   await page.locator("#styleElementSelect").selectOption(element);
@@ -243,9 +243,10 @@ test.describe("style editor events drive the store", () => {
     expect(stored).toBe(6);
     expect(typeof stored).toBe("number");
 
-    // fontSize and icon are not in this family: their attrs must survive on the element
-    expect(await page.locator("#markets").getAttribute("data-size")).toBeNull();
-    expect(await page.locator("#markets").getAttribute("font-size")).not.toBeNull();
+    // the whole markets option family is off the DOM now
+    for (const attr of ["data-size", "font-size", "data-icon"]) {
+      expect(await page.locator("#markets").getAttribute(attr), attr).toBeNull();
+    }
   });
 
   test("heightmap controls write the store per group and the renderer derives from it", async ({ page }) => {
@@ -353,5 +354,59 @@ test.describe("style editor events drive the store", () => {
     await page.locator("#mapFilters #sepia").click();
     expect(await page.evaluate(() => (window as any).styles.map.options.dataFilter)).toBeNull();
     expect(await page.locator("#map").getAttribute("filter")).toBeNull();
+  });
+
+  test("markets icon size and goods circle write the store and drive the renderer", async ({ page }) => {
+    await page.evaluate(() => {
+      (window as any).Layers.show("goods");
+      (window as any).Layers.show("markets");
+    });
+
+    await openStyleElement(page, "markets");
+    await page.locator("#styleMarketsIconSize input[type=number]").fill("11");
+    await page.locator("#styleMarketsIconSize").dispatchEvent("change");
+
+    expect(await page.evaluate(() => (window as any).styles.markets.options.fontSize)).toBe(11);
+    // drawn glyphs derive from the store base plus the zoom term (baseFont + 1/scale)
+    const scale = await currentScale(page);
+    const expectedFont = `${rn(11 + 1 / scale, 2)}px`;
+    await expect(page.locator("#markets text").first()).toHaveAttribute("font-size", expectedFont);
+    for (const attr of ["font-size", "data-icon", "data-size"]) {
+      expect(await page.locator("#markets").getAttribute(attr), attr).toBeNull();
+    }
+
+    await openStyleElement(page, "goodsIcons");
+    const before = await page.evaluate(() => (window as any).styles.goods.goodsIcons.options.circle);
+    await page.locator('label[for="styleGoodsCircle"]').click();
+    expect(await page.evaluate(() => (window as any).styles.goods.goodsIcons.options.circle)).toBe(!before);
+    expect(typeof (await page.evaluate(() => (window as any).styles.goods.goodsIcons.options.circle))).toBe("boolean");
+    expect(await page.locator("#goodsIcons").getAttribute("data-circle")).toBeNull();
+  });
+
+  test("texture controls write the store and the renderer rebuilds the image", async ({ page }) => {
+    await page.evaluate(() => (window as any).Layers.show("texture"));
+    await openStyleElement(page, "texture");
+
+    await page.locator("#styleTextureShiftX").fill("40");
+    await page.locator("#styleTextureShiftX").dispatchEvent("input");
+
+    const stored = await page.evaluate(() => (window as any).styles.texture.options);
+    expect(stored.x).toBe(40);
+    expect(typeof stored.href).toBe("string");
+
+    await expect(page.locator("#texture image")).toHaveAttribute("x", "40");
+    for (const attr of ["data-href", "data-x", "data-y"]) {
+      expect(await page.locator("#texture").getAttribute(attr), attr).toBeNull();
+    }
+  });
+
+  test("ocean outline select writes the store and redraws the layers", async ({ page }) => {
+    await openStyleElement(page, "ocean");
+
+    await page.locator("#outlineLayers").selectOption("-6,-4,-2");
+
+    expect(await page.evaluate(() => (window as any).styles.ocean.oceanLayers.options.outline)).toBe("-6,-4,-2");
+    expect(await page.locator("#oceanLayers").getAttribute("layers")).toBeNull();
+    expect(await page.evaluate(() => document.querySelectorAll("#oceanLayers > path").length)).toBe(3);
   });
 });

--- a/tests/e2e/style-editor-events.spec.ts
+++ b/tests/e2e/style-editor-events.spec.ts
@@ -216,11 +216,11 @@ test.describe("style editor events drive the store", () => {
     await openStyleElement(page, "goodsIcons");
 
     await page.locator("#styleGoodsSize input[type=number]").fill("9");
-    await page.locator("#styleGoodsSize").dispatchEvent("change");
+    await page.locator("#styleGoodsSize").dispatchEvent("input");
 
     await openStyleElement(page, "goodsBurgs");
     await page.locator("#styleGoodsBurgsSize input[type=number]").fill("7");
-    await page.locator("#styleGoodsBurgsSize").dispatchEvent("change");
+    await page.locator("#styleGoodsBurgsSize").dispatchEvent("input");
 
     const stored = await page.evaluate(() => ({
       icons: (window as any).styles.goods.goodsIcons.options.size,

--- a/tests/e2e/style-editor-events.spec.ts
+++ b/tests/e2e/style-editor-events.spec.ts
@@ -237,7 +237,7 @@ test.describe("style editor events drive the store", () => {
     await openStyleElement(page, "markets");
 
     await page.locator("#styleMarketsSize input[type=number]").fill("6");
-    await page.locator("#styleMarketsSize").dispatchEvent("change");
+    await page.locator("#styleMarketsSize").dispatchEvent("input");
 
     const stored = await page.evaluate(() => (window as any).styles.markets.options.size);
     expect(stored).toBe(6);
@@ -364,7 +364,7 @@ test.describe("style editor events drive the store", () => {
 
     await openStyleElement(page, "markets");
     await page.locator("#styleMarketsIconSize input[type=number]").fill("11");
-    await page.locator("#styleMarketsIconSize").dispatchEvent("change");
+    await page.locator("#styleMarketsIconSize").dispatchEvent("input");
 
     expect(await page.evaluate(() => (window as any).styles.markets.options.fontSize)).toBe(11);
     // drawn glyphs derive from the store base plus the zoom term (baseFont + 1/scale)

--- a/tests/e2e/style-persistence.spec.ts
+++ b/tests/e2e/style-persistence.spec.ts
@@ -214,7 +214,11 @@ test.describe("style persistence round trips", () => {
       .replace('<g id="oceanHeights"', '<g id="oceanHeights" scheme="bright" terracing="0" skip="0" relax="0" curve="curveBasisClosed" data-render="1"')
       .replace('<g id="armies"', '<g id="armies" box-size="9"')
       .replace('<g id="gridOverlay"', '<g id="gridOverlay" type="square" scale="9" dx="9" dy="9"')
-      .replace('<g id="sea_island"', '<g id="sea_island" auto-filter="0"');
+      .replace('<g id="sea_island"', '<g id="sea_island" auto-filter="0"')
+      .replace('<g id="markets"', '<g id="markets" font-size="66" data-icon="Z"')
+      .replace('<g id="goodsIcons"', '<g id="goodsIcons" data-circle="0"')
+      .replace('<g id="texture"', '<g id="texture" data-href="./z.jpg" data-x="66" data-y="66"')
+      .replace('<g id="oceanLayers"', '<g id="oceanLayers" layers="-6"');
     const staleBuffer = Buffer.from(lines.join("\r\n"), "utf8");
 
     await reload(page, staleBuffer, "style-persistence-step4-era-reloaded");
@@ -241,6 +245,14 @@ test.describe("style persistence round trips", () => {
         document.getElementById("sea_island")?.getAttribute("auto-filter")
       ],
       gridScale: styles.grid.options.scale,
+      contentAttrs: [
+        document.getElementById("markets")?.getAttribute("font-size"),
+        document.getElementById("markets")?.getAttribute("data-icon"),
+        document.getElementById("goodsIcons")?.getAttribute("data-circle"),
+        document.getElementById("texture")?.getAttribute("data-href"),
+        document.getElementById("oceanLayers")?.getAttribute("layers")
+      ],
+      oceanOutline: styles.ocean.oceanLayers.options.outline,
       rescale: styles.markers.options.rescale,
       haloWidth: styles.states.statesHalo.options.width,
       coordinatesSize: styles.coordinates.options.fontSize
@@ -260,6 +272,8 @@ test.describe("style persistence round trips", () => {
     expect(afterLoad.landScheme).not.toBe("olive");
     expect(afterLoad.smallFamilyAttrs).toEqual([null, null, null, null]);
     expect(afterLoad.gridScale).toBe(1);
+    expect(afterLoad.contentAttrs).toEqual([null, null, null, null, null]);
+    expect(afterLoad.oceanOutline).toBe("-6,-3,-1");
     expect(afterLoad.rescale).toBe(1);
     expect(afterLoad.haloWidth).toBe(10);
     expect(afterLoad.coordinatesSize).toBe(12);

--- a/tests/e2e/style-presets.spec.ts
+++ b/tests/e2e/style-presets.spec.ts
@@ -142,6 +142,9 @@ test("a saved custom preset carries the retired sizes from the store", async ({p
     styles.heightmap.oceanHeights.options.render = true;
     styles.military.options.boxSize = 4;
     styles.grid.options.scale = 2;
+    styles.markets.options.icon = "K";
+    styles.texture.options.x = 33;
+    styles.ocean.oceanLayers.options.outline = "-6,-4,-2";
     (window as any).addStylePreset();
   });
 
@@ -159,7 +162,10 @@ test("a saved custom preset carries the retired sizes from the store", async ({p
       landTerracing: upgraded.heightmap.landHeights.options.terracing,
       oceanRender: upgraded.heightmap.oceanHeights.options.render,
       armiesBox: upgraded.military.options.boxSize,
-      gridScale: upgraded.grid.options.scale
+      gridScale: upgraded.grid.options.scale,
+      marketsIcon: upgraded.markets.options.icon,
+      textureX: upgraded.texture.options.x,
+      oceanOutline: upgraded.ocean.oceanLayers.options.outline
     };
   }, raw);
 
@@ -174,6 +180,9 @@ test("a saved custom preset carries the retired sizes from the store", async ({p
     landTerracing: 5,
     oceanRender: true,
     armiesBox: 4,
-    gridScale: 2
+    gridScale: 2,
+    marketsIcon: "K",
+    textureX: 33,
+    oceanOutline: "-6,-4,-2"
   });
 });

--- a/tests/fixtures/style-baseline-generated.json
+++ b/tests/fixtures/style-baseline-generated.json
@@ -90,8 +90,7 @@
   "#goodsIcons": {
     "opacity": "1",
     "stroke-width": "0.3",
-    "filter": "url(#dropShadow01)",
-    "data-circle": "1"
+    "filter": "url(#dropShadow01)"
   },
   "#goodsBurgs": {
     "opacity": "1",
@@ -174,13 +173,9 @@
     "fill-opacity": "0.03",
     "stroke-width": "1",
     "stroke-opacity": "0.8",
-    "font-size": "5",
-    "data-icon": "⚖️",
     "style": "display: none;"
   },
-  "#oceanLayers": {
-    "layers": "-6,-3,-1"
-  },
+  "#oceanLayers": {},
   "#oceanBase": {
     "fill": "#466eab",
     "x": "0",
@@ -309,9 +304,6 @@
   },
   "#texture": {
     "mask": "url(#land)",
-    "data-x": "0",
-    "data-y": "0",
-    "data-href": "./images/textures/marble-big.jpg",
     "style": "display: none;"
   },
   "#tradeAnimation": {

--- a/tests/fixtures/style-baseline.json
+++ b/tests/fixtures/style-baseline.json
@@ -97,9 +97,7 @@
   "#goodsCells": {
     "opacity": "1"
   },
-  "#goodsIcons": {
-    "data-circle": "1"
-  },
+  "#goodsIcons": {},
   "#goodsBurgs": {
     "opacity": "1",
     "stroke": "#41414f",
@@ -183,8 +181,7 @@
     "style": "display: none;"
   },
   "#oceanLayers": {
-    "filter": "",
-    "layers": "-6,-3,-1"
+    "filter": ""
   },
   "#oceanBase": {
     "fill": "#05001f",
@@ -322,9 +319,6 @@
   "#texture": {
     "opacity": "0.2",
     "mask": "url(#water)",
-    "data-x": "0",
-    "data-y": "0",
-    "data-href": "./images/textures/mercury-small.jpg",
     "style": "display: none;"
   },
   "#tradeAnimation": {


### PR DESCRIPTION
Next step-5 batch (docs/prd/style-migration.md): four content-option families retire from the DOM, plus a latent step-4 harvest bug fix the gate tests surfaced.

| Selector | Store home | Retired |
|---|---|---|
| #markets | `markets.options.{fontSize,icon}` | font-size + data-icon (drawn glyphs carry explicit sizes) |
| #goodsIcons | `goods.goodsIcons.options.circle` | data-circle |
| #texture | `texture.options.{href,x,y}` | data-href/data-x/data-y — the image child stays; drawTexture rebuilds it from the store |
| #oceanLayers | `ocean.oceanLayers.options.outline` | layers |

**#oceanicPattern is deliberately unchanged**: the defs image is the live resource (like the texture image child); its href/opacity stay element-authoritative until the editor step gives it a proper applier.

## Latent step-4 bug fixed: numeric-string coercion

The DOM harvest and the legacy preset saver numify numeric-looking values. A single-ring ocean outline (`layers="-6"`) coerced to the number -6, failed the string schema, and parse-fallback silently reset the WHOLE ocean layer to defaults on every save of such a map — since step 4. Routes now carry a `strings` list (ocean outline, markets icon, scaleBar label — the other two were the same accident waiting). Pinned by a unit test feeding numbers through the upgrader.

## Also

- Markets and goods size sliders restyle live on drag (they were change-on-release while every other size slider is input-live). The emblem sliders stay on change deliberately — drawEmblems is a heavy deferred redraw.
- Texture shift/select handlers no longer hand-edit the image element; they write the store and the renderer rebuilds it.

## Verification

- Three new real-control e2e tests (markets fontSize incl. the baseFont+1/scale zoom term, goods circle toggle, texture rebuild, ocean outline with ring-count assertion), and the #1627-era markets test's survival assertions flipped now that its family arrived.
- Authority-gate browser tests, the step-4-era strip regression (all 7 attrs incl. a "-6" outline record-value assertion) and the Style Saver round-trip all extended and RED-verified.
- Parity baselines shrink by exactly the family attrs, proven mechanically.
- tsc, biome, 450 unit + 28 browser tests, full Playwright suite 164/164; manual validation including the goods-visibility path and live-slider behavior.