### PR TITLE
Style migration step 5: scale bar, legend geometry and label shifts move off the DOM

### DIFF
--- a/public/modules/ui/style-presets.js
+++ b/public/modules/ui/style-presets.js
@@ -132,26 +132,6 @@ function writeAttrsById(id, attrs) {
 function projectPresetOptions() {
   const byId = id => document.getElementById(id);
 
-  const scaleBar = byId("scaleBar");
-  setOrRemove(scaleBar, "data-bar-size", styles.scaleBar.options.barSize);
-  setOrRemove(scaleBar, "data-x", styles.scaleBar.options.x);
-  setOrRemove(scaleBar, "data-y", styles.scaleBar.options.y);
-  setOrRemove(scaleBar, "data-label", styles.scaleBar.options.label);
-
-  const scaleBarBack = byId("scaleBarBack");
-  setOrRemove(scaleBarBack, "data-top", styles.scaleBar.back.options.top);
-  setOrRemove(scaleBarBack, "data-right", styles.scaleBar.back.options.right);
-  setOrRemove(scaleBarBack, "data-bottom", styles.scaleBar.back.options.bottom);
-  setOrRemove(scaleBarBack, "data-left", styles.scaleBar.back.options.left);
-  writeAttrsById("scaleBarBack", styles.scaleBar.back.attrs);
-
-  const legend = byId("legend");
-  setOrRemove(legend, "data-x", styles.legend.options.x);
-  setOrRemove(legend, "data-y", styles.legend.options.y);
-  setOrRemove(legend, "data-columns", styles.legend.options.columns);
-
-  writeAttrsById("legendBox", styles.legend.box.attrs);
-
   const vignetteRect = byId("vignette-rect");
   setOrRemove(vignetteRect, "x", styles.vignette.options.x);
   setOrRemove(vignetteRect, "y", styles.vignette.options.y);
@@ -169,8 +149,6 @@ function projectPresetOptions() {
     const el = document.querySelector(`#labels > [data-group="${CSS.escape(group)}"]`);
     if (!el) continue;
     const {dx, dy} = style.options;
-    setOrRemove(el, "data-dx", dx);
-    setOrRemove(el, "data-dy", dy);
     el.style.transform = dx || dy ? `translate(${dx}em, ${dy}em)` : "";
   }
 }
@@ -465,6 +443,9 @@ function addStylePreset() {
     if (presetStyle["#legend"]) {
       presetStyle["#legend"]["data-size"] = styles.legend.options.fontSize;
       presetStyle["#legend"]["font-size"] = styles.legend.options.fontSize;
+      presetStyle["#legend"]["data-x"] = styles.legend.options.x;
+      presetStyle["#legend"]["data-y"] = styles.legend.options.y;
+      presetStyle["#legend"]["data-columns"] = styles.legend.options.columns;
     }
     if (presetStyle["#emblems > #stateEmblems"])
       presetStyle["#emblems > #stateEmblems"]["data-size"] = styles.emblems.stateEmblems.options.size;
@@ -505,6 +486,18 @@ function addStylePreset() {
       presetStyle["#texture"]["data-y"] = styles.texture.options.y;
     }
     if (presetStyle["#oceanLayers"]) presetStyle["#oceanLayers"]["layers"] = styles.ocean.oceanLayers.options.outline;
+    if (presetStyle["#scaleBar"]) {
+      presetStyle["#scaleBar"]["data-bar-size"] = styles.scaleBar.options.barSize;
+      presetStyle["#scaleBar"]["data-x"] = styles.scaleBar.options.x;
+      presetStyle["#scaleBar"]["data-y"] = styles.scaleBar.options.y;
+      presetStyle["#scaleBar"]["data-label"] = styles.scaleBar.options.label;
+    }
+    if (presetStyle["#scaleBarBack"]) {
+      presetStyle["#scaleBarBack"]["data-top"] = styles.scaleBar.back.options.top;
+      presetStyle["#scaleBarBack"]["data-right"] = styles.scaleBar.back.options.right;
+      presetStyle["#scaleBarBack"]["data-bottom"] = styles.scaleBar.back.options.bottom;
+      presetStyle["#scaleBarBack"]["data-left"] = styles.scaleBar.back.options.left;
+    }
 
     for (const [group, groupStyle] of Object.entries(styles.labels.groups)) {
       addStoredLabelStyle(`#labels > #${group}`, stylesLegacy.labelGroupToLegacy(groupStyle));

--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -285,8 +285,8 @@ function selectStyleElement() {
     styleFontSize.value = parseFloat(el.attr("font-size")) || 18;
 
     styleFontShift.style.display = "block";
-    styleFontShiftX.value = el.attr("data-dx") || 0;
-    styleFontShiftY.value = el.attr("data-dy") || 0;
+    styleFontShiftX.value = styles.labels.groups[styleGroupSelect.value]?.options.dx || 0;
+    styleFontShiftY.value = styles.labels.groups[styleGroupSelect.value]?.options.dy || 0;
   }
 
   if (styleElement === "burgIcons") {
@@ -324,7 +324,7 @@ function selectStyleElement() {
     styleSize.style.display = "block";
 
     styleLegend.style.display = "block";
-    styleLegendColItems.value = el.attr("data-columns") || 8;
+    styleLegendColItems.value = styles.legend.options.columns;
     const legendBox = el.select("#legendBox");
     styleLegendBack.value = styleLegendBackOutput.value = legendBox.size() ? legendBox.attr("fill") : "#ffffff";
     styleLegendOpacity.value = legendBox.size() ? legendBox.attr("fill-opacity") : 1;
@@ -442,11 +442,11 @@ function selectStyleElement() {
   if (styleElement === "scaleBar") {
     styleScaleBar.style.display = "block";
 
-    styleScaleBarSize.value = el.attr("data-bar-size");
+    styleScaleBarSize.value = styles.scaleBar.options.barSize;
     styleScaleBarFontSize.value = el.attr("font-size");
-    styleScaleBarPositionX.value = el.attr("data-x") || "99";
-    styleScaleBarPositionY.value = el.attr("data-y") || "99";
-    styleScaleBarLabel.value = el.attr("data-label") || "";
+    styleScaleBarPositionX.value = styles.scaleBar.options.x;
+    styleScaleBarPositionY.value = styles.scaleBar.options.y;
+    styleScaleBarLabel.value = styles.scaleBar.options.label;
 
     const scaleBarBack = el.select("#scaleBarBack");
     if (scaleBarBack.size()) {
@@ -455,10 +455,10 @@ function selectStyleElement() {
       styleScaleBarBackgroundStroke.value = styleScaleBarBackgroundStrokeOutput.value = scaleBarBack.attr("stroke");
       styleScaleBarBackgroundStrokeWidth.value = scaleBarBack.attr("stroke-width");
       styleScaleBarBackgroundFilter.value = scaleBarBack.attr("filter");
-      styleScaleBarBackgroundPaddingTop.value = scaleBarBack.attr("data-top");
-      styleScaleBarBackgroundPaddingRight.value = scaleBarBack.attr("data-right");
-      styleScaleBarBackgroundPaddingBottom.value = scaleBarBack.attr("data-bottom");
-      styleScaleBarBackgroundPaddingLeft.value = scaleBarBack.attr("data-left");
+      styleScaleBarBackgroundPaddingTop.value = styles.scaleBar.back.options.top;
+      styleScaleBarBackgroundPaddingRight.value = styles.scaleBar.back.options.right;
+      styleScaleBarBackgroundPaddingBottom.value = styles.scaleBar.back.options.bottom;
+      styleScaleBarBackgroundPaddingLeft.value = styles.scaleBar.back.options.left;
     }
   }
 
@@ -868,7 +868,7 @@ function shiftCompass() {
 }
 
 styleLegendColItems.addEventListener("input", e => {
-  d3.select("#legend").select("#legendBox").attr("data-columns", e.target.value);
+  styles.legend.options.columns = +e.target.value || 8;
   Layers.draw("legend");
 });
 
@@ -980,23 +980,17 @@ function changeFontSize(el, size) {
   el.attr("data-size", size).attr("font-size", size);
 }
 
-styleFontShiftX.addEventListener("input", e => {
-  const group = getEl().attr("data-dx", e.target.value);
+function applyLabelShift(axis, value) {
   const groupStyle = styles.labels.groups[styleGroupSelect.value];
-  if (groupStyle) groupStyle.options.dx = +e.target.value || 0;
-  const dx = e.target.value || 0;
-  const dy = group.attr("data-dy") || 0;
-  group.style("transform", +dx || +dy ? `translate(${dx}em, ${dy}em)` : null);
-});
+  if (!groupStyle) return;
+  groupStyle.options[axis] = +value || 0;
+  const { dx, dy } = groupStyle.options;
+  getEl().style("transform", dx || dy ? `translate(${dx}em, ${dy}em)` : null);
+}
 
-styleFontShiftY.addEventListener("input", e => {
-  const group = getEl().attr("data-dy", e.target.value);
-  const groupStyle = styles.labels.groups[styleGroupSelect.value];
-  if (groupStyle) groupStyle.options.dy = +e.target.value || 0;
-  const dx = group.attr("data-dx") || 0;
-  const dy = e.target.value || 0;
-  group.style("transform", +dx || +dy ? `translate(${dx}em, ${dy}em)` : null);
-});
+styleFontShiftX.addEventListener("input", e => applyLabelShift("dx", e.target.value));
+
+styleFontShiftY.addEventListener("input", e => applyLabelShift("dy", e.target.value));
 
 styleStatesBodyOpacity.addEventListener("input", e => {
   d3.select("#statesBody").attr("opacity", e.target.value);
@@ -1207,20 +1201,20 @@ styleScaleBar.addEventListener("input", function (event) {
 
   const { id, value } = event.target;
 
-  if (id === "styleScaleBarSize") d3.select("#scaleBar").attr("data-bar-size", value);
+  if (id === "styleScaleBarSize") styles.scaleBar.options.barSize = +value || 1;
   else if (id === "styleScaleBarFontSize") d3.select("#scaleBar").attr("font-size", value);
-  else if (id === "styleScaleBarPositionX") d3.select("#scaleBar").attr("data-x", value);
-  else if (id === "styleScaleBarPositionY") d3.select("#scaleBar").attr("data-y", value);
-  else if (id === "styleScaleBarLabel") d3.select("#scaleBar").attr("data-label", value);
+  else if (id === "styleScaleBarPositionX") styles.scaleBar.options.x = +value || 0;
+  else if (id === "styleScaleBarPositionY") styles.scaleBar.options.y = +value || 0;
+  else if (id === "styleScaleBarLabel") styles.scaleBar.options.label = value;
   else if (id === "styleScaleBarBackgroundOpacity") scaleBarBack.attr("opacity", value);
   else if (id === "styleScaleBarBackgroundFill") scaleBarBack.attr("fill", value);
   else if (id === "styleScaleBarBackgroundStroke") scaleBarBack.attr("stroke", value);
   else if (id === "styleScaleBarBackgroundStrokeWidth") scaleBarBack.attr("stroke-width", value);
   else if (id === "styleScaleBarBackgroundFilter") scaleBarBack.attr("filter", value);
-  else if (id === "styleScaleBarBackgroundPaddingTop") scaleBarBack.attr("data-top", value);
-  else if (id === "styleScaleBarBackgroundPaddingRight") scaleBarBack.attr("data-right", value);
-  else if (id === "styleScaleBarBackgroundPaddingBottom") scaleBarBack.attr("data-bottom", value);
-  else if (id === "styleScaleBarBackgroundPaddingLeft") scaleBarBack.attr("data-left", value);
+  else if (id === "styleScaleBarBackgroundPaddingTop") styles.scaleBar.back.options.top = +value || 0;
+  else if (id === "styleScaleBarBackgroundPaddingRight") styles.scaleBar.back.options.right = +value || 0;
+  else if (id === "styleScaleBarBackgroundPaddingBottom") styles.scaleBar.back.options.bottom = +value || 0;
+  else if (id === "styleScaleBarBackgroundPaddingLeft") styles.scaleBar.back.options.left = +value || 0;
   Layers.draw("scaleBar");
 });
 

--- a/src/generators/styles-legacy.dom.test.ts
+++ b/src/generators/styles-legacy.dom.test.ts
@@ -227,6 +227,33 @@ test("save sync lets an old map's markets, goods-circle, texture and ocean-outli
   expect(styles.ocean.oceanLayers.options.outline).toBe("-6");
 });
 
+test("save sync keeps store scaleBar and label-shift options when their attrs are absent", () => {
+  document.body.innerHTML = `<svg id="map"><g id="scaleBar" font-size="10"><rect id="scaleBarBack" data-group="back" fill="#ffffff"></rect></g>
+    <g id="labels"><g data-group="capital" font-size="6%" font-family="Almendra SC"></g></g></svg>`;
+  styles.scaleBar.options.x = 50;
+  styles.scaleBar.options.label = "here";
+  styles.scaleBar.back.options.top = 12;
+  styles.labels.groups.capital.options.dx = 1.5;
+  syncStylesFromMap();
+  expect(styles.scaleBar.options.x).toBe(50);
+  expect(styles.scaleBar.options.label).toBe("here");
+  expect(styles.scaleBar.back.options.top).toBe(12);
+  // labels are store-authoritative on save (step 4): the missing attr changes nothing
+  expect(styles.labels.groups.capital.options.dx).toBe(1.5);
+  styles.labels.groups.capital.options.dx = 0;
+});
+
+test("save sync lets an old map's scaleBar and label-shift attrs win", () => {
+  document.body.innerHTML = `<svg id="map"><g id="scaleBar" data-bar-size="2" data-x="40" data-y="41" data-label="old" font-size="10"><rect id="scaleBarBack" data-group="back" data-top="3" data-right="4" data-bottom="5" data-left="6" fill="#ffffff"></rect></g>
+    <g id="labels"><g data-group="capital" data-dx="0.7" data-dy="-0.2" font-size="6%" font-family="Almendra SC"></g></g></svg>`;
+  styles.scaleBar.options.x = 50;
+  syncStylesFromMap();
+  expect(styles.scaleBar.options).toEqual({ barSize: 2, x: 40, y: 41, label: "old" });
+  expect(styles.scaleBar.back.options).toEqual({ top: 3, right: 4, bottom: 5, left: 6 });
+  // the record-less LOAD path still harvests the label shift off an old map's attrs
+  expect(stylesFromMap(document).labels.groups.capital.options).toEqual({ dx: 0.7, dy: -0.2 });
+});
+
 test("save sync lets an old map's coordinates data-size win over the store", () => {
   document.body.innerHTML = `<svg id="map"><g id="coordinates" data-size="14"></g></svg>`;
   styles.coordinates.options.fontSize = 20;

--- a/src/generators/styles-legacy.ts
+++ b/src/generators/styles-legacy.ts
@@ -401,9 +401,14 @@ export function syncStylesFromMap(): void {
     harvested.coordinates.options = structuredClone(styles.coordinates.options);
   if (!document.getElementById("ruler")?.hasAttribute("data-size"))
     harvested.rulers.options = structuredClone(styles.rulers.options);
-  // per-key: legend geometry (x/y/columns) stays attr-authoritative until its own family
   if (!document.getElementById("legend")?.hasAttribute("data-size"))
     harvested.legend.options.fontSize = styles.legend.options.fontSize;
+  if (!document.getElementById("legend")?.hasAttribute("data-x")) {
+    harvested.legend.options.x = styles.legend.options.x;
+    harvested.legend.options.y = styles.legend.options.y;
+  }
+  if (!document.getElementById("legend")?.hasAttribute("data-columns"))
+    harvested.legend.options.columns = styles.legend.options.columns;
   for (const key of ["stateEmblems", "provinceEmblems", "burgEmblems"] as const) {
     if (!document.getElementById(key)?.hasAttribute("data-size"))
       harvested.emblems[key].options = structuredClone(styles.emblems[key].options);
@@ -437,6 +442,10 @@ export function syncStylesFromMap(): void {
     harvested.texture.options = structuredClone(styles.texture.options);
   if (!document.getElementById("oceanLayers")?.hasAttribute("layers"))
     harvested.ocean.oceanLayers.options.outline = styles.ocean.oceanLayers.options.outline;
+  if (!document.getElementById("scaleBar")?.hasAttribute("data-bar-size"))
+    harvested.scaleBar.options = structuredClone(styles.scaleBar.options);
+  if (!document.getElementById("scaleBarBack")?.hasAttribute("data-top"))
+    harvested.scaleBar.back.options = structuredClone(styles.scaleBar.back.options);
   Styles.set(harvested);
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -333,7 +333,7 @@
       </defs>
       <g id="viewbox"></g>
       <g id="scaleBar">
-        <rect id="scaleBarBack"></rect>
+        <rect id="scaleBarBack" data-group="back"></rect>
       </g>
     </svg>
     <div id="loading">

--- a/src/renderers/draw-legend.test.ts
+++ b/src/renderers/draw-legend.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it } from "vitest";
 import "@/generators/styles";
-import { drawLegend, redrawLegend } from "./draw-legend";
+import { dragLegendBox, drawLegend, fitLegendBox, redrawLegend } from "./draw-legend";
 
 beforeEach(() => {
   document.body.innerHTML = /* html */ `<svg id="map" width="800" height="600">
@@ -35,21 +35,25 @@ describe("drawLegend", () => {
     styles.legend.options.fontSize = 13;
   });
 
-  it("takes the styling from the style inputs when the legend is drawn anew", () => {
+  it("takes the styling from the store when the legend is drawn anew", () => {
+    styles.legend.options.columns = 4;
+    styles.legend.box.attrs.fill = "#123456";
     drawLegend("States", items);
 
     const box = document.getElementById("legendBox")!;
-    expect(box.getAttribute("data-columns")).toBe("8");
-    expect(box.getAttribute("fill")).toBe("#ffffff");
+    expect(box.getAttribute("data-columns")).toBe("4");
+    expect(box.getAttribute("fill")).toBe("#123456");
+    styles.legend.options.columns = 8;
+    styles.legend.box.attrs.fill = "#ffffff";
   });
 
-  it("keeps the styling of the drawn legend on redraw, ignoring the style inputs", () => {
+  it("keeps the drawn box attrs on redraw but takes columns from the store", () => {
     drawLegend("States", items);
 
     const box = document.getElementById("legendBox")!;
-    box.setAttribute("data-columns", "1"); // the user restyles the legend
-    box.setAttribute("fill", "#f0e0c0");
+    box.setAttribute("fill", "#f0e0c0"); // Styles.write restyles the drawn box directly
     box.setAttribute("fill-opacity", "0.6");
+    styles.legend.options.columns = 1;
 
     redrawLegend();
 
@@ -59,5 +63,36 @@ describe("drawLegend", () => {
     expect(redrawn.getAttribute("fill-opacity")).toBe("0.6");
     expect(document.getElementById("legendLabel")?.textContent).toBe("States");
     expect(document.querySelectorAll("#legend text")).toHaveLength(3); // 2 items + the label
+    styles.legend.options.columns = 8;
+  });
+
+  it("fitLegendBox positions from the store, ignoring the retired data attrs", () => {
+    styles.legend.options.x = 50;
+    styles.legend.options.y = 50;
+    drawLegend("States", items);
+    fitLegendBox();
+
+    const transform = document.getElementById("legend")!.getAttribute("transform");
+    // svgWidth 800 * 0.5 - bbox width 60 = 340; svgHeight 600 * 0.5 - bbox height 40 = 260
+    expect(transform).toBe("translate(340,260)");
+    styles.legend.options.x = 99;
+    styles.legend.options.y = 93;
+  });
+
+  it("dragLegendBox stores the dragged position in the store", () => {
+    drawLegend("States", items);
+    document.getElementById("legend")!.setAttribute("transform", "translate(100,100)");
+
+    dragLegendBox({
+      x: 0,
+      y: 0,
+      on: (_type: string, cb: (e: { x: number; y: number }) => void) => cb({ x: 60, y: 20 })
+    } as never);
+
+    // (100+60+60)/800*100 = 27.5 ; (100+20+40)/600*100 = 26.67
+    expect(styles.legend.options.x).toBe(27.5);
+    expect(styles.legend.options.y).toBe(26.67);
+    styles.legend.options.x = 99;
+    styles.legend.options.y = 93;
   });
 });

--- a/src/renderers/draw-legend.ts
+++ b/src/renderers/draw-legend.ts
@@ -1,7 +1,7 @@
 // The legend box: a titled, multi-column list of color swatches drawn over the map
 
 import { type D3DragEvent, select } from "d3";
-import { ensureEl, parseTransform, rn } from "@/utils";
+import { parseTransform, rn } from "@/utils";
 
 // [id, color, label] as stored in the legend `data` attribute
 export type LegendItem = (string | number | undefined)[];
@@ -12,14 +12,12 @@ const getLegend = () => select<SVGGElement, unknown>("#legend");
 export function drawLegend(name: string, data: LegendItem[]): void {
   const legend = getLegend();
 
-  // the box drawn before carries the legend styling; the style inputs only seed a legend drawn anew
+  // the box drawn before carries the box styling (Styles.write restyles it in place);
+  // the store seeds a legend drawn anew and always owns the column count
   const box = legend.select<SVGRectElement>("#legendBox").node();
-  const styleInput = (id: string) => ensureEl<HTMLInputElement>(id).value;
-  const boxStyle = (attr: string, inputId: string) => box?.getAttribute(attr) ?? styleInput(inputId);
-
-  const itemsInCol = Number(boxStyle("data-columns", "styleLegendColItems"));
-  const backColor = boxStyle("fill", "styleLegendBack");
-  const opacity = Number(boxStyle("fill-opacity", "styleLegendOpacity"));
+  const itemsInCol = styles.legend.options.columns;
+  const backColor = box?.getAttribute("fill") ?? styles.legend.box.attrs.fill;
+  const opacity = Number(box?.getAttribute("fill-opacity") ?? styles.legend.box.attrs["fill-opacity"]);
   const fontSize = styles.legend.options.fontSize;
 
   legend.selectAll("*").remove(); // fully redraw every time
@@ -100,8 +98,8 @@ export function fitLegendBox(): void {
   const legend = getLegend();
   if (!legend.selectAll("*").size()) return;
 
-  const px = Number.isNaN(Number(legend.attr("data-x"))) ? 0.99 : Number(legend.attr("data-x")) / 100;
-  const py = Number.isNaN(Number(legend.attr("data-y"))) ? 0.93 : Number(legend.attr("data-y")) / 100;
+  const px = styles.legend.options.x / 100;
+  const py = styles.legend.options.y / 100;
 
   const bbox = getBBox(legend);
   const x = rn(svgWidth * px - bbox.width);
@@ -120,10 +118,9 @@ export function dragLegendBox(event: D3DragEvent<SVGGElement, unknown, unknown>)
   event.on("drag", dragEvent => {
     const px = rn(((x + dragEvent.x + bbox.width) / svgWidth) * 100, 2);
     const py = rn(((y + dragEvent.y + bbox.height) / svgHeight) * 100, 2);
-    legend
-      .attr("transform", `translate(${x + dragEvent.x},${y + dragEvent.y})`)
-      .attr("data-x", px)
-      .attr("data-y", py);
+    legend.attr("transform", `translate(${x + dragEvent.x},${y + dragEvent.y})`);
+    styles.legend.options.x = px;
+    styles.legend.options.y = py;
   });
 }
 

--- a/src/renderers/draw-scalebar.ts
+++ b/src/renderers/draw-scalebar.ts
@@ -14,7 +14,7 @@ export function drawScaleBar(parent?: SVGSVGElement, scaleLevel = scale, width =
   TIME && !isRendered && console.time("drawScaleBar");
 
   const unit = distanceUnitInput.value;
-  const size = +scaleBar.attr("data-bar-size");
+  const { barSize: size, label, x: posX, y: posY } = styles.scaleBar.options;
 
   renderedContent?.remove(); // redraw content every time, but not scaleBarBack
   const content = scaleBar.append("g").attr("id", "scaleBarContent");
@@ -59,7 +59,6 @@ export function drawScaleBar(parent?: SVGSVGElement, scaleLevel = scale, width =
     .attr("dy", "-.6em")
     .text((d: number) => rn((((d * length) / 5) * distanceScale) / scaleLevel) + (d < 5 ? "" : ` ${unit}`));
 
-  const label = scaleBar.attr("data-label");
   if (label) {
     texts
       .append("text")
@@ -72,12 +71,13 @@ export function drawScaleBar(parent?: SVGSVGElement, scaleLevel = scale, width =
 
   const scaleBarBack = scaleBar.select<SVGRectElement>("#scaleBarBack");
   if (scaleBarBack.size()) {
-    scaleBarBack.attr("data-group", "back");
     const bbox = (content.node() as SVGGElement).getBBox();
-    const paddingTop = +scaleBarBack.attr("data-top") || 0;
-    const paddingLeft = +scaleBarBack.attr("data-left") || 0;
-    const paddingRight = +scaleBarBack.attr("data-right") || 0;
-    const paddingBottom = +scaleBarBack.attr("data-bottom") || 0;
+    const {
+      top: paddingTop,
+      left: paddingLeft,
+      right: paddingRight,
+      bottom: paddingBottom
+    } = styles.scaleBar.back.options;
 
     scaleBar
       .select("#scaleBarBack")
@@ -86,8 +86,6 @@ export function drawScaleBar(parent?: SVGSVGElement, scaleLevel = scale, width =
       .attr("width", bbox.width + paddingRight)
       .attr("height", bbox.height + paddingBottom);
 
-    const posX = +scaleBar.attr("data-x") || 99;
-    const posY = +scaleBar.attr("data-y") || 99;
     const backBbox = (scaleBarBack.node() as SVGGElement).getBBox();
     const x = rn((width * posX) / 100 - backBbox.width + 10);
     const y = rn((height * posY) / 100 - backBbox.height + 20);
@@ -99,7 +97,6 @@ export function drawScaleBar(parent?: SVGSVGElement, scaleLevel = scale, width =
   function getLength(): number {
     const init = 100;
 
-    const size = +scaleBar.attr("data-bar-size");
     let val = (init * size * distanceScale) / scaleLevel; // bar length in distance unit
     if (val > 900)
       val = rn(val, -3); // round to 1000

--- a/src/renderers/draw-texture.dom.test.ts
+++ b/src/renderers/draw-texture.dom.test.ts
@@ -1,0 +1,30 @@
+// Browser-mode test (vitest.browser.config.ts): drawTexture derives the image from the store
+// and clamps out-of-range shifts instead of emitting invalid negative sizes.
+import { beforeEach, expect, test } from "vitest";
+import "@/generators/styles";
+import { drawTexture } from "./draw-texture";
+
+beforeEach(() => {
+  document.body.innerHTML = `<svg id="map"><g id="texture"></g></svg>`;
+  globalThis.graphWidth = 800;
+  globalThis.graphHeight = 600;
+});
+
+const layer = { getEl: () => document.getElementById("texture") } as never;
+
+test("drawTexture builds the image from the store", () => {
+  styles.texture.options = { href: "./t.jpg", x: 10, y: 20 };
+  drawTexture(layer);
+  const image = document.querySelector("#texture image")!;
+  expect(image.getAttribute("href")).toBe("./t.jpg");
+  expect(image.getAttribute("x")).toBe("10");
+  expect(image.getAttribute("width")).toBe("790");
+});
+
+test("drawTexture clamps a shift beyond the map size to a zero-size image", () => {
+  styles.texture.options = { href: "./t.jpg", x: 0, y: 653 };
+  drawTexture(layer);
+  const image = document.querySelector("#texture image")!;
+  expect(Number(image.getAttribute("height"))).toBe(0);
+  expect(Number(image.getAttribute("width"))).toBe(800);
+});

--- a/src/renderers/draw-texture.ts
+++ b/src/renderers/draw-texture.ts
@@ -6,5 +6,5 @@ export function drawTexture(layer: Layer): void {
   if (!href) return void element.replaceChildren();
 
   element.innerHTML = /* html */ `<image preserveAspectRatio="xMidYMid slice"
-    x="${x}" y="${y}" width="${graphWidth - x}" height="${graphHeight - y}" href="${href}"></image>`;
+    x="${x}" y="${y}" width="${Math.max(graphWidth - x, 0)}" height="${Math.max(graphHeight - y, 0)}" href="${href}"></image>`;
 }

--- a/src/renderers/labels/label-groups.dom.test.ts
+++ b/src/renderers/labels/label-groups.dom.test.ts
@@ -1,0 +1,20 @@
+// Browser-mode test (vitest.browser.config.ts): label groups carry their shift as a transform
+// derived from the store, not as retired data-dx/data-dy attributes.
+import { expect, test } from "vitest";
+import "@/generators/styles";
+import { writeGroupStyle } from "./label-groups";
+
+test("writeGroupStyle applies the shift transform without stamping data attrs", () => {
+  document.body.innerHTML = `<svg id="map"><g id="labels"></g></svg>`;
+  const group = document.createElementNS("http://www.w3.org/2000/svg", "g");
+  document.getElementById("labels")!.appendChild(group);
+
+  const groupStyle = structuredClone(styles.labels.groups.capital);
+  groupStyle.options.dx = 1.5;
+  groupStyle.options.dy = -0.5;
+  writeGroupStyle(group, groupStyle);
+
+  expect(group.style.transform).toBe("translate(1.5em, -0.5em)");
+  expect(group.getAttribute("data-dx")).toBeNull();
+  expect(group.getAttribute("data-dy")).toBeNull();
+});

--- a/src/renderers/labels/label-groups.ts
+++ b/src/renderers/labels/label-groups.ts
@@ -30,8 +30,6 @@ export function writeGroupStyle(group: SVGGElement, groupStyle: LabelGroupStyle)
   }
 
   const { dx, dy } = groupStyle.options;
-  if (dx) group.setAttribute("data-dx", String(dx)); // the style editor reads the shift off the DOM
-  if (dy) group.setAttribute("data-dy", String(dy));
   group.style.transform = dx || dy ? `translate(${dx}em, ${dy}em)` : "";
 }
 

--- a/src/services/io/auto-update.ts
+++ b/src/services/io/auto-update.ts
@@ -872,6 +872,7 @@ export async function resolveVersionConflicts(mapVersion: string, data: string[]
     select("#scaleBar")
       .append("rect")
       .attr("id", "scaleBarBack")
+      .attr("data-group", "back")
       .attr("opacity", 0.2)
       .attr("fill", "#ffffff")
       .attr("stroke", "#000000")
@@ -1896,4 +1897,13 @@ export async function resolveVersionConflicts(mapVersion: string, data: string[]
   document.getElementById("goodsIcons")?.removeAttribute("data-circle");
   for (const attr of ["data-href", "data-x", "data-y"]) document.getElementById("texture")?.removeAttribute(attr);
   document.getElementById("oceanLayers")?.removeAttribute("layers");
+  for (const attr of ["data-bar-size", "data-x", "data-y", "data-label"])
+    document.getElementById("scaleBar")?.removeAttribute(attr);
+  for (const attr of ["data-top", "data-right", "data-bottom", "data-left"])
+    document.getElementById("scaleBarBack")?.removeAttribute(attr);
+  for (const attr of ["data-x", "data-y", "data-columns"]) document.getElementById("legend")?.removeAttribute(attr);
+  for (const el of document.querySelectorAll("#labels > *")) {
+    el.removeAttribute("data-dx");
+    el.removeAttribute("data-dy");
+  }
 }

--- a/tests/e2e/style-editor-events.spec.ts
+++ b/tests/e2e/style-editor-events.spec.ts
@@ -13,7 +13,7 @@ const waitForMap = (page: Page) =>
 
 const rn = (v: number, d = 0): number => Math.round(v * 10 ** d) / 10 ** d;
 
-async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates" | "ruler" | "legend" | "emblems" | "goodsIcons" | "goodsBurgs" | "markets" | "terrs" | "armies" | "gridOverlay" | "texture" | "ocean"): Promise<void> {
+async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates" | "ruler" | "legend" | "emblems" | "goodsIcons" | "goodsBurgs" | "markets" | "terrs" | "armies" | "gridOverlay" | "texture" | "ocean" | "scaleBar" | "labels"): Promise<void> {
   await page.evaluate(() => (window as any).showOptions());
   await page.locator("#styleTab").click();
   await page.locator("#styleElementSelect").selectOption(element);
@@ -408,5 +408,71 @@ test.describe("style editor events drive the store", () => {
     expect(await page.evaluate(() => (window as any).styles.ocean.oceanLayers.options.outline)).toBe("-6,-4,-2");
     expect(await page.locator("#oceanLayers").getAttribute("layers")).toBeNull();
     expect(await page.evaluate(() => document.querySelectorAll("#oceanLayers > path").length)).toBe(3);
+  });
+
+  test("scale bar controls write the store and the renderer derives from them", async ({ page }) => {
+    await page.evaluate(() => (window as any).Layers.show("scaleBar"));
+    await openStyleElement(page, "scaleBar");
+
+    for (const [input, value] of [
+      ["#styleScaleBarSize", "2.5"],
+      ["#styleScaleBarPositionX", "50"],
+      ["#styleScaleBarBackgroundPaddingTop", "12"]
+    ] as const) {
+      await page.locator(input).fill(value);
+      await page.locator(input).dispatchEvent("input");
+    }
+    await page.locator("#styleScaleBarLabel").fill("here be dragons");
+    await page.locator("#styleScaleBarLabel").dispatchEvent("input");
+
+    const stored = await page.evaluate(() => ({
+      barSize: (window as any).styles.scaleBar.options.barSize,
+      x: (window as any).styles.scaleBar.options.x,
+      label: (window as any).styles.scaleBar.options.label,
+      top: (window as any).styles.scaleBar.back.options.top
+    }));
+    expect(stored).toEqual({ barSize: 2.5, x: 50, label: "here be dragons", top: 12 });
+
+    // renderer derives from the store: bar line stroke-width equals barSize, label text drawn
+    await expect(page.locator("#scaleBarContent line").first()).toHaveAttribute("stroke-width", "2.5");
+    await expect(page.locator("#scaleBarContent text").last()).toHaveText("here be dragons");
+    await expect(page.locator("#scaleBarBack")).toHaveAttribute("y", "-12");
+
+    for (const attr of ["data-bar-size", "data-x", "data-y", "data-label"]) {
+      expect(await page.locator("#scaleBar").getAttribute(attr), attr).toBeNull();
+    }
+    for (const attr of ["data-top", "data-right", "data-bottom", "data-left"]) {
+      expect(await page.locator("#scaleBarBack").getAttribute(attr), attr).toBeNull();
+    }
+  });
+
+  test("label shift inputs write the store and apply the em transform", async ({ page }) => {
+    await openStyleElement(page, "labels");
+    const group = await page.evaluate(() => (window as any).styleGroupSelect.value);
+
+    await page.locator("#styleFontShiftX").fill("1.5");
+    await page.locator("#styleFontShiftX").dispatchEvent("input");
+    await page.locator("#styleFontShiftY").fill("-0.5");
+    await page.locator("#styleFontShiftY").dispatchEvent("input");
+
+    const stored = await page.evaluate(
+      g => (window as any).styles.labels.groups[g].options,
+      group
+    );
+    expect(stored).toEqual({ dx: 1.5, dy: -0.5 });
+
+    const el = page.locator(`#labels > [data-group="${group}"]`);
+    expect(await el.evaluate(node => (node as SVGElement).style.transform)).toBe("translate(1.5em, -0.5em)");
+    expect(await el.getAttribute("data-dx")).toBeNull();
+    expect(await el.getAttribute("data-dy")).toBeNull();
+  });
+
+  test("legend column input writes the store", async ({ page }) => {
+    await openStyleElement(page, "legend");
+    await page.locator("#styleLegendColItems").fill("3");
+    await page.locator("#styleLegendColItems").dispatchEvent("input");
+
+    expect(await page.evaluate(() => (window as any).styles.legend.options.columns)).toBe(3);
+    expect(await page.locator("#legend").getAttribute("data-columns")).toBeNull();
   });
 });

--- a/tests/e2e/style-persistence.spec.ts
+++ b/tests/e2e/style-persistence.spec.ts
@@ -218,7 +218,12 @@ test.describe("style persistence round trips", () => {
       .replace('<g id="markets"', '<g id="markets" font-size="66" data-icon="Z"')
       .replace('<g id="goodsIcons"', '<g id="goodsIcons" data-circle="0"')
       .replace('<g id="texture"', '<g id="texture" data-href="./z.jpg" data-x="66" data-y="66"')
-      .replace('<g id="oceanLayers"', '<g id="oceanLayers" layers="-6"');
+      .replace('<g id="oceanLayers"', '<g id="oceanLayers" layers="-6"')
+      .replace('<g id="scaleBar"', '<g id="scaleBar" data-bar-size="4" data-x="40" data-y="40" data-label="stale"')
+      .replace('<rect id="scaleBarBack"', '<rect id="scaleBarBack" data-top="66" data-right="66" data-bottom="66" data-left="66"')
+      .replace('<g id="legend"', '<g id="legend" data-x="11" data-y="11" data-columns="2"');
+    expect(lines[5], "scaleBar injection must match the serialized svg").toContain('data-bar-size="4"');
+    expect(lines[5], "legend injection must match the serialized svg").toContain('data-columns="2"');
     const staleBuffer = Buffer.from(lines.join("\r\n"), "utf8");
 
     await reload(page, staleBuffer, "style-persistence-step4-era-reloaded");
@@ -253,6 +258,13 @@ test.describe("style persistence round trips", () => {
         document.getElementById("oceanLayers")?.getAttribute("layers")
       ],
       oceanOutline: styles.ocean.oceanLayers.options.outline,
+      geometryAttrs: [
+        document.getElementById("scaleBar")?.getAttribute("data-bar-size"),
+        document.getElementById("scaleBarBack")?.getAttribute("data-top"),
+        document.getElementById("legend")?.getAttribute("data-x"),
+        document.getElementById("legend")?.getAttribute("data-columns")
+      ],
+      scaleBarSize: styles.scaleBar.options.barSize,
       rescale: styles.markers.options.rescale,
       haloWidth: styles.states.statesHalo.options.width,
       coordinatesSize: styles.coordinates.options.fontSize
@@ -274,6 +286,8 @@ test.describe("style persistence round trips", () => {
     expect(afterLoad.gridScale).toBe(1);
     expect(afterLoad.contentAttrs).toEqual([null, null, null, null, null]);
     expect(afterLoad.oceanOutline).toBe("-6,-3,-1");
+    expect(afterLoad.geometryAttrs).toEqual([null, null, null, null]);
+    expect(afterLoad.scaleBarSize).not.toBe(4);
     expect(afterLoad.rescale).toBe(1);
     expect(afterLoad.haloWidth).toBe(10);
     expect(afterLoad.coordinatesSize).toBe(12);

--- a/tests/e2e/style-presets.spec.ts
+++ b/tests/e2e/style-presets.spec.ts
@@ -145,6 +145,8 @@ test("a saved custom preset carries the retired sizes from the store", async ({p
     styles.markets.options.icon = "K";
     styles.texture.options.x = 33;
     styles.ocean.oceanLayers.options.outline = "-6,-4,-2";
+    styles.scaleBar.options.label = "posterity";
+    styles.legend.options.columns = 5;
     (window as any).addStylePreset();
   });
 
@@ -165,7 +167,9 @@ test("a saved custom preset carries the retired sizes from the store", async ({p
       gridScale: upgraded.grid.options.scale,
       marketsIcon: upgraded.markets.options.icon,
       textureX: upgraded.texture.options.x,
-      oceanOutline: upgraded.ocean.oceanLayers.options.outline
+      oceanOutline: upgraded.ocean.oceanLayers.options.outline,
+      scaleBarLabel: upgraded.scaleBar.options.label,
+      legendColumns: upgraded.legend.options.columns
     };
   }, raw);
 

--- a/tests/fixtures/style-baseline-generated.json
+++ b/tests/fixtures/style-baseline-generated.json
@@ -160,10 +160,7 @@
     "stroke-width": "2.5",
     "stroke-dasharray": "0 4 10 4",
     "stroke-linecap": "round",
-    "font-family": "Almendra SC",
-    "data-x": "99",
-    "data-y": "93",
-    "data-columns": "8"
+    "font-family": "Almendra SC"
   },
   "#markers": {
     "style": "display: none;"
@@ -262,11 +259,7 @@
   "#scaleBar": {
     "opacity": "1",
     "fill": "#353540",
-    "font-size": "10",
-    "data-x": "99",
-    "data-y": "99",
-    "data-bar-size": "2",
-    "data-label": ""
+    "font-size": "10"
   },
   "#scaleBarBack": {
     "opacity": "0.2",
@@ -274,10 +267,6 @@
     "stroke": "#000000",
     "stroke-width": "1",
     "filter": "url(#blur5)",
-    "data-top": "20",
-    "data-right": "15",
-    "data-bottom": "15",
-    "data-left": "10",
     "x": "-10",
     "y": "-20",
     "height": "32"

--- a/tests/fixtures/style-baseline.json
+++ b/tests/fixtures/style-baseline.json
@@ -167,10 +167,7 @@
     "stroke-dasharray": "0 4 10 4",
     "stroke-linecap": "round",
     "font-size": "13",
-    "font-family": "Almendra SC",
-    "data-x": "99",
-    "data-y": "93",
-    "data-columns": "8"
+    "font-family": "Almendra SC"
   },
   "#markers": {
     "opacity": "0.8",
@@ -274,10 +271,6 @@
     "opacity": "1",
     "fill": "#d0d0dc",
     "font-size": "11",
-    "data-x": "99",
-    "data-y": "99",
-    "data-bar-size": "2",
-    "data-label": "",
     "transform": "translate(1039,696)"
   },
   "#scaleBarBack": {
@@ -286,10 +279,6 @@
     "stroke": "#000000",
     "stroke-width": "1",
     "filter": "",
-    "data-top": "23",
-    "data-right": "18",
-    "data-bottom": "18",
-    "data-left": "12",
     "x": "-12",
     "y": "-23",
     "width": "237.84375",


### PR DESCRIPTION
The last step-5 batch (docs/prd/style-migration.md) — with this, every option family is off the DOM and step 5 is complete.

| Selector | Store home | Retired |
|---|---|---|
| #scaleBar | `scaleBar.options.{barSize,x,y,label}` | data-bar-size/data-x/data-y/data-label |
| #scaleBarBack | `scaleBar.back.options.{top,right,bottom,left}` | the four paddings; the rect gains a static `data-group="back"` stamp so Styles.write styles it without the projection |
| #legend | `legend.options.{x,y,columns}` | data-x/data-y/data-columns |
| #labels > groups | `labels.groups[g].options.{dx,dy}` | data-dx/data-dy (the em transform stays as the applied presentation) |

Also clamps texture shifts beyond the map size (negative image width/height produced a console error per draw; now a zero-size image).

**#vignette-rect stays element-authoritative** like #oceanicPattern — the defs rect is the live resource; it converts when the editor step gives it a proper applier.

## Contract changes

- drawLegend drawn anew seeds box fill/opacity/columns from the STORE, not from the style-panel input elements (a renderer reading UI controls is gone). On redraw the drawn box keeps its Styles.write-maintained attrs, but the column count is store-authoritative — the old drawn-box-wins rule for data-columns would have fought the store-writing handler. The pinned tests moved with the contract.
- dragLegendBox writes the store; fitLegendBox positions from it — a dragged legend now round-trips through the style record.
- Labels need no save-time gate: they have been store-authoritative on save since step 4; only the record-less load path harvests data-dx/dy (before the strip), pinned via stylesFromMap directly.

## Verification

- New/rewritten unit-level tests: writeGroupStyle transform-not-attrs, four drawLegend contract tests, dragLegendBox/fitLegendBox store round-trip, texture clamp pair — all watched fail first.
- New real-control e2e: the four-control scale bar case, label shift inputs, legend columns; editor-events 18/18.
- Authority-gate browser tests and the step-4-era strip regression extended with all eleven geometry attrs plus a record-value assertion, RED-verified against the code without the strip.
- Style Saver round-trip extended (scaleBar label + legend columns).
- Parity baselines shrink by exactly the eleven attrs on both baselines, proven mechanically.
- tsc, biome, 452 unit + 33 browser tests, full Playwright suite 165/165; manual validation including legend drag round-trip and the texture clamp.