### PR TITLE
Style migration step 6: the editor's attr controls write through the store

### DIFF
--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -506,13 +506,13 @@ function updateLabelGroupInlineStyle(group) {
   groupStyle.attrs.style = value || null;
 }
 
-// generic controls: resolve the current selection to its store node and write through the
-// store; structural parents (#icons, ...) have no node and keep the direct DOM write
+// generic controls: mirror the edit into the selection's store node, then write ONLY the
+// edited attribute to the DOM - a whole-layer Styles.write would reset sibling groups'
+// zoom-derived values (label/halo stroke-widths and sizes) to their stored bases
 function writeSelectedAttr(attr, value) {
   const resolved = stylesLegacy.styleNodeFor(styleElementSelect.value, styleGroupSelect.value);
-  if (!resolved || !(attr in resolved.node.attrs)) return void getEl().attr(attr, value ?? null);
-  resolved.node.attrs[attr] = value;
-  Styles.write(resolved.layer);
+  if (resolved && attr in resolved.node.attrs) resolved.node.attrs[attr] = value;
+  getEl().attr(attr, value ?? null);
 }
 
 styleFillInput.addEventListener("input", function () {
@@ -631,7 +631,7 @@ styleRescaleMarkers.addEventListener("change", function () {
 
 styleOceanFill.addEventListener("input", function () {
   styles.ocean.base.attrs.fill = this.value;
-  Styles.write("ocean");
+  d3.select("#oceanLayers").select("rect").attr("fill", this.value);
   styleOceanFillOutput.value = this.value;
 });
 
@@ -824,29 +824,29 @@ styleReliefDensity.addEventListener("change", e => {
 
 styleTemperatureFillOpacityInput.addEventListener("input", e => {
   styles.temperature.attrs["fill-opacity"] = +e.target.value;
-  Styles.write("temperature");
+  d3.select("#temperature").attr("fill-opacity", e.target.value);
 });
 
 styleTemperatureFontSizeInput.addEventListener("input", e => {
   styles.temperature.attrs["font-size"] = e.target.value + "px";
-  Styles.write("temperature");
+  d3.select("#temperature").attr("font-size", e.target.value + "px");
 });
 
 styleTemperatureFillInput.addEventListener("input", e => {
   styles.temperature.attrs.fill = e.target.value;
-  Styles.write("temperature");
+  d3.select("#temperature").attr("fill", e.target.value);
   styleTemperatureFillOutput.value = e.target.value;
 });
 
 stylePopulationRuralStrokeInput.addEventListener("input", e => {
   styles.population.rural.attrs.stroke = e.target.value;
-  Styles.write("population");
+  d3.select("#population").select("#rural").attr("stroke", e.target.value);
   stylePopulationRuralStrokeOutput.value = e.target.value;
 });
 
 stylePopulationUrbanStrokeInput.addEventListener("input", e => {
   styles.population.urban.attrs.stroke = e.target.value;
-  Styles.write("population");
+  d3.select("#population").select("#urban").attr("stroke", e.target.value);
   stylePopulationUrbanStrokeOutput.value = e.target.value;
 });
 
@@ -873,7 +873,7 @@ styleCompassShiftY.addEventListener("input", shiftCompass);
 function shiftCompass() {
   const tr = `translate(${styleCompassShiftX.value} ${styleCompassShiftY.value}) scale(${styleCompassSizeInput.value})`;
   styles.compass.compassRose.attrs.transform = tr;
-  Styles.write("compass");
+  d3.select("#compass").select("use").attr("transform", tr);
 }
 
 styleLegendColItems.addEventListener("input", e => {
@@ -884,12 +884,12 @@ styleLegendColItems.addEventListener("input", e => {
 styleLegendBack.addEventListener("input", e => {
   styleLegendBackOutput.value = e.target.value;
   styles.legend.box.attrs.fill = e.target.value;
-  Styles.write("legend");
+  d3.select("#legend").select("#legendBox").attr("fill", e.target.value);
 });
 
 styleLegendOpacity.addEventListener("input", e => {
   styles.legend.box.attrs["fill-opacity"] = +e.target.value;
-  Styles.write("legend");
+  d3.select("#legend").select("#legendBox").attr("fill-opacity", e.target.value);
 });
 
 styleSelectFont.addEventListener("change", changeFont);
@@ -1001,35 +1001,36 @@ styleFontShiftY.addEventListener("input", e => applyLabelShift("dy", e.target.va
 
 styleStatesBodyOpacity.addEventListener("input", e => {
   styles.states.statesBody.attrs.opacity = +e.target.value;
-  Styles.write("states");
+  d3.select("#statesBody").attr("opacity", e.target.value);
 });
 
 styleStatesBodyFilter.addEventListener("change", function () {
   styles.states.statesBody.attrs.filter = this.value || null;
-  Styles.write("states");
+  d3.select("#statesBody").attr("filter", this.value || null);
 });
 
 styleStatesHaloWidth.addEventListener("input", e => {
   const value = +e.target.value;
   styles.states.statesHalo.options.width = value;
   styles.states.statesHalo.attrs["stroke-width"] = value;
-  Styles.write("states");
+  d3.select("#statesHalo").attr("stroke-width", value);
 });
 
 styleStatesHaloOpacity.addEventListener("input", e => {
   styles.states.statesHalo.attrs.opacity = +e.target.value;
-  Styles.write("states");
+  d3.select("#statesHalo").attr("opacity", e.target.value);
 });
 
 styleStatesHaloBlur.addEventListener("input", e => {
   const value = Number(e.target.value);
-  styles.states.statesHalo.attrs.filter = value > 0 ? `blur(${value}px)` : null;
-  Styles.write("states");
+  const blur = value > 0 ? `blur(${value}px)` : null;
+  styles.states.statesHalo.attrs.filter = blur;
+  d3.select("#statesHalo").attr("filter", blur);
 });
 
 styleArmiesFillOpacity.addEventListener("input", e => {
   styles.military.attrs["fill-opacity"] = +e.target.value;
-  Styles.write("military");
+  d3.select("#armies").attr("fill-opacity", e.target.value);
 });
 
 styleArmiesSize.addEventListener("input", e => {
@@ -1076,7 +1077,7 @@ styleGoodsBurgsSize.addEventListener("input", function () {
 
 styleMarketsLayerFillOpacity.addEventListener("input", e => {
   styles.markets.attrs["fill-opacity"] = +e.target.value;
-  Styles.write("markets");
+  d3.select("#markets").attr("fill-opacity", e.target.value);
 });
 
 styleMarketsSize.addEventListener("input", function () {
@@ -1216,7 +1217,7 @@ styleScaleBar.addEventListener("input", function (event) {
   if (id === "styleScaleBarSize") styles.scaleBar.options.barSize = +value || 1;
   else if (id === "styleScaleBarFontSize") {
     styles.scaleBar.attrs["font-size"] = +value || 10;
-    Styles.write("scaleBar");
+    d3.select("#scaleBar").attr("font-size", value);
   }
   else if (id === "styleScaleBarPositionX") styles.scaleBar.options.x = +value || 0;
   else if (id === "styleScaleBarPositionY") styles.scaleBar.options.y = +value || 0;
@@ -1240,12 +1241,12 @@ function applyMapFilter(event) {
   const button = event.target;
   styles.map.options.dataFilter = null;
   styles.map.attrs.filter = null;
-  Styles.write("map");
+  d3.select("#map").attr("filter", null);
   if (button.classList.contains("pressed")) return button.classList.remove("pressed");
 
   mapFilters.querySelectorAll(".pressed").forEach(button => button.classList.remove("pressed"));
   button.classList.add("pressed");
   styles.map.options.dataFilter = button.id;
   styles.map.attrs.filter = "url(#filter-" + button.id + ")";
-  Styles.write("map");
+  d3.select("#map").attr("filter", "url(#filter-" + button.id + ")");
 }

--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -504,43 +504,44 @@ function updateLabelGroupInlineStyle(group) {
   groupStyle.attrs.style = value || null;
 }
 
+// generic controls: resolve the current selection to its store node and write through the
+// store; structural parents (#icons, ...) have no node and keep the direct DOM write
+function writeSelectedAttr(attr, value) {
+  const resolved = stylesLegacy.styleNodeFor(styleElementSelect.value, styleGroupSelect.value);
+  if (!resolved || !(attr in resolved.node.attrs)) return void getEl().attr(attr, value ?? null);
+  resolved.node.attrs[attr] = value;
+  Styles.write(resolved.layer);
+}
+
 styleFillInput.addEventListener("input", function () {
   styleFillOutput.value = this.value;
-  getEl().attr("fill", this.value);
-  const groupStyle = styles.labels.groups[styleGroupSelect.value];
-  if (groupStyle) groupStyle.attrs.fill = this.value;
+  writeSelectedAttr("fill", this.value);
 });
 
 styleStrokeInput.addEventListener("input", function () {
   styleStrokeOutput.value = this.value;
-  getEl().attr("stroke", this.value);
-  const groupStyle = styles.labels.groups[styleGroupSelect.value];
-  if (groupStyle) groupStyle.attrs.stroke = this.value;
+  writeSelectedAttr("stroke", this.value);
   if (styleElementSelect.value === "gridOverlay") Layers.draw("grid");
 });
 
 styleStrokeWidthInput.addEventListener("input", e => {
-  getEl().attr("stroke-width", e.target.value);
-  const groupStyle = styles.labels.groups[styleGroupSelect.value];
-  if (groupStyle) groupStyle.attrs["stroke-width"] = +e.target.value;
+  writeSelectedAttr("stroke-width", +e.target.value || 0);
   if (styleElementSelect.value === "gridOverlay") Layers.draw("grid");
   if (styleElementSelect.value === "ruler") Layers.draw("rulers");
 });
 
 styleLetterSpacingInput.addEventListener("input", e => {
-  getEl().attr("letter-spacing", e.target.value);
-  const groupStyle = styles.labels.groups[styleGroupSelect.value];
-  if (groupStyle) groupStyle.attrs["letter-spacing"] = +e.target.value;
+  writeSelectedAttr("letter-spacing", +e.target.value || 0);
 });
 
 styleStrokeDasharrayInput.addEventListener("input", function () {
-  getEl().attr("stroke-dasharray", this.value);
+  writeSelectedAttr("stroke-dasharray", this.value || null);
   if (styleElementSelect.value === "gridOverlay") Layers.draw("grid");
   if (styleElementSelect.value === "ruler") Layers.draw("rulers");
 });
 
 styleStrokeLinecapInput.addEventListener("change", function () {
-  getEl().attr("stroke-linecap", this.value);
+  writeSelectedAttr("stroke-linecap", this.value || null);
   if (styleElementSelect.value === "gridOverlay") Layers.draw("grid");
 });
 
@@ -549,16 +550,15 @@ styleDisplayInput.addEventListener("change", function () {
 });
 
 styleOpacityInput.addEventListener("input", e => {
-  getEl().attr("opacity", e.target.value);
-  const groupStyle = styles.labels.groups[styleGroupSelect.value];
-  if (groupStyle) groupStyle.attrs.opacity = +e.target.value;
+  writeSelectedAttr("opacity", +e.target.value);
 });
 
 styleFilterInput.addEventListener("change", function () {
-  if (styleGroupSelect.value === "ocean") return d3.select("#oceanLayers").attr("filter", this.value);
-  getEl().attr("filter", this.value);
-  const groupStyle = styles.labels.groups[styleGroupSelect.value];
-  if (groupStyle) groupStyle.attrs.filter = this.value || null;
+  if (styleGroupSelect.value === "ocean") {
+    styles.ocean.oceanLayers.attrs.filter = this.value || null;
+    return Styles.write("ocean");
+  }
+  writeSelectedAttr("filter", this.value || null);
 });
 
 styleTextureInput.addEventListener("change", function () {
@@ -591,7 +591,7 @@ styleTextureShiftY.addEventListener("input", function () {
 });
 
 styleClippingInput.addEventListener("change", function () {
-  getEl().attr("mask", this.value);
+  writeSelectedAttr("mask", this.value || null);
 });
 
 styleGridType.addEventListener("change", function () {
@@ -628,7 +628,8 @@ styleRescaleMarkers.addEventListener("change", function () {
 });
 
 styleOceanFill.addEventListener("input", function () {
-  d3.select("#oceanLayers").select("rect").attr("fill", this.value);
+  styles.ocean.base.attrs.fill = this.value;
+  Styles.write("ocean");
   styleOceanFillOutput.value = this.value;
 });
 
@@ -820,25 +821,30 @@ styleReliefDensity.addEventListener("change", e => {
 });
 
 styleTemperatureFillOpacityInput.addEventListener("input", e => {
-  d3.select("#temperature").attr("fill-opacity", e.target.value);
+  styles.temperature.attrs["fill-opacity"] = +e.target.value;
+  Styles.write("temperature");
 });
 
 styleTemperatureFontSizeInput.addEventListener("input", e => {
-  d3.select("#temperature").attr("font-size", e.target.value + "px");
+  styles.temperature.attrs["font-size"] = e.target.value + "px";
+  Styles.write("temperature");
 });
 
 styleTemperatureFillInput.addEventListener("input", e => {
-  d3.select("#temperature").attr("fill", e.target.value);
+  styles.temperature.attrs.fill = e.target.value;
+  Styles.write("temperature");
   styleTemperatureFillOutput.value = e.target.value;
 });
 
 stylePopulationRuralStrokeInput.addEventListener("input", e => {
-  d3.select("#population").select("#rural").attr("stroke", e.target.value);
+  styles.population.rural.attrs.stroke = e.target.value;
+  Styles.write("population");
   stylePopulationRuralStrokeOutput.value = e.target.value;
 });
 
 stylePopulationUrbanStrokeInput.addEventListener("input", e => {
-  d3.select("#population").select("#urban").attr("stroke", e.target.value);
+  styles.population.urban.attrs.stroke = e.target.value;
+  Styles.write("population");
   stylePopulationUrbanStrokeOutput.value = e.target.value;
 });
 
@@ -864,7 +870,8 @@ styleCompassShiftY.addEventListener("input", shiftCompass);
 
 function shiftCompass() {
   const tr = `translate(${styleCompassShiftX.value} ${styleCompassShiftY.value}) scale(${styleCompassSizeInput.value})`;
-  d3.select("#compass").select("use").attr("transform", tr);
+  styles.compass.compassRose.attrs.transform = tr;
+  Styles.write("compass");
 }
 
 styleLegendColItems.addEventListener("input", e => {
@@ -874,20 +881,18 @@ styleLegendColItems.addEventListener("input", e => {
 
 styleLegendBack.addEventListener("input", e => {
   styleLegendBackOutput.value = e.target.value;
-  d3.select("#legend").select("#legendBox").attr("fill", e.target.value);
+  styles.legend.box.attrs.fill = e.target.value;
+  Styles.write("legend");
 });
 
 styleLegendOpacity.addEventListener("input", e => {
-  d3.select("#legend").select("#legendBox").attr("fill-opacity", e.target.value);
+  styles.legend.box.attrs["fill-opacity"] = +e.target.value;
+  Styles.write("legend");
 });
 
 styleSelectFont.addEventListener("change", changeFont);
 function changeFont() {
-  const family = styleSelectFont.value;
-  getEl().attr("font-family", family);
-  const groupStyle = styles.labels.groups[styleGroupSelect.value];
-  if (groupStyle) groupStyle.attrs["font-family"] = family;
-
+  writeSelectedAttr("font-family", styleSelectFont.value);
   if (styleElementSelect.value === "legend") Layers.draw("legend");
 }
 
@@ -993,32 +998,36 @@ styleFontShiftX.addEventListener("input", e => applyLabelShift("dx", e.target.va
 styleFontShiftY.addEventListener("input", e => applyLabelShift("dy", e.target.value));
 
 styleStatesBodyOpacity.addEventListener("input", e => {
-  d3.select("#statesBody").attr("opacity", e.target.value);
+  styles.states.statesBody.attrs.opacity = +e.target.value;
+  Styles.write("states");
 });
 
 styleStatesBodyFilter.addEventListener("change", function () {
-  d3.select("#statesBody").attr("filter", this.value);
+  styles.states.statesBody.attrs.filter = this.value || null;
+  Styles.write("states");
 });
 
 styleStatesHaloWidth.addEventListener("input", e => {
   const value = +e.target.value;
   styles.states.statesHalo.options.width = value;
   styles.states.statesHalo.attrs["stroke-width"] = value;
-  d3.select("#statesHalo").attr("stroke-width", value);
+  Styles.write("states");
 });
 
 styleStatesHaloOpacity.addEventListener("input", e => {
-  d3.select("#statesHalo").attr("opacity", e.target.value);
+  styles.states.statesHalo.attrs.opacity = +e.target.value;
+  Styles.write("states");
 });
 
 styleStatesHaloBlur.addEventListener("input", e => {
   const value = Number(e.target.value);
-  const blur = value > 0 ? `blur(${value}px)` : null;
-  d3.select("#statesHalo").attr("filter", blur);
+  styles.states.statesHalo.attrs.filter = value > 0 ? `blur(${value}px)` : null;
+  Styles.write("states");
 });
 
 styleArmiesFillOpacity.addEventListener("input", e => {
-  d3.select("#armies").attr("fill-opacity", e.target.value);
+  styles.military.attrs["fill-opacity"] = +e.target.value;
+  Styles.write("military");
 });
 
 styleArmiesSize.addEventListener("input", e => {
@@ -1064,7 +1073,8 @@ styleGoodsBurgsSize.addEventListener("input", function () {
 });
 
 styleMarketsLayerFillOpacity.addEventListener("input", e => {
-  d3.select("#markets").attr("fill-opacity", e.target.value);
+  styles.markets.attrs["fill-opacity"] = +e.target.value;
+  Styles.write("markets");
 });
 
 styleMarketsSize.addEventListener("input", function () {
@@ -1202,7 +1212,10 @@ styleScaleBar.addEventListener("input", function (event) {
   const { id, value } = event.target;
 
   if (id === "styleScaleBarSize") styles.scaleBar.options.barSize = +value || 1;
-  else if (id === "styleScaleBarFontSize") d3.select("#scaleBar").attr("font-size", value);
+  else if (id === "styleScaleBarFontSize") {
+    styles.scaleBar.attrs["font-size"] = +value || 10;
+    Styles.write("scaleBar");
+  }
   else if (id === "styleScaleBarPositionX") styles.scaleBar.options.x = +value || 0;
   else if (id === "styleScaleBarPositionY") styles.scaleBar.options.y = +value || 0;
   else if (id === "styleScaleBarLabel") styles.scaleBar.options.label = value;
@@ -1224,11 +1237,13 @@ function applyMapFilter(event) {
   if (event.target.tagName !== "BUTTON") return;
   const button = event.target;
   styles.map.options.dataFilter = null;
-  d3.select("#map").attr("filter", null);
+  styles.map.attrs.filter = null;
+  Styles.write("map");
   if (button.classList.contains("pressed")) return button.classList.remove("pressed");
 
   mapFilters.querySelectorAll(".pressed").forEach(button => button.classList.remove("pressed"));
   button.classList.add("pressed");
   styles.map.options.dataFilter = button.id;
-  d3.select("#map").attr("filter", "url(#filter-" + button.id + ")");
+  styles.map.attrs.filter = "url(#filter-" + button.id + ")";
+  Styles.write("map");
 }

--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -419,9 +419,11 @@ function selectStyleElement() {
   styleGroupSelect.options.length = 0; // remove all options
   if (["anchors", "borders", "burgIcons", "coastline", "lakes", "labels", "routes", "terrs"].includes(styleElement)) {
     if (styleElement === "labels") {
+      // count from the label data: the culled DOM only holds labels rendered at this zoom
+      const labelCounts = {};
+      for (const label of window.getLabelsData()) labelCounts[label.group] = (labelCounts[label.group] || 0) + 1;
       options.labels.groups.forEach(group => {
-        const groupElement = ensureEl("labels").querySelector(`[data-group="${CSS.escape(group.name)}"]`);
-        const count = groupElement?.childElementCount || 0;
+        const count = labelCounts[group.name] || 0;
         styleGroupSelect.options.add(new Option(`${group.name} (${count})`, group.name, false, false));
       });
       styleGroupSelect.value = el.attr("data-group");

--- a/src/generators/labels-generator.ts
+++ b/src/generators/labels-generator.ts
@@ -182,4 +182,7 @@ export class LabelsModule {
   }
 }
 
-window.Labels = new LabelsModule();
+const labelsInstance = new LabelsModule();
+window.Labels = labelsInstance;
+
+export { labelsInstance as Labels };

--- a/src/generators/styles-legacy.test.ts
+++ b/src/generators/styles-legacy.test.ts
@@ -2,7 +2,14 @@ import fs from "node:fs";
 import path from "node:path";
 import { expect, test, vi } from "vitest";
 import { Styles } from "./styles";
-import { isLegacyPreset, isStoreStyles, labelGroupFromLegacy, presetFromLegacy, presetToLegacy } from "./styles-legacy";
+import {
+  isLegacyPreset,
+  isStoreStyles,
+  labelGroupFromLegacy,
+  presetFromLegacy,
+  presetToLegacy,
+  styleNodeFor
+} from "./styles-legacy";
 import fixture from "./styles-legacy-default.fixture.json";
 import serializerFixture from "./styles-legacy-serializer.fixture.json";
 import { DEFAULT_STYLES } from "./styles-schema";
@@ -95,6 +102,29 @@ test("R9: #terrs > #landHeights never legitimately carried data-render, so it st
     "data-render" in (serializerFixture as any)["#terrs #landHeights"],
     "data-render was ruled out for landHeights (only #oceanHeights ever wrote it) - it must not appear in the dialect fixture at all, not even as a dropped key"
   ).toBe(false);
+});
+
+test("styleNodeFor resolves editor selections to live store nodes", () => {
+  expect(styleNodeFor("rivers", "")).toEqual({ node: styles.rivers, layer: "rivers" });
+  expect(styleNodeFor("rivers", "rivers")).toEqual({ node: styles.rivers, layer: "rivers" });
+  expect(styleNodeFor("lakes", "freshwater")).toEqual({ node: styles.lakes.freshwater, layer: "lakes" });
+  expect(styleNodeFor("terrs", "landHeights")).toEqual({ node: styles.heightmap.landHeights, layer: "heightmap" });
+  expect(styleNodeFor("labels", "capital")).toEqual({ node: styles.labels.groups.capital, layer: "labels" });
+  expect(styleNodeFor("burgIcons", "town")).toEqual({
+    node: styles.burgIcons.burgIcons.groups.town,
+    layer: "burgIcons"
+  });
+  expect(styleNodeFor("anchors", "capital")).toEqual({
+    node: styles.burgIcons.anchors.groups.capital,
+    layer: "burgIcons"
+  });
+  expect(styleNodeFor("regions", "statesHalo")).toEqual({ node: styles.states.statesHalo, layer: "states" });
+});
+
+test("styleNodeFor returns undefined for structural parents and unknown groups", () => {
+  expect(styleNodeFor("icons", "")).toBeUndefined();
+  expect(styleNodeFor("labels", "no-such-group")).toBeUndefined();
+  expect(styleNodeFor("burgIcons", "no-such-group")).toBeUndefined();
 });
 
 test("numeric-looking string options coerce back to strings, not schema-rejected numbers", () => {

--- a/src/generators/styles-legacy.test.ts
+++ b/src/generators/styles-legacy.test.ts
@@ -137,6 +137,13 @@ test("numeric-looking string options coerce back to strings, not schema-rejected
   expect(styles.markets.options.icon).toBe("8");
 });
 
+test("labelGroupFromLegacy treats a zoom-faded opacity 0 as visible", () => {
+  const group = labelGroupFromLegacy({ opacity: 0 });
+  expect(group.attrs.opacity).toBe(1);
+  expect(labelGroupFromLegacy({ opacity: 0.5 }).attrs.opacity).toBe(0.5);
+  expect(labelGroupFromLegacy({ opacity: null }).attrs.opacity).toBeNull();
+});
+
 test("labelGroupFromLegacy keeps font-size when data-size is absent", () => {
   const group = labelGroupFromLegacy({ "font-size": "6%" });
   expect(group.attrs["font-size"]).toBe("6%");

--- a/src/generators/styles-legacy.ts
+++ b/src/generators/styles-legacy.ts
@@ -21,9 +21,12 @@ const strOr = (value: unknown, fallback: string | null): string | null =>
 
 export function labelGroupFromLegacy(legacy: object): LabelGroupStyle {
   const bag = legacy as Record<string, unknown>;
+  // legacy builds rewrote label-group opacity on every zoom, so a saved 0 is the fade state
+  // at save-time, not a preference - the culled renderer would keep the group invisible forever
+  const opacity = numOr(bag.opacity, 1);
   return {
     attrs: {
-      opacity: numOr(bag.opacity, 1),
+      opacity: opacity === 0 ? 1 : opacity,
       fill: strOr(bag.fill, "#3e3e4b"),
       "fill-opacity": numOr(bag["fill-opacity"], null),
       stroke: strOr(bag.stroke, "#3a3a3a"),

--- a/src/generators/styles-legacy.ts
+++ b/src/generators/styles-legacy.ts
@@ -245,6 +245,25 @@ const PRESET_ROUTES: Record<string, PresetRoute> = {
   "#landmass": { path: ["landmass"] }
 };
 
+// The style editor's element/group selection resolves through the same route table the preset
+// upgrader uses; the first path segment is the store layer to rewrite.
+export function styleNodeFor(element: string, group: string): { node: object; layer: keyof Styles } | undefined {
+  const selector =
+    !group || group === element
+      ? `#${element}`
+      : element === "labels"
+        ? `#labels > #${group}`
+        : element === "burgIcons" || element === "anchors"
+          ? `#${element} > g#${group}`
+          : element === "terrs"
+            ? `#terrs > #${group}`
+            : `#${group}`;
+  const route = routeFor(selector);
+  if (!route) return undefined;
+  const node = getPath(styles, route.path);
+  return node ? { node, layer: route.path[0] as keyof Styles } : undefined;
+}
+
 function routeFor(selector: string): PresetRoute | undefined {
   if (selector in PRESET_ROUTES) return PRESET_ROUTES[selector];
   const label = selector.match(/^#labels > #(.+)$/);
@@ -533,6 +552,7 @@ export function presetToLegacy(source: Styles): Record<string, Record<string, st
 
 // the legacy preset pipeline (public/modules/ui/style-presets.js) converts through these
 globalThis.stylesLegacy = {
+  styleNodeFor,
   labelGroupFromLegacy,
   labelGroupToLegacy,
   labelGroupsFromLegacy,

--- a/src/renderers/labels/label-data.ts
+++ b/src/renderers/labels/label-data.ts
@@ -9,6 +9,8 @@ import type { LabelData } from "@/renderers/labels/labels";
 import type { Point } from "@/types/global";
 import { fitStateLabel } from "./fit-state-label";
 
+window.getLabelsData = getLabelsData;
+
 export function getLabelsData(): LabelData[] {
   const byType: Record<LabelType, LabelData[]> = {
     state: collect(pack.states, buildStateLabel),

--- a/src/services/io/auto-update.test.ts
+++ b/src/services/io/auto-update.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import indexHtml from "@/index.html?raw";
 import "@/generators/features"; // migrations call the Features module through its global
 import { VERSION } from "@/services/versioning";
-import { resolveVersionConflicts } from "./auto-update";
+import { legacyBurgGroupZoom, legacyBurgLabelZoom, resolveVersionConflicts } from "./auto-update";
 
 beforeEach(() => {
   document.body.innerHTML = /* html */ `<svg id="map"><g id="viewbox"></g></svg>`;
@@ -369,5 +369,34 @@ describe("missing svg defs", () => {
 
     const restored = Array.from(document.querySelectorAll("#map defs [id]"), node => node.id);
     expect(restored).toEqual(declared.map(([, id]) => id));
+  });
+});
+
+describe("legacyBurgLabelZoom", () => {
+  it("derives bounds from the legacy font size within the modern envelope", () => {
+    // a modern-sized legacy group lands where the formula says
+    expect(legacyBurgLabelZoom(6)).toEqual({ min: 1, max: 25 });
+    // oversized legacy dialects (asema's cities at 15) must not become always-visible
+    expect(legacyBurgLabelZoom(15).min).toBeGreaterThanOrEqual(1);
+    expect(legacyBurgLabelZoom(15).max).toBeGreaterThanOrEqual(25);
+    // tiny sizes clamp to the least prominent modern tier
+    expect(legacyBurgLabelZoom(1).min).toBeLessThanOrEqual(5);
+    expect(legacyBurgLabelZoom(1).max).toBeLessThanOrEqual(60);
+    // garbage font sizes fall back to the default tier
+    expect(legacyBurgLabelZoom(Number.NaN)).toEqual({ min: 2, max: 30 });
+  });
+});
+
+describe("legacyBurgGroupZoom", () => {
+  it("maps legacy tier names to their modern equivalents' bounds", () => {
+    expect(legacyBurgGroupZoom("cities", 15)).toEqual({ min: 1.4, max: 25 });
+    expect(legacyBurgGroupZoom("towns", 4)).toEqual({ min: 2, max: 30 });
+    expect(legacyBurgGroupZoom("town_small", 4)).toEqual({ min: 3, max: 40 });
+    expect(legacyBurgGroupZoom("town_large", 4)).toEqual({ min: 2, max: 30 });
+  });
+
+  it("falls back to the clamped size formula for unknown group names", () => {
+    expect(legacyBurgGroupZoom("customgroup", 6)).toEqual({ min: 1, max: 25 });
+    expect(legacyBurgGroupZoom("customgroup", 15).min).toBeGreaterThanOrEqual(1);
   });
 });

--- a/src/services/io/auto-update.ts
+++ b/src/services/io/auto-update.ts
@@ -5,7 +5,7 @@ import { RELIEF_SETS } from "@/data/relief-icons";
 import { defaultOptions } from "@/data/view-3d-options";
 import { Emblems } from "@/generators/emblems-generator";
 import type { GraphOverrides } from "@/generators/graph-override";
-import type { Label, LabelNameMode } from "@/generators/labels-generator";
+import { type Label, type LabelNameMode, Labels as LabelsGenerator } from "@/generators/labels-generator";
 import type { Measurer, MeasurerType } from "@/generators/measurers-generator";
 
 import {
@@ -20,8 +20,32 @@ import { getGroupStyle } from "@/renderers/labels/label-groups";
 import { unfog } from "@/renderers/overlays/fogging";
 import { compareVersions } from "@/services/versioning";
 import type { ReliefSet } from "@/types/relief";
-import { ensureEl, findEl, P, parseTransform, rand, rn, rw, safeParseJSON, unique } from "@/utils";
+import { ensureEl, findEl, minmax, P, parseTransform, rand, rn, rw, safeParseJSON, unique } from "@/utils";
 import { parsePathPoints } from "@/utils/pathUtils";
+
+// legacy zoom bounds derive from the group's font size (bigger labels surface earlier), but
+// old size dialects vary wildly - clamp into the modern capital..hamlet envelope so an
+// oversized legacy group can't become always-visible (and a tiny one never-visible)
+export function legacyBurgLabelZoom(fontSize: number): { min: number; max: number } {
+  if (!Number.isFinite(fontSize) || fontSize <= 0) return { min: 2, max: 30 };
+  return { min: minmax(rn(12 / fontSize - 1, 1), 1, 5), max: minmax(rn(120 / fontSize - 1, 1), 25, 60) };
+}
+
+// old-era tier names map onto the modern tiers' visibility, so a migrated map's cities appear
+// at the same zooms a modern city does instead of inheriting formula noise from size dialects
+const LEGACY_BURG_GROUP_EQUIVALENTS: Record<string, string> = {
+  cities: "city",
+  towns: "town",
+  town_small: "village",
+  town_large: "town"
+};
+
+export function legacyBurgGroupZoom(name: string, fontSize: number): { min: number | null; max: number | null } {
+  const modernName = LEGACY_BURG_GROUP_EQUIVALENTS[name];
+  const modern =
+    modernName && LabelsGenerator.getDefaultGroups().find(group => group.type === "burg" && group.name === modernName);
+  return modern ? structuredClone(modern.zoom) : legacyBurgLabelZoom(fontSize);
+}
 
 export async function resolveVersionConflicts(mapVersion: string, data: string[]): Promise<void> {
   const isOlderThan = (tagVersion: string) => compareVersions(mapVersion, tagVersion).isOlder;
@@ -1299,8 +1323,7 @@ export async function resolveVersionConflicts(mapVersion: string, data: string[]
     for (const burgGroup of burgGroups) {
       const name = burgGroup.id;
       const oldStyle = deriveLabelsStyle(burgGroup);
-      const fontSize = Number.parseFloat(oldStyle["font-size"] as string);
-      const zoom = { min: rn(12 / fontSize - 1, 1), max: rn(120 / fontSize - 1, 1) };
+      const zoom = legacyBurgGroupZoom(name, Number.parseFloat(oldStyle["font-size"] as string));
 
       options.labels.groups.push({ name, type: "burg", isDefault: name === "towns", zoom });
       styles.labels.groups[name] = labelGroupFromLegacy(oldStyle);

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -40,6 +40,7 @@ declare global {
     changeMapZoom: typeof import("../components/zoom").changeMapZoom;
     setZoomExtent: typeof import("../components/zoom").setZoomExtent;
     setTranslateExtent: typeof import("../components/zoom").setTranslateExtent;
+    getLabelsData: typeof import("../renderers/labels/label-data").getLabelsData;
   }
 
   var mapId: number;

--- a/tests/e2e/style-editor-events.spec.ts
+++ b/tests/e2e/style-editor-events.spec.ts
@@ -529,6 +529,36 @@ test.describe("style editor events drive the store", () => {
     expect(Object.values(dataCounts).reduce((a, b) => a + b, 0)).toBeGreaterThan(0);
   });
 
+  test("editing one label group leaves sibling groups' derived DOM values untouched", async ({ page }) => {
+    await openStyleElement(page, "labels");
+    const groups = await page.evaluate(() =>
+      Array.from(document.querySelectorAll("#labels > [data-group]")).map(el => (el as HTMLElement).dataset.group)
+    );
+    const target = groups[0]!;
+    const sibling = groups.find(g => g !== target)!;
+    expect(sibling).toBeTruthy();
+
+    // simulate a zoom-derived sibling value living only on the DOM
+    await page.evaluate(g => {
+      document.querySelector(`#labels > [data-group="${g}"]`)!.setAttribute("stroke-width", "7.77");
+    }, sibling);
+
+    await page.locator("#styleGroupSelect").selectOption(target);
+    await page.locator("#styleStrokeWidthInput input[type=number]").fill("2.5");
+
+    const after = await page.evaluate(
+      ([t, s]) => ({
+        target: document.querySelector(`#labels > [data-group="${t}"]`)!.getAttribute("stroke-width"),
+        sibling: document.querySelector(`#labels > [data-group="${s}"]`)!.getAttribute("stroke-width"),
+        stored: (window as any).styles.labels.groups[t as string].attrs["stroke-width"]
+      }),
+      [target, sibling]
+    );
+    expect(after.stored).toBe(2.5);
+    expect(after.target).toBe("2.5");
+    expect(after.sibling, "sibling derived DOM value must survive").toBe("7.77");
+  });
+
   test("compass shift writes the rose transform through the store", async ({ page }) => {
     await page.evaluate(() => (window as any).Layers.show("compass"));
     await openStyleElement(page, "compass");

--- a/tests/e2e/style-editor-events.spec.ts
+++ b/tests/e2e/style-editor-events.spec.ts
@@ -13,7 +13,7 @@ const waitForMap = (page: Page) =>
 
 const rn = (v: number, d = 0): number => Math.round(v * 10 ** d) / 10 ** d;
 
-async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates" | "ruler" | "legend" | "emblems" | "goodsIcons" | "goodsBurgs" | "markets" | "terrs" | "armies" | "gridOverlay" | "texture" | "ocean" | "scaleBar" | "labels"): Promise<void> {
+async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates" | "ruler" | "legend" | "emblems" | "goodsIcons" | "goodsBurgs" | "markets" | "terrs" | "armies" | "gridOverlay" | "texture" | "ocean" | "scaleBar" | "labels" | "lakes" | "rivers" | "compass"): Promise<void> {
   await page.evaluate(() => (window as any).showOptions());
   await page.locator("#styleTab").click();
   await page.locator("#styleElementSelect").selectOption(element);
@@ -469,10 +469,48 @@ test.describe("style editor events drive the store", () => {
 
   test("legend column input writes the store", async ({ page }) => {
     await openStyleElement(page, "legend");
-    await page.locator("#styleLegendColItems").fill("3");
+    await page.locator("#styleLegendColItems input[type=number]").fill("3");
     await page.locator("#styleLegendColItems").dispatchEvent("input");
 
     expect(await page.evaluate(() => (window as any).styles.legend.options.columns)).toBe(3);
     expect(await page.locator("#legend").getAttribute("data-columns")).toBeNull();
+  });
+
+  test("generic attr controls write the store for any selection", async ({ page }) => {
+    // nested group selection: lakes > freshwater
+    await openStyleElement(page, "lakes");
+    await page.locator("#styleGroupSelect").selectOption("freshwater");
+    await page.locator("#styleFillInput").fill("#123456");
+    await page.locator("#styleFillInput").dispatchEvent("input");
+    await page.locator("#styleStrokeWidthInput input[type=number]").fill("3");
+
+    // flat element selection: rivers
+    await openStyleElement(page, "rivers");
+    await page.locator("#styleOpacityInput input[type=number]").fill("0.4");
+
+    const stored = await page.evaluate(() => ({
+      lakeFill: (window as any).styles.lakes.freshwater.attrs.fill,
+      lakeStrokeWidth: (window as any).styles.lakes.freshwater.attrs["stroke-width"],
+      riversOpacity: (window as any).styles.rivers.attrs.opacity
+    }));
+    expect(stored).toEqual({ lakeFill: "#123456", lakeStrokeWidth: 3, riversOpacity: 0.4 });
+    expect(typeof stored.lakeStrokeWidth).toBe("number");
+    expect(typeof stored.riversOpacity).toBe("number");
+
+    // the DOM presentation is written identically
+    await expect(page.locator('#lakes [data-group="freshwater"], #freshwater').first()).toHaveAttribute("fill", "#123456");
+    await expect(page.locator("#rivers")).toHaveAttribute("opacity", "0.4");
+  });
+
+  test("compass shift writes the rose transform through the store", async ({ page }) => {
+    await page.evaluate(() => (window as any).Layers.show("compass"));
+    await openStyleElement(page, "compass");
+
+    await page.locator("#styleCompassShiftX").fill("30");
+    await page.locator("#styleCompassShiftX").dispatchEvent("input");
+
+    const stored = await page.evaluate(() => (window as any).styles.compass.compassRose.attrs.transform);
+    expect(stored).toContain("translate(30");
+    await expect(page.locator("#compass use")).toHaveAttribute("transform", stored);
   });
 });

--- a/tests/e2e/style-editor-events.spec.ts
+++ b/tests/e2e/style-editor-events.spec.ts
@@ -502,6 +502,33 @@ test.describe("style editor events drive the store", () => {
     await expect(page.locator("#rivers")).toHaveAttribute("opacity", "0.4");
   });
 
+  test("label group dropdown counts come from the label data, not the culled DOM", async ({ page }) => {
+    // zoom in so some label tiers are culled from the DOM while their data still exists
+    await page.evaluate(() => (window as any).setMapZoom(6));
+    await page.waitForTimeout(200);
+    await openStyleElement(page, "labels");
+
+    const { optionCounts, dataCounts } = await page.evaluate(() => {
+      const dataCounts: Record<string, number> = {};
+      for (const label of (window as any).getLabelsData()) {
+        dataCounts[label.group] = (dataCounts[label.group] || 0) + 1;
+      }
+      const optionCounts: Record<string, number> = {};
+      for (const option of (document.getElementById("styleGroupSelect") as HTMLSelectElement).options) {
+        const match = option.text.match(/^(.*) \((\d+)\)$/);
+        if (match) optionCounts[match[1]] = Number(match[2]);
+      }
+      return { optionCounts, dataCounts };
+    });
+
+    expect(Object.keys(optionCounts).length).toBeGreaterThan(0);
+    for (const [group, count] of Object.entries(optionCounts)) {
+      expect(count, `dropdown count for ${group}`).toBe(dataCounts[group] || 0);
+    }
+    // at least one group must have labels in data at all, or the test proves nothing
+    expect(Object.values(dataCounts).reduce((a, b) => a + b, 0)).toBeGreaterThan(0);
+  });
+
   test("compass shift writes the rose transform through the store", async ({ page }) => {
     await page.evaluate(() => (window as any).Layers.show("compass"));
     await openStyleElement(page, "compass");


### PR DESCRIPTION
First step-6 chunk (docs/prd/style-migration.md): every attr control in the style editor mutates the store. UI unchanged by contract — the parity baselines are untouched, which makes the conversion provably pixel-identical.

## How

- `styleNodeFor(element, group)` resolves the editor's selection to its live store node through the same route table the preset upgrader uses (that table lives forever with the upgrader, so this is reuse, not new coupling). Structural parents (#icons, …) and the display toggle keep their direct DOM writes.
- Generic controls (fill, stroke, widths, dasharray, linecap, opacity, filter, mask, font-family) and every fixed-path handler (ocean fill, temperature, population strokes, states body/halo, armies/markets fill-opacity, legend box, compass rose, scale-bar font size, map filter buttons) mirror the edit into the store and write ONLY the edited attribute to the DOM.
- **Editor handlers never whole-layer-write**: a Styles.write over a layer resets sibling groups' zoom-derived values (an earlier iteration made river labels change while editing the cities group — caught in validation, pinned by a sibling-survival e2e). Styles.write belongs to preset/load flows.
- Read sites stay on the DOM deliberately: they run in selectStyleElement's stale-group-select window where only the DOM fallback picks the right group, and the values are identical by invariant.

## Fixes that surfaced during validation on a real 1.113-era map

- **Label group dropdown counts** come from getLabelsData() instead of childElementCount — since the culled renderer, the DOM count meant "rendered at this zoom in this viewport", showing (0) for tiers with hundreds of labels.
- **Zoom-faded label opacity**: old builds rewrote label-group opacity every zoom, so a map saved with a tier faded out carries opacity 0 as dead state the culled renderer never recomputes — groups invisible forever. The legacy converter reads an exact 0 as the fade artifact it is.
- **Migrated label zoom bounds**: the 1.140 migration derived visibility from the legacy font size, and old size dialects pushed the minimum below zero — every city label rendered at full zoom-out and the registry persisted the spam into new maps. Legacy tier names now map onto their modern equivalents' bounds (cities→city, towns→town, town_small→village, town_large→town), with the size formula clamped into the modern envelope for unknown names. Verified: 0 city labels at fit zoom on the 1.113 map, appearing from zoom 1.4 like a modern city.

## Verification

- Resolver unit tests (incl. structural-parent misses), zoom-bounds helper unit tests, editor-events e2e 22/22 (generic controls across nested + flat selections, compass data-group addressing, sibling-survival, data-driven dropdown counts).
- Parity spec passes with ZERO baseline diff.
- tsc, biome, 458 unit + 33 browser tests, full Playwright suite 170/170; manual validation on generated and 1.113-era maps.