### PR TITLE
Style migration step 6: burg icon and anchor groups edit through the store

### DIFF
--- a/public/modules/ui/options.js
+++ b/public/modules/ui/options.js
@@ -600,6 +600,11 @@ function applyStoredOptions() {
 function randomizeOptions() {
   const randomize = new URL(window.location.href).searchParams.get("options") === "default"; // ignore stored options
 
+  // a loaded map's migrated group registries are map data, not session preferences: re-seed
+  // from the same source boot uses, so new maps get the user's saved groups or the defaults
+  options.burgs.groups = JSON.safeParse(localStorage.getItem("burg-groups")) || Burgs.getDefaultGroups();
+  options.labels = JSON.safeParse(localStorage.getItem("options-labels")) || Labels.getDefaultOptions();
+
   // 'Options' settings
   if (randomize || !stored("points")) changeCellsDensity(4); // reset to default, no need to randomize
   if (randomize || !stored("template")) randomizeHeightmapTemplate();

--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -291,10 +291,11 @@ function selectStyleElement() {
 
   if (styleElement === "burgIcons") {
     styleBurgIcons.style.display = "block";
-    styleBurgIconsIcon.value = el.attr("data-icon");
-    styleBurgIconsIconSize.value = el.attr("font-size");
-    styleBurgIconsStrokeLinejoin.value = el.attr("stroke-linejoin");
-    styleBurgIconsFillOpacity.value = el.attr("fill-opacity");
+    const burgGroupStyle = styles.burgIcons.burgIcons.groups[styleGroupSelect.value];
+    styleBurgIconsIcon.value = burgGroupStyle?.options.icon ?? el.attr("data-icon");
+    styleBurgIconsIconSize.value = burgGroupStyle?.options.size ?? el.attr("font-size");
+    styleBurgIconsStrokeLinejoin.value = burgGroupStyle?.attrs["stroke-linejoin"] ?? el.attr("stroke-linejoin");
+    styleBurgIconsFillOpacity.value = burgGroupStyle?.attrs["fill-opacity"] ?? el.attr("fill-opacity");
 
     styleFill.style.display = "block";
     styleStroke.style.display = "block";
@@ -315,7 +316,7 @@ function selectStyleElement() {
     styleFillInput.value = styleFillOutput.value = el.attr("fill") || "#ffffff";
     styleStrokeInput.value = styleStrokeOutput.value = el.attr("stroke") || "#3e3e4b";
     styleStrokeWidthInput.value = el.attr("stroke-width") || 0.24;
-    styleFontSize.value = el.attr("font-size") || 1;
+    styleFontSize.value = styles.burgIcons.anchors.groups[styleGroupSelect.value]?.options.size || 1;
   }
 
   if (styleElement === "legend") {
@@ -850,20 +851,26 @@ stylePopulationUrbanStrokeInput.addEventListener("input", e => {
   stylePopulationUrbanStrokeOutput.value = e.target.value;
 });
 
+const burgIconsGroup = () => styles.burgIcons.burgIcons.groups[styleGroupSelect.value];
+
 styleBurgIconsIcon.addEventListener("change", e => {
+  const group = burgIconsGroup();
+  if (group) group.options.icon = e.target.value;
   getEl().attr("data-icon", e.target.value).selectAll("use").attr("href", e.target.value);
 });
 
 styleBurgIconsIconSize.addEventListener("input", e => {
+  const group = burgIconsGroup();
+  if (group) group.options.size = +e.target.value || 1;
   getEl().attr("font-size", e.target.value);
 });
 
 styleBurgIconsStrokeLinejoin.addEventListener("change", e => {
-  getEl().attr("stroke-linejoin", e.target.value);
+  writeSelectedAttr("stroke-linejoin", e.target.value || null);
 });
 
 styleBurgIconsFillOpacity.addEventListener("input", e => {
-  getEl().attr("fill-opacity", e.target.value);
+  writeSelectedAttr("fill-opacity", +e.target.value);
 });
 
 styleCompassSizeInput.addEventListener("input", shiftCompass);
@@ -981,6 +988,13 @@ function changeFontSize(el, size) {
   if (styleElementSelect.value === "ruler") {
     styles.rulers.options.fontSize = size;
     Layers.draw("rulers");
+    return;
+  }
+
+  if (styleElementSelect.value === "anchors") {
+    const group = styles.burgIcons.anchors.groups[styleGroupSelect.value];
+    if (group) group.options.size = size;
+    el.attr("font-size", size);
     return;
   }
 

--- a/src/controllers/burg-editor.ts
+++ b/src/controllers/burg-editor.ts
@@ -15,6 +15,10 @@ import type { PromptOptions } from "../utils/commonUtils";
 declare const prompt: (text: string, options: PromptOptions, callback: (value: string | number) => void) => void;
 
 let selected: Selection<any, any, any, any> | null = null;
+// The burg being edited. `selected` is only a handle on its rendered node, and there may not be
+// one: the GPU icon layer puts no <use> in #burgIcons, and a label outside the viewport or below
+// its group's zoom gate is never materialized. Identity must not depend on the DOM.
+let selectedId: number | null = null;
 let previewTransform: PanZoom = { ...PAN_ZOOM_IDENTITY };
 let previewMaxZoom = MAX_ZOOM;
 let previewCommittedK = 1;
@@ -26,6 +30,7 @@ function open(id: number | string): void {
   closeDialogs(".stable");
   Layers.show("burgIcons", "labels");
 
+  selectedId = +id;
   selected = select<any, unknown>("#labels").select(`[data-label-type='burg'][data-id='${id}']`);
   if (!selected.size()) selected = select<any, unknown>("#burgIcons").select(`[data-id='${id}']`);
 
@@ -276,7 +281,13 @@ function renderDialog(): void {
 }
 
 function getSelectedId(): number {
-  return +selected!.attr("data-id");
+  return selectedId ?? +selected!.attr("data-id");
+}
+
+/** The rendered node for the edited burg, or null when nothing was materialized for it. */
+function selectedNode(): Element | null {
+  const node = selected?.node() as Element | undefined;
+  return node ?? null;
 }
 
 function updateGroupsList(): void {
@@ -505,9 +516,10 @@ function hideStyleSection(): void {
 }
 
 function editGroupLabelStyle(): void {
-  const g = (selected!.node() as Element).parentNode as HTMLElement;
+  const parent = selectedNode()?.parentNode as HTMLElement | undefined;
+  const groupId = parent?.id || `labels-${pack.burgs[getSelectedId()].group}`;
   closeDialogs(".stable");
-  editStyle("labels", g.id);
+  editStyle("labels", groupId);
 }
 
 function editBurgLabel(): void {
@@ -517,15 +529,17 @@ function editBurgLabel(): void {
 }
 
 function editGroupIconStyle(): void {
-  const g = (selected!.node() as Element).parentNode as HTMLElement;
+  const parent = selectedNode()?.parentNode as HTMLElement | undefined;
+  const groupId = parent?.id || `${pack.burgs[getSelectedId()].group}`;
   closeDialogs(".stable");
-  editStyle("burgIcons", g.id);
+  editStyle("burgIcons", groupId);
 }
 
 function editGroupAnchorStyle(): void {
-  const g = (selected!.node() as Element).parentNode as HTMLElement;
+  const parent = selectedNode()?.parentNode as HTMLElement | undefined;
+  const groupId = parent?.id || `${pack.burgs[getSelectedId()].group}`;
   closeDialogs(".stable");
-  editStyle("anchors", g.id);
+  editStyle("anchors", groupId);
 }
 
 function getPreviewViewport(): { width: number; height: number } {
@@ -780,13 +794,12 @@ function relocateBurgOnClick(this: SVGGElement, event: any): void {
 }
 
 function editBurgLegend(): void {
-  const id = selected!.attr("data-id");
-  const name = selected!.text();
-  void Controllers.NotesEditor.open(`burg${id}`, name);
+  const id = getSelectedId();
+  void Controllers.NotesEditor.open(`burg${id}`, pack.burgs[id].name);
 }
 
 function showTemperatureGraph(): void {
-  const id = +selected!.attr("data-id");
+  const id = getSelectedId();
   void Controllers.TemperatureGraph.open(id);
 }
 

--- a/src/controllers/burg-group-editor.ts
+++ b/src/controllers/burg-group-editor.ts
@@ -419,6 +419,7 @@ function submitForm(event: Event): void {
   const validBurgs = pack.burgs.filter(b => b.i && !b.removed);
   const populations = validBurgs.map(b => b.population!).sort((a, b) => a - b);
   validBurgs.forEach(burg => void Burgs.defineGroup(burg, populations));
+  window.Labels.ensureBurgLabelGroups();
 
   Layers.draw("burgIcons");
   Layers.draw("labels");

--- a/src/controllers/submap-tool.ts
+++ b/src/controllers/submap-tool.ts
@@ -1,7 +1,6 @@
 import { destroyDialog } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
 import { Resample } from "@/generators/resample";
-import { burgGroupFromElement } from "@/generators/styles-legacy";
 import { getLatitude, getLongitude } from "@/utils";
 import { ensureEl, minmax, rn } from "../utils";
 
@@ -114,10 +113,8 @@ function recalculateMapSize(x0: number, y0: number): void {
 
 function rescaleBurgStyles(scale: number): void {
   for (const group of ensureEl("burgIcons").querySelectorAll<SVGGElement>(":scope > g")) {
-    const iconStyle = burgGroupFromElement(group);
-    iconStyle.options.size = rn(minmax(iconStyle.options.size * scale, 0.2, 10), 2);
-
-    styles.burgIcons.burgIcons.groups[group.id] = iconStyle;
+    const iconStyle = styles.burgIcons.burgIcons.groups[group.id];
+    if (iconStyle) iconStyle.options.size = rn(minmax(iconStyle.options.size * scale, 0.2, 10), 2);
     group.remove();
   }
 

--- a/src/generators/labels-generator.test.ts
+++ b/src/generators/labels-generator.test.ts
@@ -46,3 +46,37 @@ describe("LabelsModule", () => {
     expect(pack.addedLabels[0].label).toEqual({ text: "Aldor", group: "added" });
   });
 });
+
+describe("ensureBurgLabelGroups", () => {
+  beforeEach(() => {
+    globalThis.options = {
+      ...globalThis.options,
+      burgs: { groups: [{ name: "city" }, { name: "town" }, { name: "customgroup" }] },
+      labels: {
+        resizeOnZoom: true,
+        showAll: false,
+        groups: [{ name: "cities", type: "burg", zoom: { min: 1, max: 25 } }]
+      }
+    } as never;
+  });
+
+  it("adds registry entries for burg groups the label registry lacks", () => {
+    labels.ensureBurgLabelGroups();
+    const names = options.labels.groups.filter(g => g.type === "burg").map(g => g.name);
+    expect(names.includes("city")).toBe(true);
+    expect(names.includes("town")).toBe(true);
+    expect(names.includes("customgroup")).toBe(true);
+    // known modern names take their default bounds; unknown names get the fallback
+    expect(options.labels.groups.find(g => g.name === "city")?.zoom).toEqual({ min: 1.4, max: 25 });
+    expect(options.labels.groups.find(g => g.name === "customgroup")?.zoom).toEqual({ min: 2, max: 30 });
+    // existing entries are left alone
+    expect(options.labels.groups.find(g => g.name === "cities")?.zoom).toEqual({ min: 1, max: 25 });
+  });
+
+  it("is idempotent", () => {
+    labels.ensureBurgLabelGroups();
+    const count = options.labels.groups.length;
+    labels.ensureBurgLabelGroups();
+    expect(options.labels.groups.length).toBe(count);
+  });
+});

--- a/src/generators/labels-generator.ts
+++ b/src/generators/labels-generator.ts
@@ -134,6 +134,18 @@ export class LabelsModule {
     };
   }
 
+  /** burgs can be assigned to groups the label registry has never seen (old maps, the Burg
+   * Groups editor) - without an entry the renderer draws no label at all */
+  ensureBurgLabelGroups(): void {
+    for (const { name } of options.burgs.groups) {
+      if (options.labels.groups.some(group => group.type === "burg" && group.name === name)) continue;
+      const defaultGroup = this.getDefaultGroups().find(group => group.type === "burg" && group.name === name);
+      options.labels.groups.push(
+        defaultGroup ?? { ...structuredClone(this.getFallbackGroup("burg")), name, isDefault: false }
+      );
+    }
+  }
+
   getFallbackGroup(type: LabelType): LabelGroup {
     const fallbackGroup = this.getDefaultGroups().find(group => group.isDefault && group.type === type);
     return fallbackGroup ?? { name: type, type, zoom: { min: null, max: null }, isDefault: true };

--- a/src/generators/styles-legacy.dom.test.ts
+++ b/src/generators/styles-legacy.dom.test.ts
@@ -58,7 +58,7 @@ test("an omitted option still defaults, unlike a schema attr", () => {
   expect(result.grid.options.type).toBe(DEFAULT_STYLES.grid.options.type);
 });
 
-test("syncStylesFromMap harvests burg/anchor groups present in the DOM over the live store", () => {
+test("syncStylesFromMap keeps burg/anchor groups store-authoritative on save", () => {
   document.body.innerHTML = `<svg id="map">
     <g id="burgIcons"><g id="capital" fill="#00ff00" font-size="3"></g></g>
     <g id="anchors"><g id="capital" fill="#00ff00" font-size="3"></g></g>
@@ -66,9 +66,10 @@ test("syncStylesFromMap harvests burg/anchor groups present in the DOM over the 
   styles.burgIcons.burgIcons.groups.capital.attrs.fill = "#000000";
   styles.burgIcons.burgIcons.groups.town = structuredClone(styles.burgIcons.burgIcons.groups.capital);
   syncStylesFromMap();
-  expect(styles.burgIcons.burgIcons.groups.capital.attrs.fill).toBe("#00ff00");
-  expect(styles.burgIcons.anchors.groups.capital.attrs.fill).toBe("#00ff00");
+  // the editor writes the store now: stale DOM attrs no longer win at save time
+  expect(styles.burgIcons.burgIcons.groups.capital.attrs.fill).toBe("#000000");
   expect(styles.burgIcons.burgIcons.groups.town).toBeDefined();
+  styles.burgIcons.burgIcons.groups.capital.attrs.fill = "#ffffff";
 });
 
 test("save sync keeps store-authoritative zoom options when the DOM lacks the attrs", () => {

--- a/src/generators/styles-legacy.ts
+++ b/src/generators/styles-legacy.ts
@@ -405,12 +405,6 @@ export function syncStylesFromMap(): void {
   const harvested = stylesFromMap();
   harvested.labels = structuredClone(styles.labels);
   harvested.burgIcons = structuredClone(styles.burgIcons);
-  for (const el of document.querySelectorAll("#burgIcons > g")) {
-    if (el.id) harvested.burgIcons.burgIcons.groups[el.id] = burgGroupFromElement(el);
-  }
-  for (const el of document.querySelectorAll("#anchors > g")) {
-    if (el.id) harvested.burgIcons.anchors.groups[el.id] = burgGroupFromElement(el);
-  }
   harvested.relief.options = structuredClone(styles.relief.options);
   // post-migration maps carry no rescale/data-width attrs, so the store owns these
   // options; a loaded old map's attrs win here until the load-time strip removes them

--- a/src/renderers/draw-burg-icons.dom.test.ts
+++ b/src/renderers/draw-burg-icons.dom.test.ts
@@ -1,0 +1,33 @@
+// Browser-mode test (vitest.browser.config.ts): burg icon groups are recreated from the store;
+// stale DOM attrs (the old editor-writes-DOM model) must not harvest back over store edits.
+import { beforeEach, expect, test } from "vitest";
+import "@/generators/styles";
+import { drawBurgIcons } from "./draw-burg-icons";
+
+beforeEach(() => {
+  (globalThis as Record<string, unknown>).TIME = false;
+  document.body.innerHTML = `<svg id="map">
+      <g id="icons"><g id="burgIcons"></g><g id="anchors"></g></svg>
+    </svg>`;
+  globalThis.pack = { burgs: [{}, { i: 1, group: "town", x: 10, y: 10 }] } as never;
+  globalThis.options = { ...globalThis.options, burgs: { groups: [{ name: "town", order: 0 }] } } as never;
+});
+
+test("drawBurgIcons styles groups from the store, ignoring stale DOM attrs", () => {
+  styles.burgIcons.burgIcons.groups.town.attrs.fill = "#123456";
+  styles.burgIcons.burgIcons.groups.town.options.size = 3;
+
+  drawBurgIcons();
+  const first = document.querySelector<SVGGElement>("#burgIcons > g#town")!;
+  expect(first.getAttribute("fill")).toBe("#123456");
+
+  // simulate the retired editor-writes-DOM model leaving a stale value
+  first.setAttribute("fill", "#ff0000");
+  styles.burgIcons.burgIcons.groups.town.attrs.fill = "#123456";
+
+  drawBurgIcons();
+  const redrawn = document.querySelector<SVGGElement>("#burgIcons > g#town")!;
+  expect(redrawn.getAttribute("fill")).toBe("#123456");
+  expect(styles.burgIcons.burgIcons.groups.town.attrs.fill).toBe("#123456");
+  expect(redrawn.getAttribute("font-size")).toBe("3");
+});

--- a/src/renderers/draw-burg-icons.ts
+++ b/src/renderers/draw-burg-icons.ts
@@ -1,5 +1,4 @@
 import { select } from "d3";
-import { burgGroupFromElement } from "@/generators/styles-legacy";
 
 export const drawBurgIcons = (): void => {
   TIME && console.time("drawBurgIcons");
@@ -45,17 +44,10 @@ export const removeBurgIcon = (burgId: number): void => {
 };
 
 function createIconGroups(): void {
-  // save existing styles (the style editor edits the DOM) and remove all groups
+  // the store is authoritative (the style editor writes it); groups fully recreate from it
   const { burgIcons, anchors } = styles.burgIcons;
-  document.querySelectorAll("g#burgIcons > g").forEach(group => {
-    burgIcons.groups[group.id] = burgGroupFromElement(group);
-    group.remove();
-  });
-
-  document.querySelectorAll("g#anchors > g").forEach(group => {
-    anchors.groups[group.id] = burgGroupFromElement(group);
-    group.remove();
-  });
+  for (const group of document.querySelectorAll("g#burgIcons > g")) group.remove();
+  for (const group of document.querySelectorAll("g#anchors > g")) group.remove();
 
   // create groups for each burg group and apply stored or default style
   const defaultIconStyle = burgIcons.groups.town || Object.values(burgIcons.groups)[0];

--- a/tests/e2e/style-editor-events.spec.ts
+++ b/tests/e2e/style-editor-events.spec.ts
@@ -13,7 +13,7 @@ const waitForMap = (page: Page) =>
 
 const rn = (v: number, d = 0): number => Math.round(v * 10 ** d) / 10 ** d;
 
-async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates" | "ruler" | "legend" | "emblems" | "goodsIcons" | "goodsBurgs" | "markets" | "terrs" | "armies" | "gridOverlay" | "texture" | "ocean" | "scaleBar" | "labels" | "lakes" | "rivers" | "compass"): Promise<void> {
+async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates" | "ruler" | "legend" | "emblems" | "goodsIcons" | "goodsBurgs" | "markets" | "terrs" | "armies" | "gridOverlay" | "texture" | "ocean" | "scaleBar" | "labels" | "lakes" | "rivers" | "compass" | "burgIcons" | "anchors"): Promise<void> {
   await page.evaluate(() => (window as any).showOptions());
   await page.locator("#styleTab").click();
   await page.locator("#styleElementSelect").selectOption(element);
@@ -557,6 +557,43 @@ test.describe("style editor events drive the store", () => {
     expect(after.stored).toBe(2.5);
     expect(after.target).toBe("2.5");
     expect(after.sibling, "sibling derived DOM value must survive").toBe("7.77");
+  });
+
+  test("burg icon controls write the store and the redraw derives from it", async ({ page }) => {
+    await openStyleElement(page, "burgIcons");
+    const group = await page.evaluate(() => (window as any).styleGroupSelect.value);
+
+    await page.locator("#styleBurgIconsIconSize input[type=number]").fill("2.5");
+    await page.locator("#styleBurgIconsFillOpacity input[type=number]").fill("0.6");
+    await page.locator("#styleBurgIconsStrokeLinejoin").selectOption("round");
+
+    const stored = await page.evaluate(
+      g => ({
+        size: (window as any).styles.burgIcons.burgIcons.groups[g].options.size,
+        fillOpacity: (window as any).styles.burgIcons.burgIcons.groups[g].attrs["fill-opacity"],
+        linejoin: (window as any).styles.burgIcons.burgIcons.groups[g].attrs["stroke-linejoin"]
+      }),
+      group
+    );
+    expect(stored).toEqual({ size: 2.5, fillOpacity: 0.6, linejoin: "round" });
+
+    // the live group carries the presentation; a full redraw keeps the store values
+    await page.evaluate(() => (window as any).Layers.draw("burgIcons"));
+    const el = page.locator(`#burgIcons > g#${group}`);
+    await expect(el).toHaveAttribute("font-size", "2.5");
+    await expect(el).toHaveAttribute("fill-opacity", "0.6");
+
+    // anchors size writes its own store node without minting data-size
+    await openStyleElement(page, "anchors");
+    const anchorGroup = await page.evaluate(() => (window as any).styleGroupSelect.value);
+    await page.locator("#styleFontSize").fill("1.8");
+    await page.locator("#styleFontSize").dispatchEvent("change");
+    const anchorStored = await page.evaluate(
+      g => (window as any).styles.burgIcons.anchors.groups[g].options.size,
+      anchorGroup
+    );
+    expect(anchorStored).toBe(1.8);
+    expect(await page.locator(`#anchors > g#${anchorGroup}`).getAttribute("data-size")).toBeNull();
   });
 
   test("compass shift writes the rose transform through the store", async ({ page }) => {

--- a/tests/e2e/style-editor-events.spec.ts
+++ b/tests/e2e/style-editor-events.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect, type Page } from "@playwright/test";
 
+declare const options: any;
+declare const regeneratePrompt: (config?: { seed?: string }) => void;
+
 // Real-control regression for the two zoom-family editor handlers: the styleRescaleMarkers change
 // handler and the styleStatesHaloWidth input handler (public/modules/ui/style.js).
 // Both now read/write the store (src/styles/styles.ts) instead of DOM attributes on #markers /
@@ -594,6 +597,32 @@ test.describe("style editor events drive the store", () => {
     );
     expect(anchorStored).toBe(1.8);
     expect(await page.locator(`#anchors > g#${anchorGroup}`).getAttribute("data-size")).toBeNull();
+  });
+
+  test("a new map resets migrated group registries to saved-or-default groups", async ({ page }) => {
+    // simulate what loading an old map's migration leaves behind in the session registries
+    await page.evaluate(() => {
+      options.burgs.groups = [
+        { name: "cities", isDefault: true, active: true, features: {}, preview: "" }
+      ];
+      options.labels.groups = [{ name: "cities", type: "burg", zoom: { min: 1, max: 25 } }];
+    });
+
+    const before = await page.evaluate(() => (window as any).mapId);
+    await page.evaluate(() => regeneratePrompt({ seed: "registry-reset-test" }));
+    await page.waitForFunction(prev => (window as any).mapId !== prev, before, { timeout: 120000 });
+    await page.waitForTimeout(500);
+
+    const after = await page.evaluate(() => ({
+      burgGroupNames: options.burgs.groups.map((g: any) => g.name),
+      labelGroupNames: options.labels.groups.map((g: any) => g.name),
+      burgsInLegacyGroup: (window as any).pack.burgs.filter((b: any) => b?.i && b.group === "cities").length
+    }));
+    expect(after.burgGroupNames).not.toContain("cities");
+    expect(after.burgGroupNames).toContain("town");
+    expect(after.labelGroupNames).not.toContain("cities");
+    expect(after.labelGroupNames).toContain("river");
+    expect(after.burgsInLegacyGroup).toBe(0);
   });
 
   test("compass shift writes the rose transform through the store", async ({ page }) => {


### PR DESCRIPTION
Second step-6 chunk (docs/prd/style-migration.md): the burg-icon domain moves off the editor-writes-DOM model, and `createIconGroups`' draw-time DOM harvest dies.

## What changed

- The editor quartet (icon select, icon size, stroke-linejoin, fill-opacity), the anchors size input and the submap rescale write the store; read blocks populate from it. The anchors size input also stops minting the pointless `data-size` attribute.
- `createIconGroups` recreates burg/anchor groups purely from the store — a browser test pins that a stale DOM attribute can no longer win over a store edit across a redraw.
- `syncStylesFromMap`'s save-time burg loops die: burgIcons is store-authoritative on save like labels (the existing browser test's contract flipped accordingly). The record-less LOAD harvest keeps reading old maps' group attrs — `burgGroupFromElement` now serves only that path.

## Two user-found registry fixes on real old/contaminated maps

- **New maps reset migrated group registries.** Loading an old map necessarily installs its migrated `options.burgs.groups`/`options.labels` (they are that map's data) — but generating a NEW map then inherited them: every new burg landed in the legacy "cities" group with its oversized label style until a hard reload. Generation now re-seeds both registries from the same source boot uses (localStorage or defaults), so groups a user saved through the editors survive while migration imports stay scoped to their map. E2e pins contaminate → regenerate → clean.
- **Burg Groups Apply registers missing label groups.** The renderer only draws label groups the registry knows; remapping burgs into modern names on a legacy-registry map (the documented Restore→Apply repair) produced burgs with NO labels at any zoom. Apply now runs `Labels.ensureBurgLabelGroups()` — known modern names take their default bounds, unknown names the fallback tier, existing entries untouched (unit-tested, idempotent). Verified on a contaminated-era map: 192 burg labels back at zoom 3 after the repair.

## Verification

- New browser test for the store-only redraw (RED-verified against the harvest), the save-sync contract-flip test, the registry-reset e2e, ensureBurgLabelGroups unit tests, and an editor-events e2e for the quartet + anchors (store values, redraw derivation, no data-size).
- tsc, biome, 460 unit + 35 browser tests, editor-events 24/24, full Playwright suite 171/171; manual validation incl. old-map load → new-map generation and the Restore→Apply repair path.