### PR TITLE
Style migration step 6: the defs resources get store-driven appliers

### DIFF
--- a/public/modules/ui/style-presets.js
+++ b/public/modules/ui/style-presets.js
@@ -132,18 +132,8 @@ function writeAttrsById(id, attrs) {
 function projectPresetOptions() {
   const byId = id => document.getElementById(id);
 
-  const vignetteRect = byId("vignette-rect");
-  setOrRemove(vignetteRect, "x", styles.vignette.options.x);
-  setOrRemove(vignetteRect, "y", styles.vignette.options.y);
-  setOrRemove(vignetteRect, "width", styles.vignette.options.width);
-  setOrRemove(vignetteRect, "height", styles.vignette.options.height);
-  setOrRemove(vignetteRect, "rx", styles.vignette.options.rx);
-  setOrRemove(vignetteRect, "ry", styles.vignette.options.ry);
-  setOrRemove(vignetteRect, "filter", styles.vignette.options.filter);
-
-  const oceanicPattern = byId("oceanicPattern");
-  setOrRemove(oceanicPattern, "href", styles.ocean.options.pattern);
-  setOrRemove(oceanicPattern, "opacity", styles.ocean.options.patternOpacity);
+  window.applyVignetteOptions();
+  window.applyOceanPattern();
 
   for (const [group, style] of Object.entries(styles.labels.groups)) {
     const el = document.querySelector(`#labels > [data-group="${CSS.escape(group)}"]`);

--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -637,10 +637,12 @@ styleOceanFill.addEventListener("input", function () {
 });
 
 styleOceanPattern.addEventListener("change", function () {
+  styles.ocean.options.pattern = this.value;
   ensureEl("oceanicPattern").setAttribute("href", this.value);
 });
 
 styleOceanPatternOpacity.addEventListener("input", e => {
+  styles.ocean.options.patternOpacity = +e.target.value;
   ensureEl("oceanicPattern").setAttribute("opacity", e.target.value);
 });
 
@@ -1168,9 +1170,12 @@ styleVignettePreset.addEventListener("change", function () {
   for (const selector in attributes) {
     const el = document.querySelector(selector);
     if (!el) continue;
+    const target = selector === "#vignette" ? styles.vignette.attrs : styles.vignette.options;
     for (const attr in attributes[selector]) {
       const value = attributes[selector][attr];
-      el.setAttribute(attr, value);
+      if (attr in target) target[attr] = value;
+      if (value === null) el.removeAttribute(attr);
+      else el.setAttribute(attr, value);
     }
   }
 
@@ -1195,30 +1200,37 @@ styleVignettePreset.addEventListener("change", function () {
 });
 
 styleVignetteX.addEventListener("input", e => {
+  styles.vignette.options.x = `${e.target.value}%`;
   ensureEl("vignette-rect").setAttribute("x", `${e.target.value}%`);
 });
 
 styleVignetteWidth.addEventListener("input", e => {
+  styles.vignette.options.width = `${e.target.value}%`;
   ensureEl("vignette-rect").setAttribute("width", `${e.target.value}%`);
 });
 
 styleVignetteY.addEventListener("input", e => {
+  styles.vignette.options.y = `${e.target.value}%`;
   ensureEl("vignette-rect").setAttribute("y", `${e.target.value}%`);
 });
 
 styleVignetteHeight.addEventListener("input", e => {
+  styles.vignette.options.height = `${e.target.value}%`;
   ensureEl("vignette-rect").setAttribute("height", `${e.target.value}%`);
 });
 
 styleVignetteRx.addEventListener("input", e => {
+  styles.vignette.options.rx = `${e.target.value}%`;
   ensureEl("vignette-rect").setAttribute("rx", `${e.target.value}%`);
 });
 
 styleVignetteRy.addEventListener("input", e => {
+  styles.vignette.options.ry = `${e.target.value}%`;
   ensureEl("vignette-rect").setAttribute("ry", `${e.target.value}%`);
 });
 
 styleVignetteBlur.addEventListener("input", e => {
+  styles.vignette.options.filter = `blur(${e.target.value}px)`;
   ensureEl("vignette-rect").setAttribute("filter", `blur(${e.target.value}px)`);
 });
 

--- a/src/renderers/draw-ocean.ts
+++ b/src/renderers/draw-ocean.ts
@@ -4,6 +4,7 @@ import { ensureEl, rn, round } from "@/utils";
 
 /** the ocean outline rings, stacked from the coast outwards so the overlap deepens the shade */
 export function drawOcean(): void {
+  applyOceanPattern();
   const oceanLayers = ensureEl<SVGGElement>("oceanLayers");
   removeOcean();
 
@@ -28,3 +29,13 @@ export function drawOcean(): void {
 export function removeOcean(): void {
   for (const path of Array.from(document.querySelectorAll("#oceanLayers path"))) path.remove();
 }
+
+/** the pattern image in defs is a renderer-owned resource shaped by the store */
+export function applyOceanPattern(): void {
+  const pattern = document.getElementById("oceanicPattern");
+  if (!pattern) return;
+  pattern.setAttribute("href", styles.ocean.options.pattern);
+  pattern.setAttribute("opacity", String(styles.ocean.options.patternOpacity));
+}
+
+window.applyOceanPattern = applyOceanPattern;

--- a/src/renderers/draw-vignette.dom.test.ts
+++ b/src/renderers/draw-vignette.dom.test.ts
@@ -1,0 +1,21 @@
+// Browser-mode test (vitest.browser.config.ts): drawVignette applies the store's geometry to
+// the #vignette-rect defs resource - the projection rows' old job.
+import { beforeEach, expect, test } from "vitest";
+import "@/generators/styles";
+import { drawVignette } from "./draw-vignette";
+
+beforeEach(() => {
+  document.body.innerHTML = `<svg id="map"><defs><mask id="vignette-mask"><rect id="vignette-rect"></rect></mask></defs><g id="vignette"></g></svg>`;
+});
+
+const layer = { getEl: () => document.getElementById("vignette") } as never;
+
+test("drawVignette writes the mask rect geometry from the store", () => {
+  styles.vignette.options = { x: "1%", y: "2%", width: "98%", height: "96%", rx: "7%", ry: "8%", filter: "blur(9px)" };
+  drawVignette(layer);
+  const rect = document.getElementById("vignette-rect")!;
+  expect(rect.getAttribute("x")).toBe("1%");
+  expect(rect.getAttribute("width")).toBe("98%");
+  expect(rect.getAttribute("ry")).toBe("8%");
+  expect(rect.getAttribute("filter")).toBe("blur(9px)");
+});

--- a/src/renderers/draw-vignette.ts
+++ b/src/renderers/draw-vignette.ts
@@ -2,4 +2,17 @@ import type { Layer } from "@/components/layers";
 
 export function drawVignette(layer: Layer): void {
   layer.getEl().innerHTML = /* html */ `<rect x="0" y="0" width="100%" height="100%"></rect>`;
+  applyVignetteOptions();
 }
+
+/** the mask rect in defs is shaped by the store's geometry options */
+export function applyVignetteOptions(): void {
+  const rect = document.getElementById("vignette-rect");
+  if (!rect) return;
+  for (const [key, value] of Object.entries(styles.vignette.options)) {
+    if (value === null || value === undefined) rect.removeAttribute(key);
+    else rect.setAttribute(key, String(value));
+  }
+}
+
+window.applyVignetteOptions = applyVignetteOptions;

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -41,6 +41,8 @@ declare global {
     setZoomExtent: typeof import("../components/zoom").setZoomExtent;
     setTranslateExtent: typeof import("../components/zoom").setTranslateExtent;
     getLabelsData: typeof import("../renderers/labels/label-data").getLabelsData;
+    applyVignetteOptions: typeof import("../renderers/draw-vignette").applyVignetteOptions;
+    applyOceanPattern: typeof import("../renderers/draw-ocean").applyOceanPattern;
   }
 
   var mapId: number;

--- a/tests/e2e/style-editor-events.spec.ts
+++ b/tests/e2e/style-editor-events.spec.ts
@@ -16,7 +16,7 @@ const waitForMap = (page: Page) =>
 
 const rn = (v: number, d = 0): number => Math.round(v * 10 ** d) / 10 ** d;
 
-async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates" | "ruler" | "legend" | "emblems" | "goodsIcons" | "goodsBurgs" | "markets" | "terrs" | "armies" | "gridOverlay" | "texture" | "ocean" | "scaleBar" | "labels" | "lakes" | "rivers" | "compass" | "burgIcons" | "anchors"): Promise<void> {
+async function openStyleElement(page: Page, element: "markers" | "regions" | "coordinates" | "ruler" | "legend" | "emblems" | "goodsIcons" | "goodsBurgs" | "markets" | "terrs" | "armies" | "gridOverlay" | "texture" | "ocean" | "scaleBar" | "labels" | "lakes" | "rivers" | "compass" | "burgIcons" | "anchors" | "vignette"): Promise<void> {
   await page.evaluate(() => (window as any).showOptions());
   await page.locator("#styleTab").click();
   await page.locator("#styleElementSelect").selectOption(element);
@@ -623,6 +623,53 @@ test.describe("style editor events drive the store", () => {
     expect(after.labelGroupNames).not.toContain("cities");
     expect(after.labelGroupNames).toContain("river");
     expect(after.burgsInLegacyGroup).toBe(0);
+  });
+
+  test("ocean pattern controls write the store and the applier derives from it", async ({ page }) => {
+    await openStyleElement(page, "ocean");
+
+    await page.locator("#styleOceanPattern").selectOption({ index: 2 });
+    const chosen = await page.locator("#styleOceanPattern").inputValue();
+    await page.locator("#styleOceanPatternOpacity input[type=number]").fill("0.55");
+    await page.locator("#styleOceanPatternOpacity").dispatchEvent("input");
+
+    const stored = await page.evaluate(() => ({
+      pattern: (window as any).styles.ocean.options.pattern,
+      opacity: (window as any).styles.ocean.options.patternOpacity
+    }));
+    expect(stored).toEqual({ pattern: chosen, opacity: 0.55 });
+
+    // the applier restores the store values over a stale element on redraw
+    await page.evaluate(() => {
+      document.getElementById("oceanicPattern")!.setAttribute("opacity", "0.11");
+      (window as any).Layers.draw("ocean");
+    });
+    await expect(page.locator("#oceanicPattern")).toHaveAttribute("opacity", "0.55");
+    await expect(page.locator("#oceanicPattern")).toHaveAttribute("href", chosen);
+  });
+
+  test("vignette controls write the store and shape the mask rect", async ({ page }) => {
+    await page.evaluate(() => (window as any).Layers.show("vignette"));
+    await openStyleElement(page, "vignette");
+
+    await page.locator("#styleVignetteX").fill("7");
+    await page.locator("#styleVignetteX").dispatchEvent("input");
+    await page.locator("#styleVignetteBlur input[type=number]").fill("12");
+    await page.locator("#styleVignetteBlur").dispatchEvent("input");
+
+    const stored = await page.evaluate(() => (window as any).styles.vignette.options);
+    expect(stored.x).toBe("7%");
+    expect(stored.filter).toBe("blur(12px)");
+    await expect(page.locator("#vignette-rect")).toHaveAttribute("x", "7%");
+
+    // a vignette preset moves both the display attrs and the mask geometry through the store
+    await page.locator("#styleVignettePreset").selectOption("spotlight");
+    const preset = await page.evaluate(() => ({
+      fill: (window as any).styles.vignette.attrs.fill,
+      rx: (window as any).styles.vignette.options.rx
+    }));
+    expect(preset).toEqual({ fill: "#000000", rx: "50%" });
+    await expect(page.locator("#vignette-rect")).toHaveAttribute("rx", "50%");
   });
 
   test("compass shift writes the rose transform through the store", async ({ page }) => {


### PR DESCRIPTION
Third step-6 chunk (docs/prd/style-migration.md): the two element-authoritative defs resources move onto the store, and the label-shadow chunk closes as an audit.

## Label shadow — no work needed

styleShadowInput has synced the store since the step-2 labels absorption: updateLabelGroupInlineStyle harvests the group's inline style into `attrs.style`, excluding the transform property (the dx/dy home). Audited, documented, unchanged.

## Defs appliers

- `drawVignette` gains `applyVignetteOptions()` — the #vignette-rect mask geometry writes from `styles.vignette.options` (null removes the attribute). `drawOcean` gains `applyOceanPattern()` — #oceanicPattern href/opacity from `styles.ocean.options`. Renderer-owned, like the texture image; bridged onto window for the preset flow.
- The editor handlers (ocean pattern select + opacity slider; vignette x/y/width/height/rx/ry + blur) mirror edits into the store alongside the element write, per the targeted-write rule.
- The vignette PRESET select routes its per-selector attribute bags through the store (attrs for #vignette, options for the mask rect) before writing the elements.
- The last resource projection rows die: `projectPresetOptions` now carries only the label-shift transform loop, which retires at step 7.
- Harvest for both resources stays until step 7 — element and store are equal by construction now.

## Verification

- New browser test: drawVignette shapes the mask rect from the store (RED-verified).
- New e2e: ocean pattern/opacity with the applier restoring store values over a deliberately staled element on redraw; vignette geometry/blur plus a full preset application asserting both attrs and mask geometry through the store. Editor-events 26/26.
- tsc, biome (exit-code gated), 460 unit + 35 browser tests, full Playwright suite 173/173; manual validation incl. store/element equality checks, redraw survival, and preset round trips.