### PR TITLE
Preset switches keep the zoom-derived label size; non-style JSON is rejected

### DIFF
--- a/public/modules/ui/style-presets.js
+++ b/public/modules/ui/style-presets.js
@@ -73,7 +73,15 @@ async function fetchSystemPreset(preset) {
   }
 }
 
+function isKnownStyleFormat(json) {
+  return stylesLegacy.isLegacyPreset(json) || stylesLegacy.isStoreStyles(json);
+}
+
 function applyStylePreset(presetJson) {
+  if (!isKnownStyleFormat(presetJson)) {
+    tip("The file is not a style preset - the current style is kept", false, "error", 5000);
+    return;
+  }
   const parsed = stylesLegacy.isLegacyPreset(presetJson)
     ? stylesLegacy.presetFromLegacy(presetJson, {onUnknown: "skip"})
     : Styles.parse(presetJson);
@@ -216,6 +224,8 @@ function addStylePreset() {
 
     if (!styleJSON) return tip("Please provide a style JSON", false, "error");
     if (!JSON.isValid(styleJSON)) return tip("JSON string is not valid, please check the format", false, "error");
+    if (!isKnownStyleFormat(JSON.parse(styleJSON)))
+      return tip("The JSON is not a style preset - nothing was saved", false, "error", 5000);
     if (!desiredName) return tip("Please provide a preset name", false, "error");
     if (styleSaverTip.innerHTML === "default")
       return tip("You cannot overwrite default preset, please change the name", false, "error");

--- a/src/components/zoom.ts
+++ b/src/components/zoom.ts
@@ -54,10 +54,7 @@ function handleZoomPerFrame(): void {
   if (didScaleChange) {
     Layers.draw("scaleBar");
 
-    if (options.labels.resizeOnZoom) {
-      const fontSize = Math.max(Math.round(((100 + 100 / scale) / 2) * 100) / 100, 1);
-      select("#labels").attr("font-size", `${fontSize}px`);
-    }
+    if (options.labels.resizeOnZoom) applyLabelsZoomSize();
   }
 
   if (didPositionChange) {
@@ -91,9 +88,17 @@ function redrawTracedImage(): void {
 }
 
 /** Rescale zoom-dependent map content to the settled scale. TODO: Legacy, to be reworked */
+/** the #labels container font-size is zoom-derived; anything that rewrites the base
+ * (preset apply, load) re-derives it here */
+function applyLabelsZoomSize(): void {
+  const fontSize = Math.max(Math.round(((100 + 100 / scale) / 2) * 100) / 100, 1);
+  select("#labels").attr("font-size", `${fontSize}px`);
+}
+
 function invokeActiveZooming(): void {
   const isOptimized = ensureEl<HTMLSelectElement>("shapeRendering").value === "optimizeSpeed";
 
+  if (options.labels.resizeOnZoom) applyLabelsZoomSize();
   ViewportLayers.renderNow();
 
   if (!customization && !isOptimized) {

--- a/tests/e2e/style-editor-events.spec.ts
+++ b/tests/e2e/style-editor-events.spec.ts
@@ -672,6 +672,22 @@ test.describe("style editor events drive the store", () => {
     await expect(page.locator("#vignette-rect")).toHaveAttribute("rx", "50%");
   });
 
+  test("a preset switch keeps the zoom-derived label container size", async ({ page }) => {
+    await page.evaluate(() => (window as any).setMapZoom(4));
+    await page.waitForTimeout(300);
+    const zoomed = await page.locator("#labels").getAttribute("font-size");
+    expect(zoomed).not.toBe("100px");
+
+    await page.evaluate(async () => {
+      sessionStorage.setItem("styleChangeConfirmed", "true");
+      await (window as any).changeStyle("pale");
+    });
+    await page.waitForTimeout(200);
+
+    // the store base (100px) must not stick - the container re-derives for the current zoom
+    await expect(page.locator("#labels")).toHaveAttribute("font-size", zoomed!);
+  });
+
   test("compass shift writes the rose transform through the store", async ({ page }) => {
     await page.evaluate(() => (window as any).Layers.show("compass"));
     await openStyleElement(page, "compass");

--- a/tests/e2e/style-presets.spec.ts
+++ b/tests/e2e/style-presets.spec.ts
@@ -195,3 +195,25 @@ test("a saved custom preset carries the retired sizes from the store", async ({p
     legendColumns: 5
   });
 });
+
+test("a non-style JSON is rejected by the saver, not applied as defaults", async ({page}) => {
+  await page.goto("/?seed=test-seed&width=1280&height=720");
+  await page.waitForFunction(() => (window as any).mapId !== undefined, {timeout: 60000});
+
+  const before = await page.evaluate(() => styles.rivers.attrs.fill);
+  await page.evaluate(() => (window as any).addStylePreset());
+  await page.evaluate(() => {
+    (document.getElementById("styleSaverJSON") as HTMLTextAreaElement).value =
+      JSON.stringify({road: "#D1B86E", roofType: "Gable", treeShape: "Cotton"});
+    (document.getElementById("styleSaverName") as HTMLInputElement).value = "bogus";
+  });
+  await page.locator("#styleSaverSave").click();
+
+  await expect(page.locator("#tooltip")).toContainText("not a style preset");
+  const after = await page.evaluate(() => ({
+    fill: styles.rivers.attrs.fill,
+    saved: localStorage.getItem("fmgStyle_bogus")
+  }));
+  expect(after.fill).toBe(before);
+  expect(after.saved).toBeNull();
+});


### PR DESCRIPTION
Two user-found fixes on top of the completed step 6.

## Labels jumped large after a preset switch until the next zoom

The #labels container font-size is zoom-derived ((100 + 100/scale)/2 px) but was only recomputed on scale changes — a preset apply (or load) legitimately rewrote the store base 100px over it, and every label rendered oversized until the next zoom gesture. invokeActiveZooming now re-derives it, exactly like the halo and marker sizes it already re-derives. E2e pins the container keeping its derived size across a preset switch at zoom 4.

## Non-style JSON silently applied as pure defaults

A file that is neither a legacy selector-keyed preset nor a store record (the reported case: a Watabou village-generator style) fell through per-layer parse fallbacks — 38 console warnings and an all-defaults style. The saver now refuses to save it and the apply path refuses to apply it, both with a clear tip. E2e pins the rejection, the untouched style, and the clean localStorage.

## Round-trip fidelity check (user-run, verified)

A real legacy AFMG style export (91 selectors) uploaded through the saver and re-downloaded produced store-format JSON that deep-diffs to ZERO differences against the upgrader's direct output — the upgrade → store → serialization pipeline is lossless end to end.

## Verification

tsc, biome (exit-code gated), 460 unit + 35 browser tests, all five style-domain e2e specs explicitly 41/41, full suite zero failures; manual validation of both fixes plus the round trip.