### PR TITLE
docs: restructure wiki Q&A into topic index + per-topic pages (data-driven)

### DIFF
--- a/docs/wiki/Q&A.md
+++ b/docs/wiki/Q&A.md
@@ -1,87 +1,146 @@
-Here I want to answer the most common questions _Fantasy Map Generator_ (FMG) users may have. Please feel free to raise a new [issue](https://github.com/Azgaar/Fantasy-Map-Generator/issues) in order to request additional answers.
+Answers to the most common questions _Fantasy Map Generator_ (FMG) users have. The questions below are ranked and grouped from analysis of ~116 000 real user questions asked via the in-app assistant and the Discord help channels. Please feel free to raise a new [issue](https://github.com/Azgaar/Fantasy-Map-Generator/issues) to request additional answers.
 
-### I have issues with the Generator, what should I do?
-Please try to reproduce the issue on your own. If it's reproducible, please log [an issue](https://github.com/Azgaar/Fantasy-Map-Generator/issues). A lot of issues are caused by browsers, please also try to use incognito mode and/or another browser. I recommend Chrome as the fastest browser in terms of svg rendering.
+Pick a topic, or jump straight to a question:
 
-### The map performance is poor, how can I improve it?
-The performance mainly depends on the number of visible elements and visible map area. The optimization strategies are: 
-* Toggle off unnecessary layers. Be mindful of the _Relief Icons_ layer in particular – it’s the most resource-demanding one.
-* Open the Generator in a separate browser window, make it _much_ smaller (about 900 x 560 pixels) and re-generate the map. Then, zoom in to see the map in detail. It will reduce the rending area and _drastically_ improve the performance.
-* When generating maps, set _Points number_ to 10K. Points (cells) number highly affects performance. 
-* Toggle off map and element filters.
-* Close all irrelevant browser tabs and applications.
-* Use a leading edge browser (fresh versions on Chrome or Edge). Firefox is reported to be slower.
+### [About the project](Q&A:-About-the-project)
+* [What is Azgaar's Fantasy Map Generator?](Q&A:-About-the-project#what-is-azgaars-fantasy-map-generator)
+* [What does _Azgaar_ mean?](Q&A:-About-the-project#what-does-azgaar-mean)
+* [Who owns the maps created?](Q&A:-About-the-project#who-owns-the-maps-created)
+* [What is the team behind the project?](Q&A:-About-the-project#what-is-the-team-behind-the-project)
+* [Is there a place to discuss the Generator and share maps?](Q&A:-About-the-project#is-there-a-place-to-discuss-the-generator-and-share-maps)
+* [Where do I suggest new features or report problems?](Q&A:-About-the-project#where-do-i-suggest-new-features-or-report-problems)
+* [How can I help to improve the Generator?](Q&A:-About-the-project#how-can-i-help-to-improve-the-generator)
+* [What's new in the latest version?](Q&A:-About-the-project#whats-new-in-the-latest-version)
+* [How can I contact Azgaar directly?](Q&A:-About-the-project#how-can-i-contact-azgaar-directly)
+* [You've mentioned a Medieval Dynasty simulator. What is it?](Q&A:-About-the-project#youve-mentioned-a-medieval-dynasty-simulator-what-is-it)
 
-### Who owns the maps created?
-You. The Generator is licensed under [MIT license](https://github.com/Azgaar/Fantasy-Map-Generator/blob/master/LICENSE) and derivative works such as maps are free of charge. You can sell them or make them available for free.
+### [Getting started](Q&A:-Getting-started)
+* [How do I use the tool? Where do I begin?](Q&A:-Getting-started#how-do-i-use-the-tool-where-do-i-begin)
+* [Is there a tutorial?](Q&A:-Getting-started#is-there-a-tutorial)
+* [How do I create my own map from scratch instead of a random one?](Q&A:-Getting-started#how-do-i-create-my-own-map-from-scratch-instead-of-a-random-one)
+* [Can the Generator (or the AI assistant) make a specific map for me — my nation or my book's world?](Q&A:-Getting-started#can-the-generator-or-the-ai-assistant-make-a-specific-map-for-me--my-nation-or-my-books-world)
+* [In which order should I build a custom world?](Q&A:-Getting-started#in-which-order-should-i-build-a-custom-world)
+* [How do I make a realistic, Earth-like world?](Q&A:-Getting-started#how-do-i-make-a-realistic-earth-like-world)
+* [Where can I get a map of Earth, Europe, or a fictional world like Westeros?](Q&A:-Getting-started#where-can-i-get-a-map-of-earth-europe-or-a-fictional-world-like-westeros)
+* [How do I get several continents, one big continent, or lots of islands?](Q&A:-Getting-started#how-do-i-get-several-continents-one-big-continent-or-lots-of-islands)
+* [How do I start over with a fresh or empty map?](Q&A:-Getting-started#how-do-i-start-over-with-a-fresh-or-empty-map)
+* [How do I generate a new map with the same seed after changing a setting?](Q&A:-Getting-started#how-do-i-generate-a-new-map-with-the-same-seed-after-changing-a-setting)
 
-### My saved map is not working properly. What should I do?
-If there is no version conflict, please [raise a defect](https://github.com/Azgaar/Fantasy-Map-Generator/issues/new). If your map is _obsolete_, and it's clearly stated on load, you may either use an [appropriate version](https://github.com/Azgaar/Fantasy-Map-Generator/wiki/Changelog) of the Generator or re-create the map in a current version. There is no way to update it. The tool is under development and version conflicts are inevitable.
+### [Saving and loading](Q&A:-Saving-and-loading)
+* [How do I save my map?](Q&A:-Saving-and-loading#how-do-i-save-my-map)
+* [How can I open a saved .gz or .map file?](Q&A:-Saving-and-loading#how-can-i-open-a-saved-gz-or-map-file)
+* [Is there an autosave?](Q&A:-Saving-and-loading#is-there-an-autosave)
+* [Is there an undo button?](Q&A:-Saving-and-loading#is-there-an-undo-button)
+* [My saved map is not working properly. What should I do?](Q&A:-Saving-and-loading#my-saved-map-is-not-working-properly-what-should-i-do)
+* [Can I manually edit the save file?](Q&A:-Saving-and-loading#can-i-manually-edit-the-save-file)
+* [Can I make the .map file smaller?](Q&A:-Saving-and-loading#can-i-make-the-map-file-smaller)
+* [Can I make the map open at a specific zoom and position?](Q&A:-Saving-and-loading#can-i-make-the-map-open-at-a-specific-zoom-and-position)
+* [Can I share my map with my players so it stays interactive?](Q&A:-Saving-and-loading#can-i-share-my-map-with-my-players-so-it-stays-interactive)
 
-### Can I export a created map?
-Sure, there are a number of available options: 
-* Save to machine: save file can be directly loaded to the Generator.
-* Save to Dropbox: save file can be directly loaded to the Generator.
-* Save to storage: save map data to the browser's internal database. File will be loaded automatically on page refresh. Bear in mind that saving to desktop is safer since browser storage can be accidentally cleared
+### [Exporting](Q&A:-Exporting)
+* [Can I export a created map?](Q&A:-Exporting#can-i-export-a-created-map)
+* [How can I export the heightmap as an image?](Q&A:-Exporting#how-can-i-export-the-heightmap-as-an-image)
+* [How do I get an FMG map into Roblox Studio or a similar engine?](Q&A:-Exporting#how-do-i-get-an-fmg-map-into-roblox-studio-or-a-similar-engine)
+* [Can I embed the map into my website?](Q&A:-Exporting#can-i-embed-the-map-into-my-website)
 
-* Export .svg: save a full map as a scalable vector image. You can open the file in a browser or edit it using a vector graphics editor.
-* Export .png: save the currently displayed map fragment as a raster image. You can edit the file in any raster graphics editor.
-* Export to tiles as .zip: split map on .png chunks and save them all as a single .zip file. it allows to save giant raster images once chunks are combined.
-* Export to .json: save the map data to be used in GIS software.
+### [Interface and performance](Q&A:-Interface-and-performance)
+* [Where is the Tools menu?](Q&A:-Interface-and-performance#where-is-the-tools-menu)
+* [Is there a list of keyboard shortcuts?](Q&A:-Interface-and-performance#is-there-a-list-of-keyboard-shortcuts)
+* [How do I zoom out / see the whole map?](Q&A:-Interface-and-performance#how-do-i-zoom-out--see-the-whole-map)
+* [The menu or interface is too big or too small. How do I fix it?](Q&A:-Interface-and-performance#the-menu-or-interface-is-too-big-or-too-small-how-do-i-fix-it)
+* [My map colors look inverted or wrong.](Q&A:-Interface-and-performance#my-map-colors-look-inverted-or-wrong)
+* [The map performance is poor, how can I improve it?](Q&A:-Interface-and-performance#the-map-performance-is-poor-how-can-i-improve-it)
+* [How is the map rendered — CPU or GPU?](Q&A:-Interface-and-performance#how-is-the-map-rendered--cpu-or-gpu)
+* [Which browsers are supported?](Q&A:-Interface-and-performance#which-browsers-are-supported)
+* [Can I use the Generator on mobile?](Q&A:-Interface-and-performance#can-i-use-the-generator-on-mobile)
+* [Can I use the Generator offline or as a desktop app?](Q&A:-Interface-and-performance#can-i-use-the-generator-offline-or-as-a-desktop-app)
+* [I have issues with the Generator, what should I do?](Q&A:-Interface-and-performance#i-have-issues-with-the-generator-what-should-i-do)
+* [Does it use cookies or cache?](Q&A:-Interface-and-performance#does-it-use-cookies-or-cache)
+* [Is FMG available in other languages?](Q&A:-Interface-and-performance#is-fmg-available-in-other-languages)
+* [How do I hide the AI assistant?](Q&A:-Interface-and-performance#how-do-i-hide-the-ai-assistant)
+* [How do I get exact values on sliders?](Q&A:-Interface-and-performance#how-do-i-get-exact-values-on-sliders)
 
-### How can I open a saved .gz or .map file?
-Open the generator, click on _Load_ and select the file. Or just drag and drop the file onto the Generator window.
+### [Heightmap and terrain](Q&A:-Heightmap-and-terrain)
+* [How do I change the land — add or remove landmass?](Q&A:-Heightmap-and-terrain#how-do-i-change-the-land--add-or-remove-landmass)
+* [How do the heightmap brushes work?](Q&A:-Heightmap-and-terrain#how-do-the-heightmap-brushes-work)
+* [How do I make mountains taller?](Q&A:-Heightmap-and-terrain#how-do-i-make-mountains-taller)
+* [How do I create a lake?](Q&A:-Heightmap-and-terrain#how-do-i-create-a-lake)
+* [How do I add an island and name it?](Q&A:-Heightmap-and-terrain#how-do-i-add-an-island-and-name-it)
+* [Can I use the Coastline Editor (the red dots on the coast) to change the land?](Q&A:-Heightmap-and-terrain#can-i-use-the-coastline-editor-the-red-dots-on-the-coast-to-change-the-land)
+* [There are white bits / transparent land on my map. Why?](Q&A:-Heightmap-and-terrain#there-are-white-bits--transparent-land-on-my-map-why)
+* [Can I increase the number of cells / detail of an existing map?](Q&A:-Heightmap-and-terrain#can-i-increase-the-number-of-cells--detail-of-an-existing-map)
+* [Can I take a part of my map and make it a new map?](Q&A:-Heightmap-and-terrain#can-i-take-a-part-of-my-map-and-make-it-a-new-map)
+* [Can the tool add generated detail on top of my imported heightmap?](Q&A:-Heightmap-and-terrain#can-the-tool-add-generated-detail-on-top-of-my-imported-heightmap)
+* [How do I import an image to create terrain?](Q&A:-Heightmap-and-terrain#how-do-i-import-an-image-to-create-terrain)
+* [I only have a screenshot of an old map. Can I recreate it?](Q&A:-Heightmap-and-terrain#i-only-have-a-screenshot-of-an-old-map-can-i-recreate-it)
+* [Where can I find a real-world heightmap to import?](Q&A:-Heightmap-and-terrain#where-can-i-find-a-real-world-heightmap-to-import)
+* [How do I change the heightmap colors?](Q&A:-Heightmap-and-terrain#how-do-i-change-the-heightmap-colors)
+* [How do I change the map's physical size (km/miles)?](Q&A:-Heightmap-and-terrain#how-do-i-change-the-maps-physical-size-kmmiles)
 
-### Can I manually edit save file?
-Yes, you can do it using any text editor. However, if you break the formatting the file won't be loading. The common error is that most text editors automatically split embedded svg into separate lines.
+### [Climate and biomes](Q&A:-Climate-and-biomes)
+* [How do I make my world colder / put ice caps on both poles?](Q&A:-Climate-and-biomes#how-do-i-make-my-world-colder--put-ice-caps-on-both-poles)
+* [How do I make my map more (or less) desert-like?](Q&A:-Climate-and-biomes#how-do-i-make-my-map-more-or-less-desert-like)
+* [How do I paint biomes exactly where I want them?](Q&A:-Climate-and-biomes#how-do-i-paint-biomes-exactly-where-i-want-them)
+* [How do I change habitability?](Q&A:-Climate-and-biomes#how-do-i-change-habitability)
+* [Why are there no burgs or states in an area?](Q&A:-Climate-and-biomes#why-are-there-no-burgs-or-states-in-an-area)
+* [Can I move where ice caps start without changing my biomes?](Q&A:-Climate-and-biomes#can-i-move-where-ice-caps-start-without-changing-my-biomes)
 
-### Can I use the Generator offline?
-Yes, but it's more complex. You must have a source code editor ([VS Code](https://code.visualstudio.com/) is the best free one) and [node.js](https://nodejs.org) installed.
+### [Rivers and water](Q&A:-Rivers-and-water)
+* [How do I create a river?](Q&A:-Rivers-and-water#how-do-i-create-a-river)
+* [Can I add a lake without resetting rivers?](Q&A:-Rivers-and-water#can-i-add-a-lake-without-resetting-rivers)
+* [Can I see a river's width along its length, or what it passes through?](Q&A:-Rivers-and-water#can-i-see-a-rivers-width-along-its-length-or-what-it-passes-through)
 
-Download the [source code](https://github.com/Azgaar/Fantasy-Map-Generator/archive/refs/heads/master.zip) and unzip _all files_ from the archive.
+### [States and politics](Q&A:-States-and-politics)
+* [How do I create a new country?](Q&A:-States-and-politics#how-do-i-create-a-new-country)
+* [How do I change state, province, culture, or religion borders?](Q&A:-States-and-politics#how-do-i-change-state-province-culture-or-religion-borders)
+* [How do I merge countries?](Q&A:-States-and-politics#how-do-i-merge-countries)
+* [How do I make a state bigger or smaller?](Q&A:-States-and-politics#how-do-i-make-a-state-bigger-or-smaller)
+* [How do I represent an invasion or conquest?](Q&A:-States-and-politics#how-do-i-represent-an-invasion-or-conquest)
+* [How do provinces work? Can I merge them or nest them?](Q&A:-States-and-politics#how-do-provinces-work-can-i-merge-them-or-nest-them)
+* [How do I keep states from filling the whole map?](Q&A:-States-and-politics#how-do-i-keep-states-from-filling-the-whole-map)
+* [How do I stop a state from expanding across the sea?](Q&A:-States-and-politics#how-do-i-stop-a-state-from-expanding-across-the-sea)
+* [How do I rename a state, or regenerate its name?](Q&A:-States-and-politics#how-do-i-rename-a-state-or-regenerate-its-name)
+* [How do I change state colors?](Q&A:-States-and-politics#how-do-i-change-state-colors)
+* [Which is my biggest country?](Q&A:-States-and-politics#which-is-my-biggest-country)
+* [Can I remove a state's capital?](Q&A:-States-and-politics#can-i-remove-a-states-capital)
+* [Can borders regenerate automatically after my battles or story events?](Q&A:-States-and-politics#can-borders-regenerate-automatically-after-my-battles-or-story-events)
 
-Open the folder in VS Code and run `npm install` in terminal to install dependencies. Then run `npm run dev` to start the development server. The Tool will be available as `http://localhost:5173` (open it in your browser).
+### [Burgs and population](Q&A:-Burgs-and-population)
+* [What is a "burg"?](Q&A:-Burgs-and-population#what-is-a-burg)
+* [How do I add a city or town (burg)?](Q&A:-Burgs-and-population#how-do-i-add-a-city-or-town-burg)
+* [How do I edit a burg — name, size, type?](Q&A:-Burgs-and-population#how-do-i-edit-a-burg--name-size-type)
+* [What do the icons next to a burg mean?](Q&A:-Burgs-and-population#what-do-the-icons-next-to-a-burg-mean)
+* [How is population calculated?](Q&A:-Burgs-and-population#how-is-population-calculated)
+* [Can I upload a custom icon for cities?](Q&A:-Burgs-and-population#can-i-upload-a-custom-icon-for-cities)
+* [Can I have underwater towns or kingdoms?](Q&A:-Burgs-and-population#can-i-have-underwater-towns-or-kingdoms)
+* [Can I underline capital names?](Q&A:-Burgs-and-population#can-i-underline-capital-names)
 
-### Is there a desktop version?
-Modern technologies allow any web-application to be turned into a desktop application that supports all features of the web app. There are 3 options supported:
-* Chrome App. A shortcut app can be created in Chrome in just three clicks without installation: `Settings => More Tools => Create Shortcut...`.
-* PWA. Chromium-based browsers (Chrome, Edge, etc.) in Windows will prompt you with a big button 'Install'. Just click on it and confirm the installation. The installed tool will be added to your desktop and opened automatically. You can also create a shortcut (app) manually, see [how to do it in Chrome](https://support.google.com/chrome_webstore/answer/3060053).
+### [Cultures, religions and names](Q&A:-Cultures,-religions-and-names)
+* [What are culture types and what do they do?](Q&A:-Cultures,-religions-and-names#what-are-culture-types-and-what-do-they-do)
+* [Can I have more cultures than the slider allows?](Q&A:-Cultures,-religions-and-names#can-i-have-more-cultures-than-the-slider-allows)
+* [Can I use my own name lists for states, burgs and people?](Q&A:-Cultures,-religions-and-names#can-i-use-my-own-name-lists-for-states-burgs-and-people)
+* [How do I make generated names sound like a specific language?](Q&A:-Cultures,-religions-and-names#how-do-i-make-generated-names-sound-like-a-specific-language)
+* [Can I generate a map with no cultures or states and add my own?](Q&A:-Cultures,-religions-and-names#can-i-generate-a-map-with-no-cultures-or-states-and-add-my-own)
 
-### Which browsers are supported?
-The Generator should work in any modern browser except for Safari. The tool is developed using Chrome, so it has the best support. Firefox is reported to have worse performance. Edge 79 and later will also work. Latest Opera and Yandex Browser should work fine as well. Outdated browsers like Internet Explorer are not supported. Weird browsers like Brave may not work at all.
+### [Labels and style](Q&A:-Labels-and-style)
+* [How do I add my own text or label to the map?](Q&A:-Labels-and-style#how-do-i-add-my-own-text-or-label-to-the-map)
+* [How do I keep burg labels visible when zoomed out?](Q&A:-Labels-and-style#how-do-i-keep-burg-labels-visible-when-zoomed-out)
+* [Does the tool name mountains, forests and seas?](Q&A:-Labels-and-style#does-the-tool-name-mountains-forests-and-seas)
+* [Can I overlay my own image on the map?](Q&A:-Labels-and-style#can-i-overlay-my-own-image-on-the-map)
+* [Can I recolor relief icons, or draw them above routes?](Q&A:-Labels-and-style#can-i-recolor-relief-icons-or-draw-them-above-routes)
+* [How do I regenerate emblems (coats of arms)?](Q&A:-Labels-and-style#how-do-i-regenerate-emblems-coats-of-arms)
+* [What do the Style sliders like "Stroke dash" mean?](Q&A:-Labels-and-style#what-do-the-style-sliders-like-stroke-dash-mean)
 
-### Can I use the Generator on mobile?
-You can, but I doubt you will enjoy the experience. The Generator GUI is not suitable for mobile devices and performance is subpar. In general, I would say mobile devices are not supported.
+### [Military and battles](Q&A:-Military-and-battles)
+* [How do I create an army or regiment?](Q&A:-Military-and-battles#how-do-i-create-an-army-or-regiment)
+* [Can I simulate battles or wars?](Q&A:-Military-and-battles#can-i-simulate-battles-or-wars)
 
-### What about non-English localization?
-Localization is planned, but not ready from the coding side. Once my part with code support is done, I will inform the community to help me with actual translations. Preparation can take a lot of time as it's not a current priority.
-
-### Can I embed the map to my website?
-Yes, you can and it's easy to do. Please follow the guide [here](https://sites.google.com/view/fantasy-map-generator-embedded/home).
-
-### What does _Azgaar_ mean?
-It's my nickname, it has no meaning. The name of the tool is _Azgaar's Fantasy Map generator_, pointing to me as creator. The short form is _FMG_.
-
-### You've mentioned a Medieval Dynasty simulator. What is it?
-It's my meta-project. A CK2-style genealogical game focused on genetics. Generally a wedding/dynasty breeding simulator (see the [screenshot](https://i2.wp.com/azgaar.files.wordpress.com/2018/02/screenshot-2018-2-9-dynasty-v0-11.png)). It's in pre-alpha and currently on hold, so no demo is available. 
-
-### How can I help to improve the Generator?
-Just use it, log defects and suggest enhancements (please use the [issues](https://github.com/Azgaar/Fantasy-Map-Generator/issues) page for both cases). Share the Generator link within your community! Post on FB, Twitter etc. 
-
-We need a good video-tutorial. Please contact me if you have a video-blog and want to help.
-
-Professional help from coders / UI designers is highly appreciated.
-
-We also accept donations on [Patreon](https://www.patreon.com/azgaar).
-
-### What is the team behind the project?
-There is no team, but there is a Community. The tool is created by me, Azgaar. The community is based on our Reddit and Discord servers. Thanks for [contributors](https://github.com/Azgaar/Fantasy-Map-Generator/graphs/contributors), Community moderators and all our community members.
-
-### Do you accept donations?
-Yes, you can support the project on [Patreon](https://www.patreon.com/azgaar). If you don't want to pay monthly, you are able to decline the donation at any moment in time. Other donation platforms are not supported.
-
-### Is there a place where I can discuss the Generator, share created maps and so on?
-Yes, we have a dedicated [Discord server](https://discordapp.com/invite/X7E84HU) and [Reddit community](https://www.reddit.com/r/FantasyMapGenerator/). Both have a very active and supportive community.
-
-### How can I contact you directly?
-Please PM me on Discord or [send me an email](mailto:azgaar.fmg@yandex.com).
+### [Markers, zones and extras](Q&A:-Markers,-zones-and-extras)
+* [How do rulers (distance measurement) work?](Q&A:-Markers,-zones-and-extras#how-do-rulers-distance-measurement-work)
+* [Can a marker link to a generated dungeon map?](Q&A:-Markers,-zones-and-extras#can-a-marker-link-to-a-generated-dungeon-map)
+* [Is there time, a calendar, or history simulation?](Q&A:-Markers,-zones-and-extras#is-there-time-a-calendar-or-history-simulation)
+* [Are there rulers/leaders or dynasties for states?](Q&A:-Markers,-zones-and-extras#are-there-rulersleaders-or-dynasties-for-states)
+* [Can the hex grid number its hexes, or be used for counting?](Q&A:-Markers,-zones-and-extras#can-the-hex-grid-number-its-hexes-or-be-used-for-counting)
+* [Can fog of war edges be blurred?](Q&A:-Markers,-zones-and-extras#can-fog-of-war-edges-be-blurred)
+* [Can I focus on just one state and hide the rest?](Q&A:-Markers,-zones-and-extras#can-i-focus-on-just-one-state-and-hide-the-rest)
+* [Can I make city maps or galaxy maps with FMG?](Q&A:-Markers,-zones-and-extras#can-i-make-city-maps-or-galaxy-maps-with-fmg)

--- a/docs/wiki/Q&A:-About-the-project.md
+++ b/docs/wiki/Q&A:-About-the-project.md
@@ -1,0 +1,33 @@
+Part of the [FMG Q&A](Q&A). Related topics are listed there.
+
+## About the project
+
+### What is Azgaar's Fantasy Map Generator?
+Fantasy Map Generator (FMG) is a free browser tool that procedurally generates highly customizable fantasy maps. You can explore auto-generated worlds or build your own from scratch.
+
+### What does _Azgaar_ mean?
+It's the creator's nickname, it has no meaning. The full name of the tool is _Azgaar's Fantasy Map Generator_, the short form is _FMG_.
+
+### Who owns the maps created?
+You. The Generator is licensed under [MIT license](https://github.com/Azgaar/Fantasy-Map-Generator/blob/master/LICENSE) and derivative works such as maps are yours: you can sell them or share them freely.
+
+### What is the team behind the project?
+There is no team, but there is a Community. The tool is created by Azgaar, supported by [contributors](https://github.com/Azgaar/Fantasy-Map-Generator/graphs/contributors), Community moderators and community members on Discord and Reddit.
+
+### Is there a place to discuss the Generator and share maps?
+Yes, the [Discord server](https://discordapp.com/invite/X7E84HU) and the [Reddit community](https://www.reddit.com/r/FantasyMapGenerator/). Both are active and supportive.
+
+### Where do I suggest new features or report problems?
+Log defects and suggest enhancements on the [issues](https://github.com/Azgaar/Fantasy-Map-Generator/issues) page, or use the #fmg-suggestions channel on Discord.
+
+### How can I help to improve the Generator?
+Use it, log defects, suggest enhancements, and share the Generator within your community. A good video tutorial is needed — contact Azgaar if you run a video blog and want to help. Professional help from coders and UI designers is highly appreciated. Donations are accepted on [Patreon](https://www.patreon.com/azgaar) (cancel anytime; other platforms are not supported).
+
+### What's new in the latest version?
+See the [Changelog](Changelog). The current version is shown below the logo and in the page title (refresh the page to be sure).
+
+### How can I contact Azgaar directly?
+PM on Discord or [send an email](mailto:azgaar.fmg@yandex.com).
+
+### You've mentioned a Medieval Dynasty simulator. What is it?
+It's a meta-project: a CK2-style genealogical game focused on genetics. It's in pre-alpha and currently on hold, so no demo is available.

--- a/docs/wiki/Q&A:-Burgs-and-population.md
+++ b/docs/wiki/Q&A:-Burgs-and-population.md
@@ -1,0 +1,27 @@
+Part of the [FMG Q&A](Q&A). Related topics are listed there.
+
+## Burgs and population
+
+### What is a "burg"?
+Burg is FMG's internal name for all settlements, from hamlets to capitals. It comes from the Germanic "burg", a fortified settlement.
+
+### How do I add a city or town (burg)?
+Hold <kbd>Shift+1</kbd> and click the map to place a burg, or add one from the Burgs overview in Tools. Change its group (e.g. to Cities) in the burg editor.
+
+### How do I edit a burg — name, size, type?
+Click the burg on the map to open its editor: rename, change population, group, features and emblem there. The Burgs overview in Tools lists and edits all burgs in a table.
+
+### What do the icons next to a burg mean?
+They mark burg features (port, capital, walls, temple, shanty town...). Hover an icon to see its meaning in the tooltip at the bottom of the page. A "shanty town" marks informal, low-income housing — a worldbuilding attribute with no mechanical effect.
+
+### How is population calculated?
+Mainly from area and biome habitability, adjusted by factors like a nearby river or lake, a river estuary, a safe sea harbor, elevation, and burg status. Population scale settings live in Tools → Units.
+
+### Can I upload a custom icon for cities?
+Custom burg icons are not supported. Marker icons, however, accept any external image or data-URI pasted into the Icon Selector — placing a marker at the burg is a common workaround.
+
+### Can I have underwater towns or kingdoms?
+Not supported. Popular workaround: style the ocean to look like land and the land like ocean, then roleplay the inversion.
+
+### Can I underline capital names?
+Not via the UI. In the browser console (<kbd>F12</kbd>): `d3.select('#burgLabels > #cities').style('text-decoration', 'underline')`

--- a/docs/wiki/Q&A:-Climate-and-biomes.md
+++ b/docs/wiki/Q&A:-Climate-and-biomes.md
@@ -1,0 +1,21 @@
+Part of the [FMG Q&A](Q&A). Related topics are listed there.
+
+## Climate and biomes
+
+### How do I make my world colder / put ice caps on both poles?
+Options → Configure World → lower the pole temperatures, then Tools → regenerate Ice. Temperature is an annual average and applies to the whole world — per-biome temperature is not supported.
+
+### How do I make my map more (or less) desert-like?
+Adjust Precipitation in Options → Configure World: 0 gives a mostly unlivable desert, around 100 gives an Earth-like wet world. Wind direction also matters — the defaults already mimic Earth.
+
+### How do I paint biomes exactly where I want them?
+Tools → Biomes → click the brush button, choose a biome, and paint cells. This overrides the climate-based assignment. Biome data can't be imported, but names, colors and habitability are fully configurable in the Biomes editor.
+
+### How do I change habitability?
+Habitability comes from biomes. In Tools → Biomes you can change each biome's habitability percentage.
+
+### Why are there no burgs or states in an area?
+The area either has no culture assigned or its biome is uninhabitable (habitability 0, e.g. Glacier). Assign a culture and/or raise the biome's habitability, then regenerate or place burgs manually.
+
+### Can I move where ice caps start without changing my biomes?
+No — ice placement follows temperature, and changing temperature affects biomes. This isn't possible without code changes.

--- a/docs/wiki/Q&A:-Cultures,-religions-and-names.md
+++ b/docs/wiki/Q&A:-Cultures,-religions-and-names.md
@@ -1,0 +1,18 @@
+Part of the [FMG Q&A](Q&A). Related topics are listed there.
+
+## Cultures, religions and names
+
+### What are culture types and what do they do?
+Each culture gets a type at generation that shapes how it expands: Nomadic (deserts/grasslands), Highland (high cells), Lake (around big lakes), Naval, Hunting, River types and so on. Types also serve worldbuilding flavor. See [Culture types](Culture-types).
+
+### Can I have more cultures than the slider allows?
+Yes — add cultures manually in the Cultures editor, or set the Cultures set to Random, which raises the slider limit to 100.
+
+### Can I use my own name lists for states, burgs and people?
+Yes. Create custom namebases in Tools → Namebases, then assign them to cultures in the Cultures editor — states and burgs of that culture will use your names.
+
+### How do I make generated names sound like a specific language?
+Set the namebase of the relevant culture (Tools → Cultures) to that language's base, then regenerate state/burg names for that culture.
+
+### Can I generate a map with no cultures or states and add my own?
+Yes — set Cultures number and States number to 0 in Options before generating, or delete them afterwards in the editors, then place your own by hand.

--- a/docs/wiki/Q&A:-Exporting.md
+++ b/docs/wiki/Q&A:-Exporting.md
@@ -1,0 +1,21 @@
+Part of the [FMG Q&A](Q&A). Related topics are listed there.
+
+## Exporting
+
+### Can I export a created map?
+Yes, several ways:
+* Export .png: the currently displayed map fragment as a raster image.
+* Export .svg: the full map as a scalable vector image, editable in vector graphics editors.
+* Export to tiles as .zip: the map split into .png chunks — combine them for giant raster images.
+* Export to .json: map data for GIS software, see [GIS data export](GIS-data-export).
+
+Table-based editors (states, burgs, cultures...) can also export their data as .csv.
+
+### How can I export the heightmap as an image?
+Set the Layers preset to Heightmap and the style to Monochrome, then export as PNG. Native heightmap resolution is low, so add fine detail in external software if needed.
+
+### How do I get an FMG map into Roblox Studio or a similar engine?
+FMG and game engines are not directly compatible. Export a heightmap image (Monochrome style, PNG) and import it into the engine's terrain tool.
+
+### Can I embed the map into my website?
+Yes, and it's easy — follow [the guide](https://sites.google.com/view/fantasy-map-generator-embedded/home).

--- a/docs/wiki/Q&A:-Getting-started.md
+++ b/docs/wiki/Q&A:-Getting-started.md
@@ -1,0 +1,33 @@
+Part of the [FMG Q&A](Q&A). Related topics are listed there.
+
+## Getting started
+
+### How do I use the tool? Where do I begin?
+Three ways to use it: **Exploration** — click "New Map" for a random world, open Layers (<kbd>Tab</kbd> toggles the options pane) and explore. **Tuning** — change settings in Options (template, states number, etc.) and regenerate until it fits. **Full customization** — edit heightmap, states, cultures and everything else via the Tools tab. See the [Quick Start Tutorial](Quick-Start-Tutorial).
+
+### Is there a tutorial?
+Yes: the [Quick Start Tutorial](Quick-Start-Tutorial) and the [video tutorial playlist](https://www.youtube.com/playlist?list=PLtgiuDC8iVR2gIG8zMTRn7T_L0arl9h1C).
+
+### How do I create my own map from scratch instead of a random one?
+Go to Tools → Heightmap → Erase mode to clear the land, then draw your own landmasses with the brushes (top right). Set the climate in Options → Configure World, then generate or hand-edit rivers, cultures, states and burgs via Tools. You can also import an image of your world (see the Image Converter below). More details: [Heightmap customization](Heightmap-customization).
+
+### Can the Generator (or the AI assistant) make a specific map for me — my nation or my book's world?
+No. FMG generates random worlds which you then edit yourself. To recreate a specific world, import its image via the Image Converter and refine it with the editors. The assistant only answers questions — it cannot draw or edit maps.
+
+### In which order should I build a custom world?
+Heightmap first, then Configure World (climate) in Options. Let those determine biomes. Then: units (height scale), cultures, states, units again (population, distances), burgs and routes, provinces, religions, and finally zones and markers.
+
+### How do I make a realistic, Earth-like world?
+Use an Earth-like heightmap template or a premade Earth heightmap (Options → Heightmap), keep wind directions default, and set Precipitation to about 100 in Options → Configure World. More points gives more realistic coastlines at the cost of performance.
+
+### Where can I get a map of Earth, Europe, or a fictional world like Westeros?
+For Earth, select a premade heightmap in Options → Heightmap. For other known worlds, check [Cartography Assets](https://cartographyassets.com/asset-category/specific-assets/azgaars-generator). If it's not there, import a heightmap image via the Image Converter.
+
+### How do I get several continents, one big continent, or lots of islands?
+Pick a matching template in Tools → Heightmap (Continents, Archipelago, Atoll, Mediterranean...), or draw your own layout in Erase mode.
+
+### How do I start over with a fresh or empty map?
+Click "New Map" for a new random world. For an empty canvas, go to Tools → Heightmap → Erase and delete all land. Save a .map file first if you want to keep your current map — it will be replaced.
+
+### How do I generate a new map with the same seed after changing a setting?
+Put the cursor in the seed input in Options and press <kbd>Enter</kbd>.

--- a/docs/wiki/Q&A:-Heightmap-and-terrain.md
+++ b/docs/wiki/Q&A:-Heightmap-and-terrain.md
@@ -1,0 +1,48 @@
+Part of the [FMG Q&A](Q&A). Related topics are listed there.
+
+## Heightmap and terrain
+
+### How do I change the land — add or remove landmass?
+Go to Tools → Heightmap and read the mode dialog carefully: **Erase** discards all data and regenerates from the new heightmap; **Keep** preserves everything but won't let land become water; **Risk** allows real land/water changes while keeping most data — usually what you want on an existing map. Then use the brushes on the top right. If you sink land that has burgs, remove those burgs first or they will remain as islands. See [Heightmap customization](Heightmap-customization).
+
+### How do the heightmap brushes work?
+In the Heightmap editor pick a brush (raise, lower, smooth, align...), set its size and power at the top right, then click and drag on the map. Small size and low power give fine control.
+
+### How do I make mountains taller?
+Raise them in the Heightmap editor (Erase or Risk mode). To change how heights translate to displayed altitude, open Tools → Units and adjust the altitude exponent.
+
+### How do I create a lake?
+In Tools → Heightmap (Risk or Erase mode), lower cells below sea level while keeping them fully surrounded by land — the depression automatically becomes a lake. There is no way to add a lake without a heightmap edit, and rivers will be recalculated.
+
+### How do I add an island and name it?
+Draw it with a raise brush in the Heightmap editor (Risk mode to keep existing data). Name it by adding a label: Tools tab → Add label → click the island.
+
+### Can I use the Coastline Editor (the red dots on the coast) to change the land?
+Use the Heightmap tool for 99% of land changes. The coastline points are only for final fine-tuning of the shape — overusing them causes artifacts.
+
+### There are white bits / transparent land on my map. Why?
+Usually the coastline became too complex for the renderer — often from overusing the coastline editor. Edit the heightmap in Risk mode and change some land cells to force a redraw, or regenerate the affected layer.
+
+### Can I increase the number of cells / detail of an existing map?
+Use the Transform tool (Tools → Transform): it rebuilds the map with a new cell count while trying to keep your data. It is still a regeneration, so some details may change. To zoom into a region as its own map, use Tools → Submap.
+
+### Can I take a part of my map and make it a new map?
+Yes — Tools → Submap generates a new map from the current viewport. Zoom so the area fills the screen, then run Submap.
+
+### Can the tool add generated detail on top of my imported heightmap?
+No. You can import heightmaps, but FMG won't generate extra terrain patterns onto them. Workaround: generate a random map you like, export it as an image, blend it with your heightmap in an image editor, and import the result.
+
+### How do I import an image to create terrain?
+Tools → Heightmap → Erase → Image Converter. Ideally use a grayscale heightmap (lighter = higher). For a political or artistic map, you'll need to assign heights to colors manually in the converter, then refine with brushes.
+
+### I only have a screenshot of an old map. Can I recreate it?
+Not automatically. Import the screenshot via the Image Converter: if it shows a heightmap you can auto-assign heights; if it's political you must map each color to a height by hand, then rebuild details with the editors.
+
+### Where can I find a real-world heightmap to import?
+Create a heightmap of any Earth region with the [Heightmapper](https://tangrams.github.io/heightmapper) — export it and load it via the Image Converter.
+
+### How do I change the heightmap colors?
+Style → select the heightmap element → pick one of the color schemes or define a custom one. The "Reduce layers" slider skips height steps for a cleaner look; "Simplify line" smooths the isolines. Rendering of ocean height cells is toggled in the oceanHeights group there.
+
+### How do I change the map's physical size (km/miles)?
+The canvas size in pixels is fixed after generation, but distance is just a scale: Tools → Units, change the km/miles per pixel — see [Scale and distance](Scale-and-distance). World dimensions (including meridian length) are set in Options → Configure World → Map size. To add more land outside the canvas, export the image, extend it externally, and re-import via the Image Converter.

--- a/docs/wiki/Q&A:-Interface-and-performance.md
+++ b/docs/wiki/Q&A:-Interface-and-performance.md
@@ -1,0 +1,57 @@
+Part of the [FMG Q&A](Q&A). Related topics are listed there.
+
+## Interface and performance
+
+### Where is the Tools menu?
+Click the arrow button at the top left corner of the screen to open the Menu. Tools is one of its main tabs.
+
+### Is there a list of keyboard shortcuts?
+Yes — see [Hotkeys](Hotkeys), or press <kbd>F1</kbd> in the app. Handy ones: <kbd>Tab</kbd> (options pane), <kbd>Ctrl+S</kbd> (save), <kbd>F2</kbd> (new map), <kbd>+</kbd>/<kbd>-</kbd> (zoom), <kbd>Shift+1</kbd> then click (add a burg).
+
+### How do I zoom out / see the whole map?
+Use the mouse wheel or the <kbd>-</kbd> key. If you still can't see everything, set the Zoom extent min value in Options to 1 or a fraction like 0.6. Don't confuse map zoom with browser zoom (<kbd>Ctrl</kbd>+wheel), which scales the whole page.
+
+### The menu or interface is too big or too small. How do I fix it?
+Set browser zoom back to 100% (<kbd>Ctrl+0</kbd>), then adjust the tool's own scaling in Options → Interface size.
+
+### My map colors look inverted or wrong.
+A browser extension such as a dark-mode/dark-reader is usually the cause. Disable it for the Generator page.
+
+### The map performance is poor, how can I improve it?
+The performance mainly depends on the number of visible elements and visible map area. The optimization strategies are:
+* Toggle off unnecessary layers. Be mindful of the _Relief Icons_ layer in particular – it's the most resource-demanding one.
+* Open the Generator in a separate browser window, make it _much_ smaller (about 900 x 560 pixels) and re-generate the map. Then, zoom in to see the map in detail. It will reduce the rendering area and _drastically_ improve the performance.
+* When generating maps, set _Points number_ to 10K. Points (cells) number highly affects performance.
+* Set the _Rendering_ option to "Best performance".
+* Toggle off map and element filters.
+* Close all irrelevant browser tabs and applications.
+* Use a leading edge browser (fresh versions of Chrome or Edge). Firefox is reported to be slower.
+
+### How is the map rendered — CPU or GPU?
+The map is SVG, rendered by the browser. SVG rendering is GPU-supported but not optimized, so very detailed maps can lag. Use the _Rendering_ option (set to "Best performance") in case of significant lag.
+
+### Which browsers are supported?
+Any modern browser except Safari. Chrome is the development browser and performs best; Firefox works but is slower; recent Edge, Opera and Yandex are fine. Internet Explorer and unusual browsers like Brave are not supported.
+
+### Can I use the Generator on mobile?
+You can, but you probably won't enjoy the experience. The GUI is not suitable for mobile devices and performance is subpar. In general, mobile devices are not supported.
+
+### Can I use the Generator offline or as a desktop app?
+Yes:
+* PWA (easiest): Chromium browsers show an Install button (or Chrome menu → Cast, save and share → Install page as app). Open it once online so files get cached; it then works offline with some limitations (additional fonts and textures need network) — see [Working offline](Working-offline).
+* From source: clone the [repository](https://github.com/Azgaar/Fantasy-Map-Generator), then `npm install` and `npm run dev` (requires Node.js 24+), or `npm run build` and serve the generated `dist` folder with any web server — see [Run FMG locally](Run-FMG-locally). Serving the raw files without a build step no longer works.
+
+### I have issues with the Generator, what should I do?
+Please try to reproduce the issue on your own. If it's reproducible, please log [an issue](https://github.com/Azgaar/Fantasy-Map-Generator/issues). A lot of issues are caused by browsers — try incognito mode and/or another browser. Chrome is recommended as the fastest browser for svg rendering.
+
+### Does it use cookies or cache?
+No cookies. Application data lives in the browser cache and storage — after major releases a stale cache can cause glitches, so clear the site cache if the tool misbehaves after an update.
+
+### Is FMG available in other languages?
+Localization is planned, but not ready from the coding side; once code support is done the community will be asked to help with translations. Meanwhile, in Options click "Init Google Translate" for a machine translation — quality is limited.
+
+### How do I hide the AI assistant?
+Options → Generator settings → set "Azgaar assistant" to Hide.
+
+### How do I get exact values on sliders?
+Use the arrow keys while a slider is focused to step precisely.

--- a/docs/wiki/Q&A:-Labels-and-style.md
+++ b/docs/wiki/Q&A:-Labels-and-style.md
@@ -1,0 +1,24 @@
+Part of the [FMG Q&A](Q&A). Related topics are listed there.
+
+## Labels and style
+
+### How do I add my own text or label to the map?
+Tools tab → Add label button → click the map where the text goes (hold <kbd>Shift</kbd> to place several). Click any label to edit its text; fonts, sizes and colors per label group are in Style → Labels.
+
+### How do I keep burg labels visible when zoomed out?
+Style → Labels → uncheck "Toggle visibility automatically".
+
+### Does the tool name mountains, forests and seas?
+Not automatically. Add labels manually for natural features (Tools → Add label).
+
+### Can I overlay my own image on the map?
+Yes, as a Texture: Style → select the Texture element → use the plus icon next to the image dropdown, provide the image URL and apply. The image host must allow CORS requests. See also [Heightmap image overlay](Heightmap-image-overlay).
+
+### Can I recolor relief icons, or draw them above routes?
+Icon colors can't be changed, but there is an alternative pre-colored icon set in Style, and you can make icons semi-transparent to tint them from below. Layer order (e.g. relief above routes) is changed by dragging the toggle buttons on the Layers tab. Adding new relief icons is not supported.
+
+### How do I regenerate emblems (coats of arms)?
+For everything: Tools → regenerate Emblems. For one state, province or burg: click its emblem and use Regenerate in the Edit Emblem dialog.
+
+### What do the Style sliders like "Stroke dash" mean?
+They are standard SVG properties. Stroke dash sets the line's dash pattern and endcaps (round, butt, square). Hover any control for a tooltip explaining it.

--- a/docs/wiki/Q&A:-Markers,-zones-and-extras.md
+++ b/docs/wiki/Q&A:-Markers,-zones-and-extras.md
@@ -1,0 +1,31 @@
+Part of the [FMG Q&A](Q&A). Related topics are listed there.
+
+## Markers, zones and extras
+
+### How do rulers (distance measurement) work?
+Open the Measurers Editor: Tools → Measurers (or <kbd>Shift+=</kbd>). It offers a linear ruler, opisometer, route opisometer and planimeter — each tooltip explains its type. To delete a ruler, click its label. Distance and unit scales are set in Tools → Units, see [Scale and distance](Scale-and-distance).
+
+### Can a marker link to a generated dungeon map?
+Yes. Create a [marker](Markers), edit its note, click the Source code button and insert (replacing YOUR_SEED):
+```html
+<p><a href="https://watabou.github.io/one-page-dungeon/?seed=YOUR_SEED" target="_blank">Click here to go to the dungeon</a></p>
+<p><iframe src="https://watabou.github.io/one-page-dungeon/?seed=YOUR_SEED"></iframe></p>
+```
+
+### Is there time, a calendar, or history simulation?
+No — the map is a static moment. The era and year in Options only stamp dates onto notes (battles, regiments). Over-time simulation is a long-term plan. There is also no travel-time calculator; use rulers and the distance scale.
+
+### Are there rulers/leaders or dynasties for states?
+Not supported. Use notes and labels to record them manually.
+
+### Can the hex grid number its hexes, or be used for counting?
+No — the grid overlay is purely visual.
+
+### Can fog of war edges be blurred?
+No, fog edges cannot be made blurry.
+
+### Can I focus on just one state and hide the rest?
+There's no per-state workspace. Pin the state in the States editor to fog the others visually, or make a Submap of its region.
+
+### Can I make city maps or galaxy maps with FMG?
+FMG targets country-to-continent scale — no city blocks or buildings. For cities, burgs link to external city generators. Galaxy maps aren't a goal, but creative styling can fake the look; examples on Discord.

--- a/docs/wiki/Q&A:-Military-and-battles.md
+++ b/docs/wiki/Q&A:-Military-and-battles.md
@@ -1,0 +1,9 @@
+Part of the [FMG Q&A](Q&A). Related topics are listed there.
+
+## Military and battles
+
+### How do I create an army or regiment?
+Open the [Military overview](Military-Forces) (Tools), click the list icon to open the Regiments overview, select a state and add a regiment. Click the new regiment on the map to edit its name, icon and forces. Note: adding new military unit _types_ regenerates regiments, which removes hand-placed ones.
+
+### Can I simulate battles or wars?
+Battles: yes — with the Military layer on, click a regiment, press the attack button, and select the target to open the [Battle Simulator](Battle-Simulator) (based on unit power set in the Military units editor; you can't attack your own state's regiments). Wars over time: no — set diplomacy to Enemy and paint conquered borders manually.

--- a/docs/wiki/Q&A:-Rivers-and-water.md
+++ b/docs/wiki/Q&A:-Rivers-and-water.md
@@ -1,0 +1,12 @@
+Part of the [FMG Q&A](Q&A). Related topics are listed there.
+
+## Rivers and water
+
+### How do I create a river?
+Open Tools → Rivers. Either click "Add River" and click a cell to auto-trace a river from there, or use "Create a new river selecting river cells" to draw its course cell by cell.
+
+### Can I add a lake without resetting rivers?
+No. Lakes are created by heightmap edits, and rivers directly depend on the heightmap, so they are recalculated when the edit completes — even in Risk mode.
+
+### Can I see a river's width along its length, or what it passes through?
+Click the river: its details show the mouth width. In the editor dialog, the Elevation profile button lists the burgs the river (or a route) passes.

--- a/docs/wiki/Q&A:-Saving-and-loading.md
+++ b/docs/wiki/Q&A:-Saving-and-loading.md
@@ -1,0 +1,35 @@
+Part of the [FMG Q&A](Q&A). Related topics are listed there.
+
+## Saving and loading
+
+### How do I save my map?
+Click Save (or <kbd>Ctrl+S</kbd>) and choose:
+* Save to machine: downloads a .map file with the whole project — use this as your master copy.
+* Save to browser storage: loads automatically on page refresh, but is lost if site data is cleared, and holds only one map.
+* Save to Dropbox: save file stored in your cloud.
+
+Save a .map file regularly — there is no full undo.
+
+### How can I open a saved .gz or .map file?
+Open the Generator, click on _Load_ and select the file. Or just drag and drop the file onto the Generator window.
+
+### Is there an autosave?
+Yes, to browser storage — but browser storage is not fully reliable and holds one map only. Download a .map backup from time to time and keep it safe.
+
+### Is there an undo button?
+There is no global undo. Some editors have their own history — the Heightmap editor has undo/redo buttons, and <kbd>Ctrl+Z</kbd> works where an undo control is visible. Save a .map file at least every 30 minutes of work.
+
+### My saved map is not working properly. What should I do?
+If your map is _obsolete_, and it's clearly stated on load, you may either use an [appropriate version](Changelog) of the Generator or re-create the map in the current version — there is no way to update it. If there is no version conflict, please [raise a defect](https://github.com/Azgaar/Fantasy-Map-Generator/issues/new). Also check that nothing (browser extension, popup policy) blocked the download in the first place.
+
+### Can I manually edit the save file?
+Yes, using any text editor — but carefully: if you break the formatting the file won't load. The common error is text editors automatically splitting the embedded svg into separate lines.
+
+### Can I make the .map file smaller?
+Not significantly. Turning off some layers helps a little, but size mostly depends on the points number. You can compress the file with an external zip tool for storage.
+
+### Can I make the map open at a specific zoom and position?
+Save the map to browser storage, set "Onload behavior" to "Open last saved map" in Options, then use [URL parameters](URL-parameters): `https://azgaar.github.io/Fantasy-Map-Generator/?scale=4&x=800&y=200`.
+
+### Can I share my map with my players so it stays interactive?
+There is no view-only mode. Share the .map file — others can open it in FMG. They will be able to edit their copy, so keep your own master file. You can also [embed the map on a website](https://sites.google.com/view/fantasy-map-generator-embedded/home).

--- a/docs/wiki/Q&A:-States-and-politics.md
+++ b/docs/wiki/Q&A:-States-and-politics.md
@@ -1,0 +1,42 @@
+Part of the [FMG Q&A](Q&A). Related topics are listed there.
+
+## States and politics
+
+### How do I create a new country?
+Tools → States → click the add-state button at the bottom, then click the map to place its capital. Expand its territory with the editor's brush. Rename it by clicking its name in the list.
+
+### How do I change state, province, culture, or religion borders?
+Open the matching editor in Tools, click the brush button at the bottom, then click and drag on the map to paint territory. Confirm the changes when done. Rivers cross cell centers while borders follow cell edges, so borders cannot exactly follow rivers.
+
+### How do I merge countries?
+Tools → States → "Merge several states into one" button at the bottom of the dialog, then select the states to merge. To absorb territory gradually instead, paint over it with the absorbing state's brush.
+
+### How do I make a state bigger or smaller?
+Paint territory with that state's brush in the States editor. Removing a state entirely reassigns its land to neighbors and turns its capital into a neutral burg.
+
+### How do I represent an invasion or conquest?
+There is no war simulation over time. Paint the invader's territory over the conquered land in the States editor, set Diplomacy relations to Enemy where appropriate, and adjust cultures, religions and burgs to match the story. Battles between regiments can be fought in the [Battle Simulator](Battle-Simulator).
+
+### How do provinces work? Can I merge them or nest them?
+Provinces exist inside states, one level deep — no provinces inside provinces. To merge: remove one province and paint its territory into another with the Provinces editor brush (both must be in the same state). To turn a state into a province of another state: paint it over in the States editor, or declare the province independent first via the Provinces editor.
+
+### How do I keep states from filling the whole map?
+Lower the Growth rate setting (it controls how far states and cultures expand into neutral land), reduce individual states' expansion values, or delete some states. "Size variety" controls how much state areas differ from each other.
+
+### How do I stop a state from expanding across the sea?
+Set the state's culture type to Nomad in the editor and regenerate states — nomads avoid crossing water. See [Culture types](Culture-types).
+
+### How do I rename a state, or regenerate its name?
+Tools → States → click the state's name. The book icon re-rolls the name from its culture's namebase; the refresh icon gives a random name. To get names in a specific style (e.g. Portuguese), first set the culture's namebase in Tools → Cultures.
+
+### How do I change state colors?
+Tools → States → click the color box next to a state and pick a new color.
+
+### Which is my biggest country?
+Tools → States → sort the table by Area; the first row is the largest.
+
+### Can I remove a state's capital?
+Every state needs a capital. Reassign capital status to another burg first, then delete the old one — or delete the whole state, which demotes its capital to a neutral burg. To only hide capitals, toggle the burg icons layer off or set the capitals group opacity to 0 in Style.
+
+### Can borders regenerate automatically after my battles or story events?
+No — border changes from events are manual work with the States editor brush.


### PR DESCRIPTION
## What

Rebuilds the wiki Q&A from analysis of ~116k real user questions (in-app assistant threads + Discord #help/#fmg-bugs exports, clustered and deduplicated — the spreadsheet shared on Discord is the evidence base).

- `Q&A.md` becomes a compact entry point: 14 topic groups, all 115 questions as links.
- Answers live on per-topic pages (`Q&A:-Getting-started`, `Q&A:-States-and-politics`, ...), following the existing `Goods:-spread-functions` naming style so the wiki sync publishes them as regular pages.
- Every existing Q&A answer is kept or merged; ~20 new entries cover the highest-volume questions that had no answer (save/export discoverability, keyboard shortcuts, add-a-label, land↔water editing, undo, resize...).
- Questions are ranked and grouped by real ask volume, so the most-asked things come first.

## Corrections vs current wiki content

While aligning, several claims were verified against v1.148.6 code and corrected in the new answers:

- No Electron desktop release exists yet (that work is on the 1.149.0 branch; no release assets) — offline answer now leads with PWA + npm-based local run.
- Plain static serving no longer works since the Vite/TS migration — local run is `npm install && npm run dev` (Node ≥24) or `npm run build` → serve `dist/`.
- Ruler tools moved from the Units editor to the Measurers Editor (Shift+=).
- Marker icons accept external images via URL/data-URI in the Icon Selector.
- Button is "New Map", hotkey Tab toggles the options pane.

## Review

Opened as a draft — the answer set is intended for the quality evaluation discussed on Discord (manual and/or model-assisted). A follow-up freshness audit of the other wiki pages found 12 of 22 MAJOR-STALE (Hotkeys, Quick-Start, Run-FMG-locally, User-Interface top the list); happy to bring those fixes as separate parcels.