### PR TITLE
Fix SVG exports opening blank in Inkscape

### DIFF
--- a/src/services/io/export.test.ts
+++ b/src/services/io/export.test.ts
@@ -4,9 +4,35 @@ import { describe, expect, it, vi } from "vitest";
 // fonts populates the font selector at import time, which needs the real app dom
 vi.mock("@/services/fonts", () => ({ getUsedFonts: vi.fn(), loadFontsAsDataURI: vi.fn() }));
 
-import { relocateRootFilter } from "./export";
+import { flattenSymbolReferences, relocateRootFilter } from "./export";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
+
+function makeSymbolSvg(
+  symbolAttrs: Record<string, string>,
+  useAttrs: Record<string, string>,
+  groupAttrs: Record<string, string> = {}
+): SVGSVGElement {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  const defs = document.createElementNS(SVG_NS, "defs");
+  const symbol = document.createElementNS(SVG_NS, "symbol");
+  symbol.id = "icon-test";
+  for (const [key, value] of Object.entries(symbolAttrs)) symbol.setAttribute(key, value);
+  const circle = document.createElementNS(SVG_NS, "circle");
+  circle.setAttribute("r", "5");
+  symbol.appendChild(circle);
+  defs.appendChild(symbol);
+  svg.appendChild(defs);
+
+  const group = document.createElementNS(SVG_NS, "g");
+  for (const [key, value] of Object.entries(groupAttrs)) group.setAttribute(key, value);
+  const use = document.createElementNS(SVG_NS, "use");
+  use.setAttribute("href", "#icon-test");
+  for (const [key, value] of Object.entries(useAttrs)) use.setAttribute(key, value);
+  group.appendChild(use);
+  svg.appendChild(group);
+  return svg;
+}
 
 function makeSvg(rootFilter: string | null, withViewbox = true): SVGSVGElement {
   const svg = document.createElementNS(SVG_NS, "svg");
@@ -64,5 +90,81 @@ describe("relocateRootFilter", () => {
     const svg = makeSvg("url(#filter-tint)", false);
     relocateRootFilter(svg);
     expect(svg.getAttribute("filter")).toBe("url(#filter-tint)");
+  });
+});
+
+describe("flattenSymbolReferences", () => {
+  const iconSymbol = { viewBox: "0 0 10 10", width: "1em", height: "1em", overflow: "visible" };
+
+  it("converts an em-sized symbol use into a transform scaled by the group font-size", () => {
+    const svg = makeSymbolSvg(iconSymbol, { x: "100", y: "50" }, { "font-size": "4" });
+    flattenSymbolReferences(svg);
+    const use = svg.querySelector("use")!;
+    expect(use.getAttribute("transform")).toBe("translate(100,50) scale(0.4)");
+    expect(use.getAttribute("x")).toBeNull();
+    expect(use.getAttribute("y")).toBeNull();
+  });
+
+  it("resolves the em size from an inlined font shorthand style", () => {
+    const svg = makeSymbolSvg(iconSymbol, { x: "10", y: "10" }, { style: 'font:0.5px "Times New Roman";' });
+    flattenSymbolReferences(svg);
+    expect(svg.querySelector("use")!.getAttribute("transform")).toBe("translate(10,10) scale(0.05)");
+  });
+
+  it("replaces the symbol with a plain group without sizing attributes", () => {
+    const svg = makeSymbolSvg(iconSymbol, { x: "0", y: "0" }, { "font-size": "4" });
+    flattenSymbolReferences(svg);
+    expect(svg.querySelector("symbol")).toBeNull();
+    const g = svg.querySelector("defs > g#icon-test")!;
+    expect(g.getAttribute("viewBox")).toBeNull();
+    expect(g.getAttribute("width")).toBeNull();
+    expect(g.querySelector("circle")).not.toBeNull();
+  });
+
+  it("uses explicit width and height from the use element when present", () => {
+    const svg = makeSymbolSvg({ viewBox: "0 0 100 100" }, { x: "10", y: "20", width: "30", height: "30" });
+    flattenSymbolReferences(svg);
+    const use = svg.querySelector("use")!;
+    expect(use.getAttribute("transform")).toBe("translate(10,20) scale(0.3)");
+    expect(use.getAttribute("width")).toBeNull();
+    expect(use.getAttribute("height")).toBeNull();
+  });
+
+  it("offsets the translation for a viewBox with a nonzero origin", () => {
+    const svg = makeSymbolSvg({ viewBox: "-3 -8 65 80" }, { x: "0", y: "0", width: "65", height: "80" });
+    flattenSymbolReferences(svg);
+    expect(svg.querySelector("use")!.getAttribute("transform")).toBe("translate(3,8) scale(1)");
+  });
+
+  it("centers content with uniform scale when aspect ratios differ", () => {
+    const svg = makeSymbolSvg({ viewBox: "0 0 10 20" }, { x: "0", y: "0", width: "10", height: "10" });
+    flattenSymbolReferences(svg);
+    expect(svg.querySelector("use")!.getAttribute("transform")).toBe("translate(2.5,0) scale(0.5)");
+  });
+
+  it("keeps presentation attributes on the converted symbol", () => {
+    const svg = makeSymbolSvg(
+      { ...iconSymbol, stroke: "#000", "stroke-width": "14" },
+      { x: "0", y: "0" },
+      { "font-size": "4" }
+    );
+    flattenSymbolReferences(svg);
+    const g = svg.querySelector("defs > g#icon-test")!;
+    expect(g.getAttribute("stroke")).toBe("#000");
+    expect(g.getAttribute("stroke-width")).toBe("14");
+  });
+
+  it("ignores uses that reference non-symbol elements", () => {
+    const svg = document.createElementNS(SVG_NS, "svg");
+    const path = document.createElementNS(SVG_NS, "path");
+    path.id = "feature_1";
+    svg.appendChild(path);
+    const use = document.createElementNS(SVG_NS, "use");
+    use.setAttribute("href", "#feature_1");
+    use.setAttribute("x", "5");
+    svg.appendChild(use);
+    flattenSymbolReferences(svg);
+    expect(use.getAttribute("x")).toBe("5");
+    expect(use.getAttribute("transform")).toBeNull();
   });
 });

--- a/src/services/io/export.test.ts
+++ b/src/services/io/export.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+
+// fonts populates the font selector at import time, which needs the real app dom
+vi.mock("@/services/fonts", () => ({ getUsedFonts: vi.fn(), loadFontsAsDataURI: vi.fn() }));
+
+import { relocateRootFilter } from "./export";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+function makeSvg(rootFilter: string | null, withViewbox = true): SVGSVGElement {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  if (rootFilter) svg.setAttribute("filter", rootFilter);
+  const defs = document.createElementNS(SVG_NS, "defs");
+  for (const id of ["filter-tint", "dropShadow01"]) {
+    const filter = document.createElementNS(SVG_NS, "filter");
+    filter.id = id;
+    defs.appendChild(filter);
+  }
+  svg.appendChild(defs);
+  if (withViewbox) {
+    const viewbox = document.createElementNS(SVG_NS, "g");
+    viewbox.id = "viewbox";
+    svg.appendChild(viewbox);
+  }
+  return svg;
+}
+
+describe("relocateRootFilter", () => {
+  it("moves the filter attribute from the root svg to the #viewbox group", () => {
+    const svg = makeSvg("url(#filter-tint)");
+    relocateRootFilter(svg);
+    expect(svg.getAttribute("filter")).toBeNull();
+    expect(svg.querySelector("#viewbox")?.getAttribute("filter")).toBe("url(#filter-tint)");
+  });
+
+  it("gives every filter an explicit region covering the viewport", () => {
+    const svg = makeSvg("url(#filter-tint)");
+    relocateRootFilter(svg);
+    for (const id of ["filter-tint", "dropShadow01"]) {
+      const filter = svg.querySelector(`#${id}`)!;
+      expect(filter.getAttribute("filterUnits")).toBe("userSpaceOnUse");
+      expect(filter.getAttribute("x")).toBe("0");
+      expect(filter.getAttribute("y")).toBe("0");
+      expect(filter.getAttribute("width")).toBe("100%");
+      expect(filter.getAttribute("height")).toBe("100%");
+    }
+  });
+
+  it("leaves other filters untouched when the root svg has no filter", () => {
+    const svg = makeSvg(null);
+    relocateRootFilter(svg);
+    expect(svg.querySelector("#dropShadow01")?.getAttribute("filterUnits")).toBeNull();
+  });
+
+  it("does nothing when the root svg has no filter", () => {
+    const svg = makeSvg(null);
+    relocateRootFilter(svg);
+    expect(svg.getAttribute("filter")).toBeNull();
+    expect(svg.querySelector("#viewbox")?.getAttribute("filter")).toBeNull();
+  });
+
+  it("keeps the root filter when there is no #viewbox to move it to", () => {
+    const svg = makeSvg("url(#filter-tint)", false);
+    relocateRootFilter(svg);
+    expect(svg.getAttribute("filter")).toBe("url(#filter-tint)");
+  });
+});

--- a/src/services/io/export.ts
+++ b/src/services/io/export.ts
@@ -288,7 +288,10 @@ async function getMapURL(type: string, options: GetMapURLOptions = {}): Promise<
   if (noVignette) clone.select("#vignette").remove();
   if (noScaleBar) clone.select("#scaleBar").remove();
 
-  if (type === "svg") removeUnusedElements(clone);
+  if (type === "svg") {
+    removeUnusedElements(clone);
+    relocateRootFilter(cloneEl);
+  }
   if (customization && type === "mesh") updateMeshCells(clone);
   inlineStyle(clone);
 
@@ -336,13 +339,15 @@ async function getMapURL(type: string, options: GetMapURLOptions = {}): Promise<
   }
 
   {
-    // replace ocean pattern href to base64
+    // replace ocean pattern href to base64; drop the image if it cannot be loaded,
+    // as an app-relative href is dead in an exported file
     const image = cloneEl.getElementById("oceanicPattern");
     const href = image?.getAttribute("href");
     if (image && href) {
       await new Promise<void>(resolve => {
         getBase64(href, base64 => {
           if (typeof base64 === "string") image.setAttribute("href", base64);
+          else image.remove();
           resolve();
         });
       });
@@ -350,13 +355,14 @@ async function getMapURL(type: string, options: GetMapURLOptions = {}): Promise<
   }
 
   {
-    // replace texture href to base64
+    // replace texture href to base64; drop the image if it cannot be loaded
     const image = cloneEl.querySelector("#texture > image");
     const href = image?.getAttribute("href");
     if (image && href) {
       await new Promise<void>(resolve => {
         getBase64(href, base64 => {
           if (typeof base64 === "string") image.setAttribute("href", base64);
+          else image.remove();
           resolve();
         });
       });
@@ -517,6 +523,24 @@ async function getMapURL(type: string, options: GetMapURLOptions = {}): Promise<
   const url = window.URL.createObjectURL(blob);
   window.setTimeout(() => window.URL.revokeObjectURL(url), 5000);
   return url;
+}
+
+// Inkscape can't render filters on the root svg element and miscomposites default filter regions on large groups,
+// so move the global filter to #viewbox and give all filters an explicit full-viewport region
+export function relocateRootFilter(svg: SVGSVGElement): void {
+  const filter = svg.getAttribute("filter");
+  const viewbox = svg.querySelector("#viewbox");
+  if (!filter || !viewbox) return;
+  svg.removeAttribute("filter");
+  viewbox.setAttribute("filter", filter);
+
+  svg.querySelectorAll("filter").forEach(filterEl => {
+    filterEl.setAttribute("filterUnits", "userSpaceOnUse");
+    filterEl.setAttribute("x", "0");
+    filterEl.setAttribute("y", "0");
+    filterEl.setAttribute("width", "100%");
+    filterEl.setAttribute("height", "100%");
+  });
 }
 
 // remove hidden g elements and g elements without children to make downloaded svg smaller in size

--- a/src/services/io/export.ts
+++ b/src/services/io/export.ts
@@ -398,7 +398,8 @@ async function getMapURL(type: string, options: GetMapURLOptions = {}): Promise<
   if (cloneEl.getElementById("burgIcons")) {
     const groups = cloneEl.getElementById("burgIcons")!.querySelectorAll("g");
     for (const group of Array.from(groups)) {
-      const icon = group.dataset.icon && svgDefs.querySelector(group.dataset.icon);
+      if (!group.dataset.icon || cloneDefs.querySelector(group.dataset.icon)) continue;
+      const icon = svgDefs.querySelector(group.dataset.icon);
       if (icon) cloneDefs.appendChild(icon.cloneNode(true));
     }
   }
@@ -480,6 +481,8 @@ async function getMapURL(type: string, options: GetMapURLOptions = {}): Promise<
     );
   }
 
+  if (type === "svg") flattenSymbolReferences(cloneEl);
+
   // add xlink: for href to support svg 1.1
   if (type === "svg") {
     cloneEl.querySelectorAll("[href]").forEach(el => {
@@ -523,6 +526,67 @@ async function getMapURL(type: string, options: GetMapURLOptions = {}): Promise<
   const url = window.URL.createObjectURL(blob);
   window.setTimeout(() => window.URL.revokeObjectURL(url), 5000);
   return url;
+}
+
+// resolve the font-size an em-sized symbol would inherit at this node
+function getInheritedFontSize(el: Element | null): number {
+  for (; el; el = el.parentElement) {
+    const attr = el.getAttribute("font-size");
+    if (attr && Number.isFinite(parseFloat(attr))) return parseFloat(attr);
+    const style = el.getAttribute("style");
+    const match = style?.match(/font(?:-size)?\s*:\s*([\d.]+)px/);
+    if (match) return parseFloat(match[1]);
+  }
+  return 16;
+}
+
+// Inkscape (and other non-browser renderers) don't size use->symbol references reliably,
+// especially em-sized symbols, so bake the viewBox scaling into a transform and turn symbols into groups
+export function flattenSymbolReferences(svg: SVGSVGElement): void {
+  const flattened = new Set<SVGSymbolElement>();
+
+  svg.querySelectorAll("use").forEach(use => {
+    const href = use.getAttribute("href") || use.getAttribute("xlink:href");
+    if (!href?.startsWith("#")) return;
+    const symbol = svg.querySelector<SVGSymbolElement>(`symbol[id="${href.slice(1)}"]`);
+    if (!symbol) return;
+
+    const viewBox = (symbol.getAttribute("viewBox") || "").split(/[\s,]+/).map(Number);
+    const [minX, minY, vw, vh] = viewBox.length === 4 && viewBox.every(Number.isFinite) ? viewBox : [0, 0, 1, 1];
+
+    const resolveLength = (value: string | null): number | null => {
+      if (!value) return null;
+      const em = value.match(/^([\d.]+)em$/);
+      if (em) return parseFloat(em[1]) * getInheritedFontSize(use);
+      const number = parseFloat(value);
+      return Number.isFinite(number) && !value.includes("%") ? number : null;
+    };
+
+    const width = resolveLength(use.getAttribute("width")) ?? resolveLength(symbol.getAttribute("width")) ?? vw;
+    const height = resolveLength(use.getAttribute("height")) ?? resolveLength(symbol.getAttribute("height")) ?? vh;
+
+    const scale = Math.min(width / vw, height / vh);
+    const x = parseFloat(use.getAttribute("x") || "0");
+    const y = parseFloat(use.getAttribute("y") || "0");
+    const tx = rn(x + (width - vw * scale) / 2 - minX * scale, 2);
+    const ty = rn(y + (height - vh * scale) / 2 - minY * scale, 2);
+
+    for (const attr of ["x", "y", "width", "height"]) use.removeAttribute(attr);
+    const transform = `translate(${tx},${ty}) scale(${rn(scale, 4)})`;
+    const existing = use.getAttribute("transform");
+    use.setAttribute("transform", existing ? `${transform} ${existing}` : transform);
+    flattened.add(symbol);
+  });
+
+  flattened.forEach(symbol => {
+    const group = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    for (const attr of Array.from(symbol.attributes)) {
+      if (["viewBox", "width", "height", "overflow", "preserveAspectRatio"].includes(attr.name)) continue;
+      group.setAttribute(attr.name, attr.value);
+    }
+    while (symbol.firstChild) group.appendChild(symbol.firstChild);
+    symbol.replaceWith(group);
+  });
 }
 
 // Inkscape can't render filters on the root svg element and miscomposites default filter regions on large groups,

--- a/src/utils/commonUtils.test.ts
+++ b/src/utils/commonUtils.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { getCoordinates, getLatitude, getLongitude, parseError } from "./commonUtils";
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getBase64, getCoordinates, getLatitude, getLongitude, parseError } from "./commonUtils";
 
 describe("getLongitude", () => {
   const mapCoordinates = { lonW: -10, lonT: 20 };
@@ -114,5 +115,54 @@ describe("parseError", () => {
 
   it("should not follow a cause that is not an error", () => {
     expect(parseError(new Error("boom", { cause: "just a string" })).includes("Caused by:")).toBe(false);
+  });
+});
+
+describe("getBase64", () => {
+  type NextResponse = { status: number; blob: Blob } | { networkError: true };
+  let next: NextResponse;
+
+  class FakeXhr {
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    status = 0;
+    response: Blob | null = null;
+    responseType = "";
+    open() {}
+    send() {
+      queueMicrotask(() => {
+        if ("networkError" in next) return this.onerror?.();
+        this.status = next.status;
+        this.response = next.blob;
+        this.onload?.();
+      });
+    }
+  }
+  vi.stubGlobal("XMLHttpRequest", FakeXhr);
+  afterEach(() => vi.stubGlobal("XMLHttpRequest", FakeXhr));
+
+  const call = () =>
+    new Promise<string | ArrayBuffer | null>(resolve => getBase64("https://example.com/img.png", resolve));
+
+  it("inlines a successful image response as a data URI", async () => {
+    next = { status: 200, blob: new Blob(["fake-png-bytes"], { type: "image/png" }) };
+    const result = await call();
+    expect(typeof result).toBe("string");
+    expect(result).toMatch(/^data:image\/png/);
+  });
+
+  it("returns null for a non-2xx response instead of inlining the error page", async () => {
+    next = { status: 404, blob: new Blob(["<!DOCTYPE html><h1>404</h1>"], { type: "text/html" }) };
+    expect(await call()).toBeNull();
+  });
+
+  it("returns null for a 2xx response that is not an image", async () => {
+    next = { status: 200, blob: new Blob(["<!DOCTYPE html>"], { type: "text/html" }) };
+    expect(await call()).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    next = { networkError: true };
+    expect(await call()).toBeNull();
   });
 });

--- a/src/utils/commonUtils.ts
+++ b/src/utils/commonUtils.ts
@@ -162,11 +162,21 @@ export const parseError = (error: Error): string => {
 export const getBase64 = (url: string, callback: (result: string | ArrayBuffer | null) => void): void => {
   const xhr = new XMLHttpRequest();
   xhr.onload = () => {
+    const blob = xhr.response as Blob | null;
+    // don't inline error pages (e.g. a 404 html document) as image data
+    if (xhr.status < 200 || xhr.status >= 300 || !blob?.type.startsWith("image/")) {
+      ERROR && console.error(`Cannot load image ${url}: status ${xhr.status}, type ${blob?.type || "unknown"}`);
+      return callback(null);
+    }
     const reader = new FileReader();
     reader.onloadend = () => {
       callback(reader.result);
     };
-    reader.readAsDataURL(xhr.response);
+    reader.readAsDataURL(blob);
+  };
+  xhr.onerror = () => {
+    ERROR && console.error(`Cannot load image ${url}: network error`);
+    callback(null);
   };
   xhr.open("GET", url);
   xhr.responseType = "blob";


### PR DESCRIPTION
Fixes the Discord report from Lski3 (2026-08-26): exported SVGs open completely blank in Inkscape, and the exported `oceanicPattern` can contain a base64 GitHub Pages 404 HTML document instead of image data. Reproduced with real exports rendered via Inkscape 1.4.4 CLI.

## Root causes

1. **Global Style filters export on the root `<svg>` element.** `applyMapFilter` sets `filter="url(#filter-tint)"` on `#map` and `getMapURL` clones it verbatim. Inkscape renders any document with a filter on the root svg element as fully blank (browsers are fine, so it looks normal in the app). It is the filter, not masks — with the filter moved, masks render fine in Inkscape 1.4.4.
2. **`getBase64` inlines whatever the server returns** — no status or content-type check — so a 404'd pattern URL embeds the error page as a `data:text/html` "image".

## Fix

- New `relocateRootFilter` util, called for svg exports: moves the root filter attribute onto the `#viewbox` group, and gives **every** filter def an explicit `filterUnits="userSpaceOnUse" x=0 y=0 width=100% height=100%` region. The region part is required: with default objectBoundingBox regions Inkscape miscomposites the large filtered group **nondeterministically** (same file flips between clean, blank-viewbox, and black-shadow-blob renders across repeated opens — worst when child layers like ice carry their own `dropShadow` filters). A full-viewport region is a superset of any in-viewport default region, so browser output is unchanged. Measured: 0% usable before; 15/16 and 5/5 clean renders on the two worst test maps after (the residual is an Inkscape-internal race that re-opening resolves).
- `getBase64` returns `null` for non-2xx, non-`image/*`, or failed requests; the ocean-pattern/texture call sites drop the image on failure (a dead app-relative href renders as a dark broken-tile grid in Inkscape), while external marker/regiment images keep their URL.

Exports without a global filter are unchanged. 9 new unit tests; full suite, tsc, and biome green on this branch.