### PR TITLE
Record-less old maps keep their burg and anchor group styling

### DIFF
--- a/src/generators/styles-legacy.dom.test.ts
+++ b/src/generators/styles-legacy.dom.test.ts
@@ -58,15 +58,29 @@ test("an omitted option still defaults, unlike a schema attr", () => {
   expect(result.grid.options.type).toBe(DEFAULT_STYLES.grid.options.type);
 });
 
-test("syncStylesFromMap keeps burg/anchor groups store-authoritative on save", () => {
+test("record-less sync harvests burg/anchor groups from the DOM, size dialect included", () => {
+  document.body.innerHTML = `<svg id="map">
+    <g id="burgIcons"><g id="largetowns" fill="#fffff0" fill-opacity="0.7" size="0.8" stroke="#3e3e4b"></g></g>
+    <g id="anchors"><g id="largetowns" fill="#fffff0" size="1.6"></g></g>
+  </svg>`;
+  syncStylesFromMap();
+  // a map with no style record at all: its DOM groups are the only source of their styling
+  expect(styles.burgIcons.burgIcons.groups.largetowns.attrs.fill).toBe("#fffff0");
+  expect(styles.burgIcons.burgIcons.groups.largetowns.options.size).toBe(0.8);
+  expect(styles.burgIcons.anchors.groups.largetowns.options.size).toBe(1.6);
+  expect(styles.burgIcons.burgIcons.groups.capital).toBeDefined(); // defaults stay as fallbacks
+  Styles.set(structuredClone(Styles.defaults));
+});
+
+test("a legacy style record keeps its burg/anchor groups against the DOM harvest", () => {
   document.body.innerHTML = `<svg id="map">
     <g id="burgIcons"><g id="capital" fill="#00ff00" font-size="3"></g></g>
     <g id="anchors"><g id="capital" fill="#00ff00" font-size="3"></g></g>
   </svg>`;
   styles.burgIcons.burgIcons.groups.capital.attrs.fill = "#000000";
   styles.burgIcons.burgIcons.groups.town = structuredClone(styles.burgIcons.burgIcons.groups.capital);
-  syncStylesFromMap();
-  // the editor writes the store now: stale DOM attrs no longer win at save time
+  syncStylesFromMap({ hasStyleRecord: true });
+  // stylesFromLegacy already seeded these from the record; the DOM may carry stale values
   expect(styles.burgIcons.burgIcons.groups.capital.attrs.fill).toBe("#000000");
   expect(styles.burgIcons.burgIcons.groups.town).toBeDefined();
   styles.burgIcons.burgIcons.groups.capital.attrs.fill = "#ffffff";

--- a/src/generators/styles-legacy.test.ts
+++ b/src/generators/styles-legacy.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { expect, test, vi } from "vitest";
 import { Styles } from "./styles";
 import {
+  burgGroupFromLegacy,
   isLegacyPreset,
   isStoreStyles,
   labelGroupFromLegacy,
@@ -203,4 +204,10 @@ test("save.ts's master-compat shim: a top-level anchors:{} still parses clean", 
   const parsed = Styles.parse(record);
   expect(parsed).toEqual(DEFAULT_STYLES);
   expect(warn).not.toHaveBeenCalled();
+});
+
+test("burg group size reads the pre-1.9x size attr when font-size is absent", () => {
+  expect(burgGroupFromLegacy({ size: "0.8" }).options.size).toBe(0.8);
+  expect(burgGroupFromLegacy({ "font-size": "2", size: "0.8" }).options.size).toBe(2);
+  expect(burgGroupFromLegacy({}).options.size).toBe(1);
 });

--- a/src/generators/styles-legacy.ts
+++ b/src/generators/styles-legacy.ts
@@ -78,7 +78,8 @@ export function burgGroupFromLegacy(legacy: object): BurgGroupStyle {
       filter: strOr(bag.filter, null)
     },
     options: {
-      size: toNumber(bag["font-size"], 1),
+      // pre-1.9x maps carry the group size as a bare `size` attr instead of font-size
+      size: toNumber(bag["font-size"], toNumber(bag.size, 1)),
       icon: strOr(bag["data-icon"], null) ?? "#icon-circle"
     }
   };
@@ -369,7 +370,7 @@ function harvestBag(
 const LABEL_SCHEMA_ATTRS = Object.keys(Object.values(DEFAULT_STYLES.labels.groups)[0].attrs);
 const LABEL_ATTRS = [...LABEL_SCHEMA_ATTRS, "data-dx", "data-dy", "data-size"];
 const BURG_SCHEMA_ATTRS = Object.keys(Object.values(DEFAULT_STYLES.burgIcons.burgIcons.groups)[0].attrs);
-const BURG_ATTRS = [...BURG_SCHEMA_ATTRS, "font-size", "data-icon"];
+const BURG_ATTRS = [...BURG_SCHEMA_ATTRS, "font-size", "size", "data-icon"];
 
 export function stylesFromMap(root: ParentNode = document): Styles {
   const bags: Record<string, Record<string, unknown>> = {};
@@ -399,12 +400,15 @@ export function stylesFromMap(root: ParentNode = document): Styles {
   return presetFromLegacy(bags, { onUnknown: "skip" });
 }
 
-// runs on both edges (save, and record-less old-map migration on load): harvest the
-// DOM-authoritative layers, overlay the domains the store owns
-export function syncStylesFromMap(): void {
+// load-only migration for maps without a store record: harvest the DOM-authoritative
+// layers, overlay the domains the store owns
+export function syncStylesFromMap({ hasStyleRecord = false } = {}): void {
   const harvested = stylesFromMap();
+  // the labels migration seeds styles.labels from the DOM before this runs, and a legacy
+  // record seeds burg groups via stylesFromLegacy; with no record at all the map's own
+  // DOM groups are the only source of their styling, so the harvest keeps them
   harvested.labels = structuredClone(styles.labels);
-  harvested.burgIcons = structuredClone(styles.burgIcons);
+  if (hasStyleRecord) harvested.burgIcons = structuredClone(styles.burgIcons);
   harvested.relief.options = structuredClone(styles.relief.options);
   // post-migration maps carry no rescale/data-width attrs, so the store owns these
   // options; a loaded old map's attrs win here until the load-time strip removes them

--- a/src/services/io/auto-update.ts
+++ b/src/services/io/auto-update.ts
@@ -1676,11 +1676,14 @@ export async function resolveVersionConflicts(mapVersion: string, data: string[]
       }
     }
 
+    // scoped to the parent: same-named groups under different parents are by design
+    // (#burgIcons > g#city beside #anchors > g#city), only same-parent copies are duplicates
     const groupsById = new Map<string, SVGGElement[]>();
     for (const group of groups) {
-      const sameId = groupsById.get(group.id) ?? [];
+      const key = `${(group.parentNode as Element | null)?.id ?? ""}>${group.id}`;
+      const sameId = groupsById.get(key) ?? [];
       sameId.push(group);
-      groupsById.set(group.id, sameId);
+      groupsById.set(key, sameId);
     }
 
     const declared = new Set<string>();
@@ -1890,8 +1893,11 @@ export async function resolveVersionConflicts(mapVersion: string, data: string[]
 
   // Version-lie maps make the record's own shape the only trustworthy signal: harvest fills the store for
   // record-less maps so the next save persists correctly, while absorbed domains stay with migration-gate values
-  if (!isStoreStyles(safeParseJSON(data[48]))) {
-    syncStylesFromMap();
+  {
+    const styleRecord = safeParseJSON(data[48]);
+    if (!isStoreStyles(styleRecord)) {
+      syncStylesFromMap({ hasStyleRecord: Boolean(styleRecord) });
+    }
   }
 
   // unconditional: step-4-era saves carry these attrs beside a store record too, and the

--- a/tests/e2e/style-persistence.spec.ts
+++ b/tests/e2e/style-persistence.spec.ts
@@ -154,6 +154,51 @@ test.describe("style persistence round trips", () => {
     expect(parsed).toHaveProperty("map");
   });
 
+  test("record-less burg and anchor groups: the map's own styling reaches the store and the record", async ({
+    page,
+    context
+  }) => {
+    await context.clearCookies();
+    await page.goto("/");
+    await page.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+
+    // a pre-1.9x-dialect map: same-named groups under #burgIcons and #anchors (by design, not
+    // duplicates), styled via the bare `size` attr. The 1.145 dedupe migration must keep both,
+    // and the record-less harvest must carry them into the store instead of the boot defaults.
+    const fixture = fs.readFileSync(path.join(__dirname, "../fixtures/1.112.1.map"));
+    const lines = fixture.toString("utf8").split("\r\n");
+    lines[5] = lines[5]
+      .replace('<g id="burgIcons"/>', '<g id="burgIcons"><g id="cities" fill="#ee2222" size="0.9"><use></use></g></g>')
+      .replace('<g id="anchors"/>', '<g id="anchors"><g id="cities" fill="#22ee22" size="2.2"><use></use></g></g>');
+    expect(lines[5], "burg group injection must match the serialized svg").toContain('fill="#ee2222"');
+    expect(lines[5], "anchor group injection must match the serialized svg").toContain('fill="#22ee22"');
+
+    await waitForMap(page);
+    await reload(page, Buffer.from(lines.join("\r\n"), "utf8"), "recordless-burg-groups");
+    await page.waitForTimeout(1000);
+
+    const harvested = await page.evaluate(() => ({
+      iconFill: styles.burgIcons.burgIcons.groups.cities?.attrs?.fill ?? null,
+      iconSize: styles.burgIcons.burgIcons.groups.cities?.options?.size ?? null,
+      anchorFill: styles.burgIcons.anchors.groups.cities?.attrs?.fill ?? null,
+      anchorSize: styles.burgIcons.anchors.groups.cities?.options?.size ?? null
+    }));
+
+    // this fixture postdates the 1.109 size-doubling migration, so the sizes harvest as written
+    expect(harvested.iconFill).toBe("#ee2222");
+    expect(harvested.iconSize).toBe(0.9);
+    expect(harvested.anchorFill).toBe("#22ee22");
+    expect(harvested.anchorSize).toBe(2.2);
+
+    const savedAgain = await saveAsDownload(page);
+    const record = JSON.parse(savedAgain.toString("utf8").split("\r\n")[48]);
+    expect(record.burgIcons.burgIcons.groups.cities.options.size).toBe(0.9);
+    expect(record.burgIcons.anchors.groups.cities.options.size).toBe(2.2);
+  });
+
   test("preset-nulled attr stays absent: a preset switch survives a save and load with no backfill", async ({
     page,
     context


### PR DESCRIPTION
First fix from the old-map field testing round — found with a real 1.88.00 map (Nov 2022) and verified against a 1.90.01 save of the same world. Three stacked defects hid each other; together they made record-less old maps lose all burg icon and anchor group styling (everything fell back to the `town` defaults — the "my anchors/icons reset" class of report).

## The three defects

1. **The 1.145 duplicate-groups migration dedupes by id alone.** Same-named groups under different parents — `#burgIcons > g#cities` beside `#anchors > g#cities` — are by design, not duplicates, but the dedupe kept only the first non-empty copy. Every pre-1.145 load destroyed its anchor groups; maps with a style record never showed it because the groups recreate from the record. Now scoped to the parent (`parentId>id`), which still removes the real same-parent duplicates the migration targets.

2. **Pre-1.9x maps carry the group size as a bare `size` attr.** The harvest only read `font-size`, so sizes collapsed to the default 1. `burgGroupFromLegacy` now falls back to `size` when `font-size` is absent (`font-size` still wins when both are present).

3. **The record-less harvest overwrote its own burg-group result with the boot defaults.** `syncStylesFromMap`'s store-clone of `burgIcons` was a save-time rule (the editor writes the store, stale DOM must not win) — but since step 7 the sync is load-only, and with no record at all the map's DOM groups are the only source of their styling. The clone now applies only when a legacy record already seeded the store (`hasStyleRecord`, passed by the caller). The labels clone stays as-is: the labels migration seeds the store from the DOM before the sync runs, verified end to end on both specimens (custom per-group fonts survive).

## Verification

- New e2e pin (RED-verified against the unfixed source): the record-less 1.112.1 fixture with injected same-named icon/anchor groups — they survive the dedupe, harvest into the store with their own fills and sizes, and re-save into the record.
- New unit + browser tests for the `size` dialect and the record-less/record-seeded sync contracts.
- Full battery: 461 unit + 36 browser + 188/188 e2e, tsc and biome clean.
- Both real specimens load with their original styling (icon sizes carry the intended 1.109 ×2 conversion; anchors keep theirs verbatim) and re-save as store-format records.
