### PR TITLE
Install the desktop app from a Nix flake

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,51 @@
+name: Nix package
+
+on:
+  # Nothing else builds the flake, so a stale npmDepsHash or a broken derivation would
+  # otherwise reach main unnoticed: the npm lock file carries the app version, and a
+  # version bump alone is enough to invalidate the hash
+  pull_request:
+    branches: [main]
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "nix/**"
+      - "package.json"
+      - "package-lock.json"
+      - "electron/**"
+      - "scripts/electron.mjs"
+      - "vite.config.ts"
+
+  workflow_dispatch:
+
+jobs:
+  nix-build:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: Check the flake evaluates
+        run: nix flake check --no-build --all-systems
+      - name: Build the desktop package
+        run: nix build .#fantasy-map-generator -L
+      - name: Check the built app is complete
+        run: |
+          set -euo pipefail
+          test -x result/bin/fantasy-map-generator
+          for file in main.js preload.js icon.png renderer/index.html; do
+            test -f "result/share/fantasy-map-generator/dist-electron/$file"
+          done
+          # the app reads its version from the package.json shipped beside the bundle
+          version=$(jq -r .version result/share/fantasy-map-generator/package.json)
+          test "$version" = "$(jq -r .version package.json)"
+          echo "built fantasy-map-generator $version"

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@
 /dist-electron
 /release
 .DS_Store
+
+# nix build output
+/result
+/result-*

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ _Inspiration:_
 
 - Scott Turner's [_Here Dragons Abound_](https://heredragonsabound.blogspot.com)
 
+## Desktop app
+
+Installers for Linux, Windows and macOS are attached to each
+[release](https://github.com/Azgaar/Fantasy-Map-Generator/releases). Nix users can build
+the same app from the flake instead — see [Install with Nix](https://github.com/Azgaar/Fantasy-Map-Generator/wiki/Install-with-Nix):
+
+```sh
+nix run github:Azgaar/Fantasy-Map-Generator
+```
+
 ## Contribution
 
 Pull requests are highly welcomed. The codebase is messy and I will appreciate if you start with minor changes. Check out the [data model](https://github.com/Azgaar/Fantasy-Map-Generator/wiki/Data-model) before contributing.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -39,6 +39,7 @@ The project is under active development. Join our [Discord server](https://disco
 
 **Running and integrating**
 [Run FMG locally](https://github.com/Azgaar/Fantasy-Map-Generator/wiki/Run-FMG-locally) ·
+[Install with Nix](https://github.com/Azgaar/Fantasy-Map-Generator/wiki/Install-with-Nix) ·
 [Working offline](https://github.com/Azgaar/Fantasy-Map-Generator/wiki/Working-offline) ·
 [URL parameters](https://github.com/Azgaar/Fantasy-Map-Generator/wiki/URL-parameters) ·
 [GIS data export](https://github.com/Azgaar/Fantasy-Map-Generator/wiki/GIS-data-export) ·

--- a/docs/wiki/Install-with-Nix.md
+++ b/docs/wiki/Install-with-Nix.md
@@ -1,0 +1,137 @@
+The desktop app ships as an AppImage, a `.deb`, a Windows installer and a macOS
+`.dmg` from the [releases page](https://github.com/Azgaar/Fantasy-Map-Generator/releases).
+Nix users do not need any of them: the flake builds the same app and installs it
+like any other package.
+
+Everything below needs flakes enabled. On NixOS put this in your configuration:
+
+```nix
+nix.settings.experimental-features = [ "nix-command" "flakes" ];
+```
+
+On other distributions, add `experimental-features = nix-command flakes` to
+`~/.config/nix/nix.conf`.
+
+## Just run it
+
+Downloads, builds and launches in one step, leaving nothing installed:
+
+```sh
+nix run github:Azgaar/Fantasy-Map-Generator
+```
+
+The first run takes a few minutes — mostly fetching Electron's ~250 MB runtime
+from `cache.nixos.org`. Later runs start instantly.
+
+## Install it
+
+```sh
+nix profile install github:Azgaar/Fantasy-Map-Generator
+```
+
+This puts `fantasy-map-generator` on your `PATH` and installs a desktop entry, so
+it also appears in your application launcher.
+
+To update, upgrade and uninstall:
+
+```sh
+nix profile upgrade fantasy-map-generator
+nix profile list                            # find the index or name
+nix profile remove fantasy-map-generator
+```
+
+## Add it to a NixOS system
+
+Add the flake as an input and pull the package into `systemPackages`:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    fantasy-map-generator.url = "github:Azgaar/Fantasy-Map-Generator";
+  };
+
+  outputs = { nixpkgs, fantasy-map-generator, ... }: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        ./configuration.nix
+        {
+          environment.systemPackages = [
+            fantasy-map-generator.packages.x86_64-linux.default
+          ];
+        }
+      ];
+    };
+  };
+}
+```
+
+Home Manager is the same idea with `home.packages` instead of
+`environment.systemPackages`.
+
+The flake pins its own nixpkgs, so the app is built against that rather than
+your system's. That costs a little disk and buys a build that does not break when
+your channel moves.
+
+## Build from a local checkout
+
+```sh
+nix build                          # result/ symlinks the built app
+./result/bin/fantasy-map-generator
+```
+
+`nix develop` is a different thing — a shell with Node and the dev tooling for
+working on the source, not a way to run the packaged app. See
+[Run FMG locally](https://github.com/Azgaar/Fantasy-Map-Generator/wiki/Run-FMG-locally).
+
+## What you get
+
+A wrapper around nixpkgs' `electron_43` running the renderer built from this
+repo. It is the same code as the AppImage, assembled by Nix instead of by
+electron-builder, which means:
+
+- **No self-updating.** The in-app updater is inactive: a Nix store path is
+  read-only, and an app that rewrites itself would defeat the point. Update
+  through Nix, as above.
+- **No bundled Chromium.** Electron comes from `cache.nixos.org` and is shared
+  with every other Electron app on your system, instead of a private copy inside
+  an AppImage.
+- **Your maps are unaffected.** They live in
+  `~/.config/fantasy-map-generator`, outside the store, and survive updates and
+  uninstalls. The AppImage and the Nix build read the same directory, so you can
+  switch between them without losing anything.
+
+## Platform support
+
+Linux only. `x86_64-linux` is what the package is built and tested on;
+`aarch64-linux` is exposed and evaluates, but has not been run.
+
+macOS is deliberately excluded. The package wraps a bare Electron binary, which
+is not a macOS `.app` bundle — the dock, the menu bar and file associations all
+expect one. Use the `.dmg` from the releases page instead. (`nix develop` still
+works on macOS for development.)
+
+## Troubleshooting
+
+**`error: experimental Nix feature 'nix-command' is disabled`** — enable flakes,
+see the top of this page.
+
+**`error: flake 'github:...' does not provide attribute 'packages.x86_64-darwin.default'`**
+— you are on macOS; see Platform support.
+
+**The window is blank, or fails on a Wayland session** — force X11 through
+XWayland:
+
+```sh
+NIXOS_OZONE_WL= fantasy-map-generator
+```
+
+The wrapper enables native Wayland only when `NIXOS_OZONE_WL` is set, so
+clearing it falls back to XWayland.
+
+**Stale build after pulling** — Nix caches by flake revision. Refresh it:
+
+```sh
+nix run --refresh github:Azgaar/Fantasy-Map-Generator
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "Azgaar's Fantasy Map Generator";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      # x86_64-darwin is absent because nixpkgs 26.11 dropped it: naming a system it no
+      # longer supports makes every output for it throw rather than simply not exist
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+
+      # the package wraps a bare Electron, which is not a macOS .app bundle, so it is
+      # offered only where it can run; `nix develop` still works everywhere
+      linuxSystems = nixpkgs.lib.filter (nixpkgs.lib.hasSuffix "-linux") systems;
+      forLinuxSystems = f: nixpkgs.lib.genAttrs linuxSystems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forLinuxSystems (pkgs: {
+        fantasy-map-generator = pkgs.callPackage ./nix/package.nix { };
+        default = self.packages.${pkgs.stdenv.hostPlatform.system}.fantasy-map-generator;
+      });
+
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = [ pkgs.nodejs ];
+        };
+      });
+
+      formatter = forAllSystems (pkgs: pkgs.nixfmt-tree);
+    };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,116 @@
+{
+  lib,
+  buildNpmPackage,
+  copyDesktopItems,
+  electron_43,
+  fetchNpmDeps,
+  jq,
+  makeDesktopItem,
+  makeWrapper,
+  runCommand,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "fantasy-map-generator";
+  version = (lib.importJSON ../package.json).version;
+
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../build
+      ../electron
+      ../package.json
+      ../package-lock.json
+      ../public
+      ../scripts
+      ../src
+      ../tsconfig.json
+      ../vite.config.ts
+    ];
+  };
+
+  # Hashing the lock file as-is would tie this hash to the app version, because
+  # `sync-version.js` rewrites the root version in package-lock.json on every bump —
+  # a pre-commit hook, so it happens constantly. Nothing but the dependency set should
+  # move this hash, so the version is flattened out before it is taken.
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-npm-deps";
+    src = runCommand "${finalAttrs.pname}-package-lock" { nativeBuildInputs = [ jq ]; } ''
+      mkdir -p $out
+      jq '(.version, .packages."".version) |= "0.0.0"' \
+        ${../package-lock.json} > $out/package-lock.json
+    '';
+    hash = "sha256-kLMsfN7M4OqO3asaKh0BKgCIV/07kHZnhz1QYmUCjU0=";
+  };
+
+  # the lock file is hashed with its version flattened, so the copy npm checks must match
+  postPatch = ''
+    ${lib.getExe jq} '(.version, .packages."".version) |= "0.0.0"' package-lock.json > lock.tmp
+    mv lock.tmp package-lock.json
+  '';
+
+  # `prepare` installs git hooks, and electron's postinstall downloads a browser we do not use
+  npmFlags = [ "--ignore-scripts" ];
+  dontNpmBuild = true;
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  # `npm run electron build` typechecks and bundles both processes into dist-electron/,
+  # stopping short of electron-builder, which would fetch prebuilt binaries over the network
+  buildPhase = ''
+    runHook preBuild
+    npm run electron build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fantasy-map-generator
+    cp -r dist-electron $out/share/fantasy-map-generator/
+    cp package.json $out/share/fantasy-map-generator/
+
+    install -Dm644 build/icon.png \
+      $out/share/icons/hicolor/512x512/apps/fantasy-map-generator.png
+
+    makeWrapper ${lib.getExe electron_43} $out/bin/fantasy-map-generator \
+      --add-flags $out/share/fantasy-map-generator \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+      --inherit-argv0
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "fantasy-map-generator";
+      exec = "fantasy-map-generator %U";
+      icon = "fantasy-map-generator";
+      desktopName = "Fantasy Map Generator";
+      genericName = "Fantasy Map Editor";
+      comment = "Generate and edit fantasy maps";
+      categories = [
+        "Graphics"
+        "Education"
+      ];
+      keywords = [
+        "map"
+        "fantasy"
+        "cartography"
+        "worldbuilding"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "Free web application that helps fantasy writers, game masters and cartographers create and edit fantasy maps";
+    homepage = "https://github.com/Azgaar/Fantasy-Map-Generator";
+    license = lib.licenses.mit;
+    mainProgram = "fantasy-map-generator";
+    # the wrapper starts a bare Electron; macOS wants a real .app bundle, so use the dmg release there
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Nix users currently have to run the AppImage. This adds a flake so the desktop app installs like any other package on those systems:

```sh
nix run github:Azgaar/Fantasy-Map-Generator            # run it, install nothing
nix profile install github:Azgaar/Fantasy-Map-Generator
```

The AppImage, deb, nsis and dmg targets are untouched — this is an extra route, not a replacement. It is also a way for Linux users to get the desktop app without a self-updating binary, which some distributions object to on principle.

## What it does

`nix/package.nix` runs `npm run electron build` and wraps nixpkgs' `electron_43` around the resulting `dist-electron/`. Same renderer as the AppImage, assembled by Nix rather than electron-builder.

It works because `scripts/electron.mjs` already separates `build` from `dist`: the Nix build stops at `build` and never invokes electron-builder, which would need network access the build sandbox does not have. `electron_43` matches `package.json`'s `^43.4.1` exactly and comes prebuilt from the public binary cache, so this is a ~4 minute build, not a Chromium compile.

Three details that are load-bearing, and commented in the file so they are not undone by accident:

- Install scripts are skipped. `simple-git-hooks`' `prepare` has no `.git` to write to in the sandbox, `electron`'s postinstall would download a Chromium the package does not use, and `electron-winstaller` is Windows-only.
- `npmDepsHash` is taken over the lock file **with its root version flattened to `0.0.0`**, and `postPatch` flattens the copy npm validates against to match. `sync-version.js` rewrites that version on every bump, so hashing the file as-is would break the build on every release rather than only when a dependency actually changes. `package.json` is left alone, so the app still reports its own version.
- Packages are exposed on Linux only. The wrapper starts a bare Electron, which is not a macOS `.app` bundle — the dock, menu bar and file associations all expect one, so the dmg stays the answer there. `nix develop` still works on every system.

## The CI job

`nix-build.yml` builds the flake on PRs that touch the flake, the package files or the desktop sources, and checks the built app is complete — binary, `main.js`, `preload.js`, `icon.png`, `renderer/index.html`, and the shipped version matching the repo's — rather than only that the derivation succeeded. It takes about a minute.

It is there because nothing else builds the flake, and a Nix package that silently stops building is worse than none. If you would rather not spend CI minutes on it, deleting that one file leaves everything else working; the tradeoff is that breakage would then surface as a user report instead.

## Verification

Built and **run** against this branch, not just compiled. Launched headless under Xvfb and inspected over the DevTools protocol: `app://fmg/index.html` loads through the custom scheme from a read-only store path, the preload bridge is live, and it generates a full map (13,062 cells, 1,610 burgs, 18 states, 1,922 rendered SVG paths). `nix flake check --all-systems` passes.

`docs/nix.md` covers running, installing, NixOS and Home Manager, the Wayland fallback, and what the package deliberately does not do — the in-app updater stays inactive, since a Nix store path is read-only and updates come through Nix instead. Maps are unaffected either way: they live in `~/.config/fantasy-map-generator`, outside the store, so users can move between the AppImage and this build without losing anything.

Stated plainly in the doc: only `x86_64-linux` is built and tested. `aarch64-linux` is exposed and evaluates, but I have not run it.

Happy to drop the CI job, the docs, or the README section if you would prefer a smaller footprint.