### PR TITLE
Give the desktop app a Quit on Linux and Windows

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -181,7 +181,11 @@ function buildMenu(): void {
   const isMac = process.platform === "darwin";
 
   const template: MenuItemConstructorOptions[] = [
-    ...(isMac ? ([{ role: "appMenu" }] satisfies MenuItemConstructorOptions[]) : []),
+    ...(isMac
+      ? ([{ role: "appMenu" }] satisfies MenuItemConstructorOptions[])
+      : // the app menu carries Quit on macOS; elsewhere there is otherwise no way to leave the app
+        // from the UI at all, which a window manager that draws no titlebar leaves with none
+        ([{ label: "File", submenu: [{ role: "quit" }] }] satisfies MenuItemConstructorOptions[])),
     { role: "editMenu" },
     {
       label: "View",


### PR DESCRIPTION
On macOS `role: "appMenu"` carries Quit. Everywhere else the menu is Edit, View, Window and Help — none of which can leave the app. Combined with `autoHideMenuBar` and a window manager that draws no titlebar, there is no way out of the app from its own UI at all.

Reported from real use on a tiling compositor (niri): no titlebar, no close button, and nothing in the menu to quit with. The only exit was the compositor's own kill binding.

A File menu now carries the role on non-mac, which also registers the usual accelerator so Ctrl+Q works.

Verified by reading the menu back out of a built app:

```
[{ "label": "File", "items": ["Quit"] }, { "label": "Edit", ... }, ...]
```

One line of judgement worth flagging: I put Quit alone under File rather than adding Save or Open alongside it, since those already live in the app's own UI and duplicating them into the native menu would be a bigger decision than this fix needs.

Companion to #1654, which fixes the confirmation dialog stacking on itself. They are independent — either can be taken without the other.