### PR TITLE
Ask once when closing the desktop app, not once per event

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -225,10 +225,16 @@ function allowClose(): void {
  * silently instead of prompting, which would make the window unclosable. Ask natively instead
  */
 function confirmOnClose(window: BrowserWindow): void {
+  let confirming = false;
+
   window.on("close", event => {
     saveState(window);
     if (skipConfirmation) return;
     event.preventDefault();
+    // Cmd+Q reaches the window through before-quit as well as the close itself, and a window
+    // manager binding can deliver it more than once; without this the dialog stacks on itself
+    if (confirming) return;
+    confirming = true;
 
     dialog
       .showMessageBox(window, {
@@ -241,6 +247,7 @@ function confirmOnClose(window: BrowserWindow): void {
         detail: "The map is autosaved to the app storage, but save it to a file to be safe"
       })
       .then(({ response }) => {
+        confirming = false;
         if (response !== 0) {
           quitting = false;
           return;


### PR DESCRIPTION
`confirmOnClose` prevents the default and opens a confirmation, but nothing stops it running again while that dialog is already up. Cmd+Q reaches the window through `before-quit` as well as through the close itself, and a window manager binding can deliver it more than once, so each delivery stacked another identical dialog on top of the last.

Reported from real use: quitting with a compositor keybinding produced the dialog drawn on itself, and dismissing one revealed the next.

A `confirming` flag closes it, cleared when the dialog resolves so a cancelled quit still asks again next time.

## Also worth knowing

The same handler blocks automated teardown. `app.close()` from Playwright triggers the confirmation and then waits on a dialog no test can answer — a cold-start measurement here took 52s instead of 1.1s before I noticed. That is properly the test harness's problem and is fixed there by calling `app.exit()` instead, so nothing in this PR addresses it. Flagging it only because anyone writing Electron tests against this app will hit it and the symptom looks nothing like the cause.

Companion to #1653, which adds a Quit to the menu on Linux and Windows. They are independent — either can be taken without the other.