### PR TITLE
Fix the layers URL param test, which has failed on every PR since 86b74fd8

### DIFF
--- a/tests/e2e/layer-scenarios.spec.ts
+++ b/tests/e2e/layer-scenarios.spec.ts
@@ -327,7 +327,8 @@ test.describe("layer scenarios", () => {
     expect(errors).toEqual([]);
   });
 
-  test("layers wins over preset, ignores unknown ids and clears the set when none are known", async ({ page }) => {
+  test("layers wins over preset, ignores unknown ids and keeps the map when none are known", async ({ page }) => {
+    const errors = watchErrors(page);
     await page.goto(
       "/?seed=url-layers-override&width=1280&height=720&preset=religions&layers=provinces,nope,borders"
     );
@@ -336,11 +337,15 @@ test.describe("layer scenarios", () => {
     await expect(page.locator("#layersPreset")).toHaveValue("custom");
     const active = await page.evaluate(() => Layers.state.active.slice().sort());
     expect(active).toEqual(["borders", "provinces"]);
+    expect(errors).toEqual([]);
 
+    // a layers param naming nothing the app knows is unusable, not an instruction to show
+    // nothing: it leaves the map as it is and says so, rather than blanking it
     await page.evaluate(() => {
       const params = new URLSearchParams({ layers: "nope,missing" });
       (window as any).applyURLLayers(params);
     });
-    expect(await page.evaluate(() => Layers.state.active)).toEqual([]);
+    expect(await page.evaluate(() => Layers.state.active.slice().sort())).toEqual(["borders", "provinces"]);
+    await expect.poll(() => errors.join("\n")).toContain('layers="nope,missing"');
   });
 });


### PR DESCRIPTION
`layer-scenarios.spec.ts` has failed on every pull request for a while — I hit it on #1652, and it also fails on `regiments-fix` and `refactor/dialogs`, so it is not any one branch's doing.

## What happened

`86b74fd8` ("fix: url param error handling") stopped an all-invalid `layers=` from calling `Layers.set([])`:

```ts
if (ids.length) {
  Layers.set(ids);
} else {
  ERROR && console.error(`URL param layers="${layersParam}" has no valid layer ids`);
}
```

The test still asserted the old behaviour — its name ends "and clears the set when none are known" — so `expect(...).toEqual([])` now receives `["provinces", "borders"]`.

## Which side I changed, and why

The code. A `layers=` param naming nothing the app recognises is an unusable param, not an instruction to display nothing: a typo in a shared link, or ids from an older version, should not hand someone a blank map. That reads as the intent of the commit rather than an oversight, so the test follows the code.

The first two thirds of the test are untouched and still pass — layers still wins over preset, and unknown ids mixed with known ones are still ignored. Only the all-invalid case changed, plus the name.

I also added an assertion that the reason is actually reported. Ignoring the param silently would be its own bug, and nothing covered that.

## Verification

Run against the system chromium, since the bundled headless shell will not start on this machine:

- stock `1.150.0`: fails, `expect(received).toEqual(expected)`, received `["provinces", "borders"]` — the CI failure reproduced exactly
- with this change: passes
- whole file: 23 passed

Happy to invert this if the old behaviour was the intended one after all — in that case the fix belongs in `applyURLLayers` instead, moving `Layers.set([])` into the `else` alongside the log, and I will send that instead.