### PR TITLE
fix: align unknown layers URL e2e with error handling (#1650)

### DIFF
--- a/tests/e2e/layer-scenarios.spec.ts
+++ b/tests/e2e/layer-scenarios.spec.ts
@@ -327,7 +327,7 @@ test.describe("layer scenarios", () => {
     expect(errors).toEqual([]);
   });
 
-  test("layers wins over preset, ignores unknown ids and clears the set when none are known", async ({ page }) => {
+  test("layers wins over preset, ignores unknown ids and leaves the set when none are known", async ({ page }) => {
     await page.goto(
       "/?seed=url-layers-override&width=1280&height=720&preset=religions&layers=provinces,nope,borders"
     );
@@ -337,10 +337,18 @@ test.describe("layer scenarios", () => {
     const active = await page.evaluate(() => Layers.state.active.slice().sort());
     expect(active).toEqual(["borders", "provinces"]);
 
+    // a typo-only layers= must not wipe the map; it logs and keeps the current set
+    const invalidLayersErrors: string[] = [];
+    page.on("console", msg => {
+      if (msg.type() === "error") invalidLayersErrors.push(msg.text());
+    });
+
     await page.evaluate(() => {
       const params = new URLSearchParams({ layers: "nope,missing" });
       (window as any).applyURLLayers(params);
     });
-    expect(await page.evaluate(() => Layers.state.active)).toEqual([]);
+
+    expect(await page.evaluate(() => Layers.state.active.slice().sort())).toEqual(["borders", "provinces"]);
+    expect(invalidLayersErrors.some(text => text.includes("no valid layer ids"))).toBe(true);
   });
 });


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change, motivation and context. It it's a but fix, add a reference in format #issue_number -->

Fixes #1650.

After `86b74fd8`, a `?layers=` value with no valid ids leaves the current layers alone and logs an error. The e2e still expected the set to be cleared.

Updated the spec to match.

## Test

- [x] `npx playwright test tests/e2e/layer-scenarios.spec.ts -g "layers wins over preset"`