### PR TITLE
Old maps keep their styling across a save and reload

### DIFF
--- a/src/generators/styles-legacy.dom.test.ts
+++ b/src/generators/styles-legacy.dom.test.ts
@@ -291,3 +291,10 @@ test("harvesting an old map does not emit values the schema rejects", () => {
   expect(warn).not.toHaveBeenCalled();
   warn.mockRestore();
 });
+
+test("an attr the layer registry declares survives a map that predates it", () => {
+  // #fogging in old maps carries no mask; the registry stamps it after the harvest runs
+  document.body.innerHTML = `<svg id="map"><g id="fogging" opacity="0.98"></g></svg>`;
+  syncStylesFromMap({ hasStyleRecord: true });
+  expect(styles.fogging.attrs.mask).toBe(DEFAULT_STYLES.fogging.attrs.mask);
+});

--- a/src/generators/styles-legacy.dom.test.ts
+++ b/src/generators/styles-legacy.dom.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { harvestAttributes, stylesFromMap, syncStylesFromMap } from "./styles-legacy";
 import { DEFAULT_STYLES } from "./styles-schema";
 
@@ -274,4 +274,20 @@ test("save sync lets an old map's coordinates data-size win over the store", () 
   styles.coordinates.options.fontSize = 20;
   syncStylesFromMap();
   expect(styles.coordinates.options.fontSize).toBe(14);
+});
+
+test("an old map omitting a non-nullable attr keeps the values it does carry", () => {
+  // #provs in pre-1.148 maps carries opacity alone
+  document.body.innerHTML = `<svg id="map"><g id="provs" opacity="0.6"></g></svg>`;
+  const result = stylesFromMap(document);
+  expect(result.provinces.attrs.opacity).toBe(0.6);
+  expect(result.provinces.attrs["font-family"]).toBe(DEFAULT_STYLES.provinces.attrs["font-family"]);
+});
+
+test("harvesting an old map does not emit values the schema rejects", () => {
+  document.body.innerHTML = `<svg id="map"><g id="provs" opacity="0.6"></g></svg>`;
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  stylesFromMap(document);
+  expect(warn).not.toHaveBeenCalled();
+  warn.mockRestore();
 });

--- a/src/generators/styles-legacy.dom.test.ts
+++ b/src/generators/styles-legacy.dom.test.ts
@@ -298,3 +298,12 @@ test("an attr the layer registry declares survives a map that predates it", () =
   syncStylesFromMap({ hasStyleRecord: true });
   expect(styles.fogging.attrs.mask).toBe(DEFAULT_STYLES.fogging.attrs.mask);
 });
+
+test("a child group the map predates leaves its parent's styling in place", () => {
+  // pre-1.143 maps have no #sea_island: the layer group itself is styled
+  document.body.innerHTML = `<svg id="map"><g id="coastline" opacity="0.5" stroke-width="0.7"></g></svg>`;
+  const result = stylesFromMap(document);
+  expect(DEFAULT_STYLES.coastline.sea_island.attrs["stroke-width"]).not.toBeNull();
+  expect(result.coastline.sea_island.attrs["stroke-width"]).toBeNull();
+  expect(result.coastline.sea_island.attrs.opacity).toBeNull();
+});

--- a/src/generators/styles-legacy.ts
+++ b/src/generators/styles-legacy.ts
@@ -346,6 +346,13 @@ export function harvestAttributes(): Record<string, string[]> {
   return table;
 }
 
+// the group a child route hangs off: #sea_island's is #coastline, #landHeights' is #terrs
+function layerElementFor(route: PresetRoute, root: ParentNode): Element | null {
+  if (route.path.length < 2) return null;
+  const layer = Layers.all.find(({ id }) => id === route.path[0]);
+  return layer ? root.querySelector(`#${layer.elementId}`) : null;
+}
+
 function harvestValue(value: string): string | number {
   if (value === "") return "";
   const n = Number(value);
@@ -379,10 +386,19 @@ export function stylesFromMap(root: ParentNode = document): Styles {
   const bags: Record<string, Record<string, unknown>> = {};
 
   for (const [selector, attrs] of Object.entries(harvestAttributes())) {
-    const el = root.querySelector(selector);
-    if (!el) continue;
     const route = PRESET_ROUTES[selector];
     const nullable = route.ownAttrs === false ? [] : nullableAttrsAt(route.path);
+    const el = root.querySelector(selector);
+
+    if (!el) {
+      // a map predating the child groups styles the layer group itself; leaving the child at its
+      // default would stamp it over the parent, so record the parent's attrs as "not set" here
+      const parent = layerElementFor(route, root);
+      const inherited = parent ? nullable.filter(attr => parent.hasAttribute(attr)) : [];
+      if (inherited.length) bags[selector] = Object.fromEntries(inherited.map(attr => [attr, null]));
+      continue;
+    }
+
     bags[selector] = harvestBag(el, attrs, nullable);
   }
   for (const el of root.querySelectorAll("#labels > *")) {

--- a/src/generators/styles-legacy.ts
+++ b/src/generators/styles-legacy.ts
@@ -4,7 +4,7 @@
 
 import "./styles";
 import type { Styles } from "./styles-schema";
-import { DEFAULT_STYLES } from "./styles-schema";
+import { DEFAULT_STYLES, nullableAttrsAt } from "./styles-schema";
 
 type LabelGroupStyle = Styles["labels"]["groups"][string];
 
@@ -351,19 +351,20 @@ function harvestValue(value: string): string | number {
   return Number.isNaN(n) ? value : n;
 }
 
-// a schema attr the element does not carry becomes an explicit null, so a preset-nulled
-// attr round-trips as null instead of the seeded default; options keep omit-means-default
+// a nullable schema attr the element does not carry becomes an explicit null, so a preset-nulled
+// attr round-trips as null instead of the seeded default; a non-nullable one is omitted, keeping
+// the default the schema demands. Options keep omit-means-default either way
 function harvestBag(
   el: Element,
   attrs: string[],
-  schemaAttrs: string[] = attrs
+  nullableAttrs: string[] = attrs
 ): Record<string, string | number | null> {
   const bag: Record<string, string | number | null> = {};
   for (const attr of attrs) {
     const inline = (el as HTMLElement).style?.[attr as any];
     const value = inline ? inline : el.getAttribute(attr);
     if (value !== null && value !== undefined) bag[attr] = harvestValue(value);
-    else if (schemaAttrs.includes(attr)) bag[attr] = null;
+    else if (nullableAttrs.includes(attr)) bag[attr] = null;
   }
   return bag;
 }
@@ -380,8 +381,8 @@ export function stylesFromMap(root: ParentNode = document): Styles {
     const el = root.querySelector(selector);
     if (!el) continue;
     const route = PRESET_ROUTES[selector];
-    const schemaAttrs = route.ownAttrs === false ? [] : attrKeysAt(route.path);
-    bags[selector] = harvestBag(el, attrs, schemaAttrs);
+    const nullable = route.ownAttrs === false ? [] : nullableAttrsAt(route.path);
+    bags[selector] = harvestBag(el, attrs, nullable);
   }
   for (const el of root.querySelectorAll("#labels > *")) {
     const name = (el as HTMLElement).dataset.group || el.id.replace(/^labels-/, "");

--- a/src/generators/styles-legacy.ts
+++ b/src/generators/styles-legacy.ts
@@ -2,6 +2,7 @@
 // edges use this: map-file save/load and legacy preset routing. Dies when those write the new
 // format natively.
 
+import { Layers } from "@/components/layers";
 import "./styles";
 import type { Styles } from "./styles-schema";
 import { DEFAULT_STYLES, nullableAttrsAt } from "./styles-schema";
@@ -468,6 +469,17 @@ export function syncStylesFromMap({ hasStyleRecord = false } = {}): void {
     harvested.scaleBar.options = structuredClone(styles.scaleBar.options);
   if (!document.getElementById("scaleBarBack")?.hasAttribute("data-top"))
     harvested.scaleBar.back.options = structuredClone(styles.scaleBar.back.options);
+  // the layer registry stamps its declared attrs after this runs, so a map predating one
+  // harvests it as null; the store keeps the attr until the element itself carries it
+  for (const layer of Layers.all) {
+    const node = (harvested as Record<string, any>)[layer.id]?.attrs;
+    const stored = (styles as Record<string, any>)[layer.id]?.attrs;
+    if (!node || !stored) continue;
+    const el = document.getElementById(layer.elementId);
+    for (const attr of Object.keys(layer.params.attrs ?? {})) {
+      if (attr in node && !el?.hasAttribute(attr)) node[attr] = stored[attr];
+    }
+  }
   Styles.set(harvested);
 }
 

--- a/src/generators/styles-schema.ts
+++ b/src/generators/styles-schema.ts
@@ -246,3 +246,12 @@ export type StyleLayerId = keyof Styles & (LayerId | "map");
 
 // default-styles.json is the single source of style defaults, validated strictly at boot
 export const DEFAULT_STYLES: Styles = stylesSchema.parse(defaultStyles);
+
+// the attrs at a store path that accept null, i.e. may be harvested as "attribute not set"
+export function nullableAttrsAt(path: string[]): string[] {
+  let node: any = stylesSchema;
+  for (const key of [...path, "attrs"]) node = node?.shape?.[key];
+  const shape = node?.shape;
+  if (!shape) return [];
+  return Object.keys(shape).filter(attr => shape[attr].safeParse(null).success);
+}

--- a/src/generators/styles.test.ts
+++ b/src/generators/styles.test.ts
@@ -60,3 +60,19 @@ describe("schema reconciliation", () => {
     expect(DEFAULT_STYLES.labels.attrs["font-size"]).toBe("100px");
   });
 });
+
+describe("per-attribute repair", () => {
+  test("an invalid attribute falls back alone, not with its whole layer", () => {
+    const doc = structuredClone(DEFAULT_STYLES) as any;
+    doc.provinces.attrs.opacity = 0.6;
+    doc.provinces.attrs["font-family"] = null; // non-nullable in the schema
+    const parsed = Styles.parse(doc);
+    expect(parsed.provinces.attrs.opacity).toBe(0.6);
+    expect(parsed.provinces.attrs["font-family"]).toBe(DEFAULT_STYLES.provinces.attrs["font-family"]);
+  });
+
+  test("a layer that cannot be repaired still falls back whole", () => {
+    const parsed = Styles.parse({ ...DEFAULT_STYLES, provinces: "not a layer" });
+    expect(parsed.provinces).toEqual(DEFAULT_STYLES.provinces);
+  });
+});

--- a/src/generators/styles.ts
+++ b/src/generators/styles.ts
@@ -1,3 +1,4 @@
+import type { z } from "zod";
 import { type LayerId, Layers } from "@/components/layers";
 import { DEFAULT_STYLES, type StyleLayerId, type Styles as StylesData, stylesSchema } from "./styles-schema";
 
@@ -11,13 +12,48 @@ function parse(json: unknown): StylesData {
   const result = {} as Record<string, unknown>;
   for (const [layer, schema] of Object.entries(stylesSchema.shape)) {
     const parsed = schema.safeParse(input[layer]);
-    if (parsed.success) result[layer] = parsed.data;
-    else {
+    if (parsed.success) {
+      result[layer] = parsed.data;
+      continue;
+    }
+
+    const fallback = structuredClone(DEFAULT_STYLES[layer as keyof StylesData]);
+    const repaired = replaceInvalidValues(input[layer], fallback, parsed.error);
+    const reparsed = repaired === undefined ? undefined : schema.safeParse(repaired);
+
+    if (reparsed?.success) {
+      console.warn(`Styles.parse: invalid "${layer}" values replaced with defaults`);
+      result[layer] = reparsed.data;
+    } else {
       console.warn(`Styles.parse: invalid or missing "${layer}", default used`);
-      result[layer] = structuredClone(DEFAULT_STYLES[layer as keyof StylesData]);
+      result[layer] = fallback;
     }
   }
   return result as StylesData;
+}
+
+// replaces the failing values alone, so one bad attribute does not cost the layer around it;
+// undefined when that cannot be done, leaving the caller its whole-layer fallback
+function replaceInvalidValues(input: unknown, fallback: unknown, error: z.ZodError): unknown {
+  if (typeof input !== "object" || input === null) return undefined;
+
+  const repaired = structuredClone(input) as Record<PropertyKey, any>;
+  for (const { path } of error.issues) {
+    if (!path.length) return undefined;
+
+    let target: any = repaired;
+    let source: any = fallback;
+    for (const key of path.slice(0, -1)) {
+      target = target?.[key];
+      source = source?.[key];
+    }
+
+    const key = path[path.length - 1];
+    if (target === undefined || target === null || source === undefined || source === null) return undefined;
+    if (!(key in source)) return undefined;
+    target[key] = structuredClone(source[key]);
+  }
+  return repaired;
 }
 
 function set(data: StylesData): void {


### PR DESCRIPTION
Loading a pre-1.148 map, saving it and loading it again currently loses styling the map carried. Three causes, one commit each.

### An old map missing one attribute loses the layer around it

`stylesFromMap` writes an explicit `null` for every schema attr the element does not carry. `font-family` (provinces, legend) and `font-size` (temperature) are not nullable, so `Styles.parse` rejects the layer and falls back to the whole default — taking the map's own colors, widths and opacities with it. The first save persists those defaults and the next load applies them.

`tests/fixtures/1.143.1.map` carries `<g id="provs" opacity="0.6"/>` and lost that 0.6 to the default 0.7.

The harvest now omits a non-nullable attr rather than nulling it, so the seeded default stands, and `Styles.parse` replaces only the values that fail rather than the layer around them. Nullability is read off the schema, so it stays right as attrs are added.

### A registry-declared attr the map predates

`syncStylesFromMap` runs before `Layers.restore` stamps the attrs the registry declares, so a map saved before one existed harvests it as `null`. `#fogging` is the live case: pre-1.143 maps carry no mask, the store recorded null, and the next load stripped `mask="url(#fog)"` — fogging then covers the whole map instead of the fogged cells.

The store keeps its own value for a declared attr until the element carries one, matching how the surrounding guards treat `rescale`, `data-width` and the rest.

### A child group the map predates

Maps older than the child groups style the layer group itself: 1.143.1 has `#coastline` with opacity, stroke-width and a filter, and no `#sea_island` at all. The harvest skipped the missing child and left the schema default in the store, which the next load stamped onto the child the registry had since created — 0.5 over the map's 0.7, and the group's opacity applied a second time.

An absent child now records the attrs its parent carries as "not set", so the parent goes on styling the layer as it did before the store existed. Layers the map simply predates (a new `#goods`, `#journeys`) still take their defaults, and a child carrying its own attrs is untouched — parent-level styling is the normal shape for routes, borders and population, not only a legacy one.

### Verification

Six tests added, each watched failing first. `tsc` clean, `biome check` clean, 533 unit + 40 browser passing, build green; each commit is green on its own.

Checked by loading each map, saving through `Save.prepareMapData` and loading the result back, then diffing every layer and child group attribute:

| map | before | after |
|---|---|---|
| `1.112.1` | `#fogging` loses its mask | no change |
| `1.139.4` | `#fogging` loses its mask | no change |
| `1.143.1` | `#provs` 0.6 → 0.7, coastline child overrides the parent | no change |
| a 1.149.2 map with modern child groups | no change | no change |

1.149.2 round-trips all three fixtures unchanged, so these are migration regressions rather than long-standing behaviour.

One caveat: the third fix is validated against the three fixtures plus one modern map, and old map shapes vary more than that. The rule is deliberately narrow — it only fires when a child element is missing entirely — but a wider corpus of pre-1.143 maps would be better proof.