### PR TITLE
fix: stamp brushes by distance travelled, not per pointer event

### DIFF
--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -14,6 +14,10 @@ Current version of the Fantasy Map Generator is the latest `master` branch. You 
 
 # Releases
 
+**1.151.1 - 2026-09-03**:
+
+- Brushes stamp by distance travelled: smooth, gap-free painting at any refresh rate by _[barrulus](https://github.com/barrulus)_ [1.151.1]
+
 **[1.150.0](https://github.com/Azgaar/Fantasy-Map-Generator/archive/refs/tags/v1.150.0.zip) - 2026-09-05**:
 
 - Journey Editor and new Journeys layer [1.150.0]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fantasy-map-generator",
-  "version": "1.150.0",
+  "version": "1.151.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fantasy-map-generator",
-      "version": "1.150.0",
+      "version": "1.151.1",
       "license": "MIT",
       "dependencies": {
         "alea": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fantasy-map-generator",
   "productName": "Fantasy Map Generator",
-  "version": "1.150.0",
+  "version": "1.151.1",
   "description": "Azgaar's _Fantasy Map Generator_ is a free web application that helps fantasy writers, game masters, and cartographers create and edit fantasy maps.",
   "homepage": "https://github.com/Azgaar/Fantasy-Map-Generator#readme",
   "bugs": {

--- a/src/controllers/heightmap-editor.ts
+++ b/src/controllers/heightmap-editor.ts
@@ -1268,9 +1268,8 @@ function dragBrush(this: SVGElement, event: any): void {
     if (selection?.length) changeHeightForSelection(selection, start);
   };
 
-  // stamps follow the distance travelled, so the stroke does not depend on the pointer event rate
   const stroke = createBrushStroke(r / 2, applyAt);
-  stroke.moveTo(startX, startY); // stamps once on start, so a plain click changes height
+  stroke.moveTo(startX, startY); // so a plain click changes height
 
   event.on("drag", (dragEvent: any) => {
     const [x, y] = getPointer(dragEvent, this);

--- a/src/controllers/heightmap-editor.ts
+++ b/src/controllers/heightmap-editor.ts
@@ -12,6 +12,7 @@ import { removeEmblem } from "@/renderers/draw-emblems";
 import { moveCircle, removeCircle } from "@/renderers/overlays/brush-circle";
 import { downloadFile, getFileName, uploadFile } from "@/utils";
 import { ensureEl, findEl, generateSeed, getPointer, last, lim, link, minmax, rn, unique } from "../utils";
+import { createBrushStroke } from "../utils/brushUtils";
 import type { PromptOptions } from "../utils/commonUtils";
 
 // Legacy app prompt shadows the DOM built-in (same pattern as burg-editor / route-groups-editor). TODO: replace with dialog
@@ -1255,11 +1256,8 @@ function dragBrush(this: SVGElement, event: any): void {
   const [startX, startY] = getPointer(event, this);
   const start = Grid.findCell(startX, startY); // fixed once per drag: Align replicates this cell's height
 
-  const applyBrush = (pointerEvent: any) => {
-    const p = getPointer(pointerEvent, this);
-    moveCircle(p[0], p[1], r);
-
-    const inRadius = Grid.findAll(p[0], p[1], r);
+  const applyAt = (x: number, y: number) => {
+    const inRadius = Grid.findAll(x, y, r);
     let selection = inRadius;
     const cellTypeFilter = ensureEl<HTMLSelectElement>("cellTypeFilter").value;
     if (cellTypeFilter === "land") {
@@ -1270,8 +1268,15 @@ function dragBrush(this: SVGElement, event: any): void {
     if (selection?.length) changeHeightForSelection(selection, start);
   };
 
-  applyBrush(event); // apply once on start so a plain click changes height
-  event.on("drag", applyBrush);
+  // stamps follow the distance travelled, so the stroke does not depend on the pointer event rate
+  const stroke = createBrushStroke(r / 2, applyAt);
+  stroke.moveTo(startX, startY); // stamps once on start, so a plain click changes height
+
+  event.on("drag", (dragEvent: any) => {
+    const [x, y] = getPointer(dragEvent, this);
+    moveCircle(x, y, r);
+    stroke.moveTo(x, y);
+  });
   event.on("end", updateHeightmap);
 }
 

--- a/src/controllers/paint-editor.test.ts
+++ b/src/controllers/paint-editor.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PaintEditorOptions } from "./paint-editor";
 import { PaintEditor } from "./paint-editor";
 import "@/generators/pack-generator"; // registers the Pack global the editor finds cells with
@@ -86,6 +86,10 @@ beforeEach(() => {
   $(parentDialog).dialog({ close: () => parentDialog.remove() });
 });
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("PaintEditor", () => {
   it("reopens its destroyed parent through the close callback", () => {
     const onClose = vi.fn(() => {
@@ -166,6 +170,31 @@ describe("PaintEditor", () => {
     expect([...changes]).toEqual([[3, 1]]);
     expect(calls).toEqual(["apply", "close"]);
     expect(globalThis.customization).toBe(0);
+  });
+
+  it("paints the whole path of a fast swipe, not only where the pointer events landed", async () => {
+    vi.spyOn(Pack, "findAll").mockImplementation(x => [Math.floor(x / 10)]); // one cell per 10px column
+    pack.cells.h = new Uint8Array(7).fill(30);
+    pack.cells.v = Array.from({ length: 7 }, () => [0, 1, 2]);
+    pack.cells.p = Array.from({ length: 7 }, () => [2, 2]);
+    const onApply = vi.fn();
+    PaintEditor.open(getOptions({ onApply })); // default radius 12: stamps every 6px
+
+    const viewbox = document.getElementById("viewbox")!;
+    const eventView = document.defaultView!;
+    const mouseEvent = (type: string, init: MouseEventInit) => {
+      const event = new eventView.MouseEvent(type, init);
+      Object.defineProperty(event, "view", { value: eventView });
+      return event;
+    };
+    viewbox.dispatchEvent(mouseEvent("mousedown", { bubbles: true, button: 0, clientX: 1, clientY: 1 }));
+    eventView.dispatchEvent(mouseEvent("mousemove", { bubbles: true, buttons: 1, clientX: 61, clientY: 1 })); // one event
+    eventView.dispatchEvent(mouseEvent("mouseup", { bubbles: true, button: 0, clientX: 61, clientY: 1 }));
+    await new Promise(resolve => setTimeout(resolve, 0));
+    document.getElementById("paintEditorApply")?.click();
+
+    const changes = onApply.mock.calls[0][0] as ReadonlyMap<number, number>;
+    expect([...changes.keys()].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5, 6]);
   });
 
   it("owns stroke history", async () => {

--- a/src/controllers/paint-editor.ts
+++ b/src/controllers/paint-editor.ts
@@ -13,6 +13,7 @@ import {
   updatePaintOverlay
 } from "@/renderers/overlays/paint-overlay";
 import { ensureEl, getPointer } from "@/utils";
+import { createBrushStroke } from "@/utils/brushUtils";
 
 export interface PaintEditorItem {
   id: number;
@@ -188,12 +189,7 @@ function handleDragStart(this: SVGElement, event: D3DragEvent<SVGElement, unknow
   const historyEntry: PaintHistoryEntry = new Map();
   let recorded = false;
 
-  event.on("drag", (dragEvent: D3DragEvent<SVGElement, unknown, unknown>) => {
-    if (!dragEvent.dx && !dragEvent.dy) return;
-
-    const [x, y] = getPointer(dragEvent, this);
-    moveCircle(x, y, radius);
-
+  const stroke = createBrushStroke(radius / 2, (x, y) => {
     const found = radius > 5 ? Pack.findAll(x, y, radius) : [Pack.findCell(x, y)];
     const cells = found.filter((cell): cell is number => cell !== undefined);
     const selectedId = getState().selectedId;
@@ -201,6 +197,22 @@ function handleDragStart(this: SVGElement, event: D3DragEvent<SVGElement, unknow
 
     recordHistory(historyEntry);
     recorded = true;
+  });
+  const [startX, startY] = getPointer(event, this);
+  let started = false;
+
+  event.on("drag", (dragEvent: D3DragEvent<SVGElement, unknown, unknown>) => {
+    if (!dragEvent.dx && !dragEvent.dy) return;
+
+    const [x, y] = getPointer(dragEvent, this);
+    moveCircle(x, y, radius);
+
+    // a plain click selects (see handleMapClick): the stroke starts where the pointer went down, on the first move
+    if (!started) {
+      started = true;
+      stroke.moveTo(startX, startY);
+    }
+    stroke.moveTo(x, y);
   });
 }
 

--- a/src/controllers/paint-editor.ts
+++ b/src/controllers/paint-editor.ts
@@ -207,7 +207,7 @@ function handleDragStart(this: SVGElement, event: D3DragEvent<SVGElement, unknow
     const [x, y] = getPointer(dragEvent, this);
     moveCircle(x, y, radius);
 
-    // a plain click selects (see handleMapClick): the stroke starts where the pointer went down, on the first move
+    // start only on real movement: a plain click selects instead (handleMapClick)
     if (!started) {
       started = true;
       stroke.moveTo(startX, startY);

--- a/src/controllers/relief-editor.test.ts
+++ b/src/controllers/relief-editor.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ReliefEditor } from "./relief-editor";
+import "@/generators/pack-generator"; // registers the Pack global the editor finds cells with
+
+vi.mock("@/components/viewbox-events", () => ({ applyDefaultViewboxEvents: vi.fn() }));
+vi.mock("@/components/layers", () => ({ Layers: { show: vi.fn(), draw: vi.fn() } }));
+vi.mock("@/renderers/draw-relief-icons", () => ({ redrawRelief: vi.fn(), getSceneReliefIcon: vi.fn() }));
+vi.mock("@/components/dialog/dialog-helpers", async importOriginal => ({
+  ...(await importOriginal<typeof import("@/components/dialog/dialog-helpers")>()),
+  closeDialogs: vi.fn()
+}));
+
+/** One fast swipe along y=50: mousedown at x0, a single mousemove to x1, mouseup */
+async function swipe(x0: number, x1: number): Promise<void> {
+  const viewbox = document.getElementById("viewbox")!;
+  const eventView = document.defaultView!;
+  const mouseEvent = (type: string, init: MouseEventInit) => {
+    const event = new eventView.MouseEvent(type, init);
+    Object.defineProperty(event, "view", { value: eventView });
+    return event;
+  };
+  viewbox.dispatchEvent(mouseEvent("mousedown", { bubbles: true, button: 0, clientX: x0, clientY: 50 }));
+  eventView.dispatchEvent(mouseEvent("mousemove", { bubbles: true, buttons: 1, clientX: x1, clientY: 50 }));
+  eventView.dispatchEvent(mouseEvent("mouseup", { bubbles: true, button: 0, clientX: x1, clientY: 50 }));
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+function openBulkMode(button: "reliefBulkAdd" | "reliefBulkRemove"): string {
+  ReliefEditor.open(document.querySelector("#terrain")!);
+  document.getElementById(button)!.click();
+  const icon = document.querySelector<SVGElement>("#reliefIconsDiv svg[data-type]")!;
+  icon.classList.add("pressed");
+  (document.getElementById("reliefRadiusNumber") as HTMLInputElement).value = "10";
+  (document.getElementById("reliefSpacingNumber") as HTMLInputElement).value = "2";
+  return icon.dataset.type!;
+}
+
+beforeEach(() => {
+  document.body.innerHTML =
+    '<div id="dialogs"></div><div id="tooltip"></div><svg id="map"><g id="viewbox"><g id="terrain"></g></g><g id="debug"></g></svg>';
+  globalThis.customization = 0;
+  vi.spyOn(Pack, "findCell").mockReturnValue(0);
+  globalThis.pack = { cells: { h: new Uint8Array([30]) }, relief: [] } as unknown as typeof pack;
+  window.$ = vi.fn(() => ({ dialog: vi.fn() })) as unknown as typeof window.$;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ReliefEditor bulk brushes", () => {
+  it("places icons along the whole path of a fast swipe, not only where the pointer events landed", async () => {
+    openBulkMode("reliefBulkAdd");
+
+    await swipe(0, 400);
+
+    const centers = pack.relief.map(icon => icon.x + icon.s / 2);
+    expect(centers.length).toBeGreaterThan(20);
+    expect(Math.min(...centers)).toBeLessThan(100);
+    expect(Math.max(...centers)).toBeGreaterThan(300);
+  });
+
+  it("removes icons along the whole path of a fast swipe", async () => {
+    const icon = openBulkMode("reliefBulkRemove");
+    pack.relief = Array.from({ length: 21 }, (_, i) => ({ icon, x: i * 20 - 2, y: 48, s: 4 })); // one every 20px
+
+    await swipe(0, 400);
+
+    expect(pack.relief).toEqual([]);
+  });
+});

--- a/src/controllers/relief-editor.ts
+++ b/src/controllers/relief-editor.ts
@@ -9,6 +9,7 @@ import { getSceneReliefIcon, redrawRelief } from "@/renderers/draw-relief-icons"
 import { moveCircle, removeCircle } from "@/renderers/overlays/brush-circle";
 import type { ReliefSet } from "@/types/relief";
 import { capitalize, ensureEl, findAllInQuadtree, getPointer, rn } from "../utils";
+import { createBrushStroke } from "../utils/brushUtils";
 
 const ICON_BOX = 40; // icon preview box size in px, as defined in css
 
@@ -267,15 +268,12 @@ function dragToAdd(this: SVGElement, event: any): void {
 
   const tree = quadtree(pack.relief.map(({ x, y, s }) => [x + s / 2, y + s / 2] as [number, number]));
 
-  event.on("drag", function (this: SVGElement, dragEvent: any) {
-    const p = getPointer(dragEvent, this);
-    moveCircle(p[0], p[1], r);
-
+  const stroke = createBrushStroke(r / 2, (x, y) => {
     range(Math.ceil(r / 10)).forEach(() => {
       const a = Math.PI * 2 * Math.random();
       const rad = r * Math.random();
-      const cx = p[0] + rad * Math.cos(a);
-      const cy = p[1] + rad * Math.sin(a);
+      const cx = x + rad * Math.cos(a);
+      const cy = y + rad * Math.sin(a);
 
       if (tree.find(cx, cy, spacing)) return; // too close to existing icon
       if (pack.cells.h[Pack.findCell(cx, cy)!] < 20) return; // on water cell
@@ -284,7 +282,19 @@ function dragToAdd(this: SVGElement, event: any): void {
       tree.add([cx, cy]);
       insertIcon({ icon, x: rn(cx - h, 2), y: rn(cy - h, 2), s: rn(h * 2, 2) });
     });
+  });
+  const [startX, startY] = getPointer(event, this);
+  let started = false;
 
+  event.on("drag", function (this: SVGElement, dragEvent: any) {
+    const [x, y] = getPointer(dragEvent, this);
+    moveCircle(x, y, r);
+
+    if (!started) {
+      started = true;
+      stroke.moveTo(startX, startY); // the stroke starts where the pointer went down, on the first move
+    }
+    stroke.moveTo(x, y);
     redrawRelief();
   });
 }
@@ -337,11 +347,8 @@ function dragToRemove(this: SVGElement, event: any): void {
     tree.add([reliefIcon.x + reliefIcon.s / 2, reliefIcon.y + reliefIcon.s / 2, reliefIcon]);
   }
 
-  event.on("drag", function (this: SVGElement, dragEvent: any) {
-    const p = getPointer(dragEvent, this);
-    moveCircle(p[0], p[1], r);
-
-    const found = findAllInQuadtree(p[0], p[1], r, tree);
+  const stroke = createBrushStroke(r / 2, (x, y) => {
+    const found = findAllInQuadtree(x, y, r, tree);
     if (!found.length) return;
 
     const removed = new Set(found.map(entry => entry[2]));
@@ -349,6 +356,19 @@ function dragToRemove(this: SVGElement, event: any): void {
     pack.relief = pack.relief.filter(reliefIcon => !removed.has(reliefIcon));
     if (selectedIcon && removed.has(selectedIcon)) selectedIcon = null;
     redrawRelief();
+  });
+  const [startX, startY] = getPointer(event, this);
+  let started = false;
+
+  event.on("drag", function (this: SVGElement, dragEvent: any) {
+    const [x, y] = getPointer(dragEvent, this);
+    moveCircle(x, y, r);
+
+    if (!started) {
+      started = true;
+      stroke.moveTo(startX, startY);
+    }
+    stroke.moveTo(x, y);
   });
 }
 

--- a/src/controllers/relief-editor.ts
+++ b/src/controllers/relief-editor.ts
@@ -292,7 +292,7 @@ function dragToAdd(this: SVGElement, event: any): void {
 
     if (!started) {
       started = true;
-      stroke.moveTo(startX, startY); // the stroke starts where the pointer went down, on the first move
+      stroke.moveTo(startX, startY); // no stamps on a plain click
     }
     stroke.moveTo(x, y);
     redrawRelief();

--- a/src/services/versioning.ts
+++ b/src/services/versioning.ts
@@ -19,10 +19,11 @@ import { dialogState } from "@/components/dialog/state";
 import { tip } from "@/components/tooltips";
 import { isElectron } from "./platform";
 
-export const VERSION = "1.150.0";
+export const VERSION = "1.151.1";
 
 // new changes on top
 const latestPublicChanges = [
+  "Brushes: smooth, gap-free painting at any screen refresh rate",
   "Journey Editor and new Journeys layer",
   "Desktop App",
   "URL params to open specific layers or preset",

--- a/src/utils/brushUtils.test.ts
+++ b/src/utils/brushUtils.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { createBrushStroke } from "./brushUtils";
+
+function record() {
+  const stamps: [number, number][] = [];
+  return { stamps, stamp: (x: number, y: number) => stamps.push([x, y]) };
+}
+
+describe("createBrushStroke", () => {
+  it("stamps at the first point of the stroke", () => {
+    const { stamps, stamp } = record();
+    createBrushStroke(10, stamp).moveTo(5, 5);
+    expect(stamps).toEqual([[5, 5]]);
+  });
+
+  it("places stamps at even spacing along a segment, however few events cover it", () => {
+    const { stamps, stamp } = record();
+    const stroke = createBrushStroke(10, stamp);
+    stroke.moveTo(0, 0);
+    stroke.moveTo(40, 0); // one fast event over four spacings
+    expect(stamps).toEqual([
+      [0, 0],
+      [10, 0],
+      [20, 0],
+      [30, 0],
+      [40, 0]
+    ]);
+  });
+
+  it("stamps the same positions whether a segment arrives as one event or many", () => {
+    const one = record();
+    const strokeOne = createBrushStroke(10, one.stamp);
+    strokeOne.moveTo(0, 0);
+    strokeOne.moveTo(30, 40);
+
+    const many = record();
+    const strokeMany = createBrushStroke(10, many.stamp);
+    strokeMany.moveTo(0, 0);
+    for (let i = 1; i <= 25; i++) strokeMany.moveTo((30 * i) / 25, (40 * i) / 25); // 2px steps
+
+    expect(many.stamps.length).toBe(one.stamps.length);
+    many.stamps.forEach(([x, y], i) => {
+      expect(x).toBeCloseTo(one.stamps[i][0], 6);
+      expect(y).toBeCloseTo(one.stamps[i][1], 6);
+    });
+  });
+
+  it("carries the leftover distance into the next event", () => {
+    const { stamps, stamp } = record();
+    const stroke = createBrushStroke(10, stamp);
+    stroke.moveTo(0, 0);
+    stroke.moveTo(7, 0); // short of a spacing
+    stroke.moveTo(14, 0); // 14 travelled: one stamp at 10
+    stroke.moveTo(21, 0); // 21 travelled: one stamp at 20
+    expect(stamps).toEqual([
+      [0, 0],
+      [10, 0],
+      [20, 0]
+    ]);
+  });
+
+  it("does not stamp for movement shorter than the spacing", () => {
+    const { stamps, stamp } = record();
+    const stroke = createBrushStroke(10, stamp);
+    stroke.moveTo(0, 0);
+    for (let i = 0; i < 100; i++) stroke.moveTo(i % 2, 0); // jitter in place
+    expect(stamps).toEqual([[0, 0]]);
+  });
+});

--- a/src/utils/brushUtils.ts
+++ b/src/utils/brushUtils.ts
@@ -1,14 +1,9 @@
 export interface BrushStroke {
-  /** Report the pointer position: the first call stamps there, later ones lay stamps along the way */
   moveTo(x: number, y: number): void;
 }
 
-/**
- * A brush stroke that stamps by distance travelled, not by pointer event. Pointer events arrive once per
- * displayed frame, so applying a brush per event paints faster on a high-refresh monitor and leaves gaps
- * on a fast swipe. Placing a stamp every `spacing` pixels from the last one makes the result depend on
- * the gesture only, the way raster painters do it. Jitter in place travels nowhere, so it stamps nothing
- */
+// stamps every `spacing` px of pointer travel, not per pointer event: per-event brushes paint faster
+// on high-refresh monitors and leave gaps on fast swipes. The first moveTo stamps in place
 export function createBrushStroke(spacing: number, stamp: (x: number, y: number) => void): BrushStroke {
   let stampX = 0;
   let stampY = 0;
@@ -24,7 +19,6 @@ export function createBrushStroke(spacing: number, stamp: (x: number, y: number)
         return;
       }
 
-      // every full spacing from the last stamp towards the pointer, so a fast swipe has no gaps
       let distance = Math.hypot(x - stampX, y - stampY);
       while (distance >= spacing) {
         const t = spacing / distance;

--- a/src/utils/brushUtils.ts
+++ b/src/utils/brushUtils.ts
@@ -1,0 +1,38 @@
+export interface BrushStroke {
+  /** Report the pointer position: the first call stamps there, later ones lay stamps along the way */
+  moveTo(x: number, y: number): void;
+}
+
+/**
+ * A brush stroke that stamps by distance travelled, not by pointer event. Pointer events arrive once per
+ * displayed frame, so applying a brush per event paints faster on a high-refresh monitor and leaves gaps
+ * on a fast swipe. Placing a stamp every `spacing` pixels from the last one makes the result depend on
+ * the gesture only, the way raster painters do it. Jitter in place travels nowhere, so it stamps nothing
+ */
+export function createBrushStroke(spacing: number, stamp: (x: number, y: number) => void): BrushStroke {
+  let stampX = 0;
+  let stampY = 0;
+  let started = false;
+
+  return {
+    moveTo(x, y) {
+      if (!started) {
+        started = true;
+        stampX = x;
+        stampY = y;
+        stamp(x, y);
+        return;
+      }
+
+      // every full spacing from the last stamp towards the pointer, so a fast swipe has no gaps
+      let distance = Math.hypot(x - stampX, y - stampY);
+      while (distance >= spacing) {
+        const t = spacing / distance;
+        stampX += (x - stampX) * t;
+        stampY += (y - stampY) * t;
+        stamp(stampX, stampY);
+        distance -= spacing;
+      }
+    }
+  };
+}


### PR DESCRIPTION
# Description

Fixes #1664: brush speed depended on the monitor refresh rate, and fast swipes left gaps.

Pointer events arrive once per displayed frame, so a brush applied per event painted ~4x faster at 240Hz than at 60Hz, and a fast swipe at 60Hz put consecutive stamps further apart than the brush radius.

The fix is one shared helper, `createBrushStroke(spacing, stamp)` in `src/utils/brushUtils.ts`: the first pointer position stamps, and every later position lays stamps every `spacing` px from the last stamp towards the pointer, the way raster painters do it. The result depends on the gesture only: high refresh rate gives more events but the same stamps per distance; a fast swipe fills in the intermediate stamps; jitter in place travels nowhere and stamps nothing.

Wired into every brush on master (spacing = half the radius in all of them):
- heightmap brushes (`dragBrush`); a plain click still applies once
- the paint editor used by states, cultures, religions, zones and markets (`handleDragStart`); anchors at mousedown on the first move, so a plain click still only selects
- relief editor bulk add and bulk remove (`dragToAdd`, `dragToRemove`)

All other `drag` handlers move a single element (markers, routes, rivers, labels, regiments, emblems, ice, measurers, vertices, journey points) and are not brushes.

Tests: unit tests for the helper, plus fast-swipe tests for the paint editor and the relief brushes. Verified in a headless browser: a 400px swipe delivered as a single pointer event raises every cell along the path (no gaps), and 200 one-pixel jitter moves in place apply exactly one power step.
