### PR TITLE
feat: annex states and provinces by clicking on the map

### DIFF
--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -356,6 +356,9 @@ state**._ A controller does **not** hold pure static data, services, or serializ
 - **App-level UI** — dialogs and widgets that are opened over the map but say nothing about it:
   the About dialog (`app-info`). They have a controller's lifecycle but not a controller's
   subject, so they live here and load with the shell.
+- **Shared editor behaviour** — interaction helpers several editors call rather than copy:
+  dialog helpers, tooltips, the default map events (`viewbox-events`), and map modes such as
+  `annex-mode`, which the States and Provinces editors both drive with their own merge logic.
 
 Widgets like `hierarchy-tree` and `minimap` may move to `components/` if they generalize.
 

--- a/docs/wiki/Knowledge Base.md
+++ b/docs/wiki/Knowledge Base.md
@@ -338,7 +338,7 @@ Go to Tools -> Units and change the '1 map pixel' distance scale. To change how 
 
 ### How to merge provinces?
 
-Open the Provinces Editor, filter the list by the state the provinces belong to and click on the 'Merge several provinces into one' button at the dialog bottom. Provinces of different states cannot be merged, reassign them in the States Editor first. Alternatively remove a province and repaint its territory to another one with the Paint brush
+Open the Provinces Editor and click the 'Annex provinces' button (crown icon) at the dialog bottom. Click the province that absorbs the others on the map, then click the provinces to annex; hold Shift to keep annexing several. A confirmation lists what will be merged, so a mis-click can be cancelled. To pick from a list instead, filter by the state the provinces belong to and use the 'Merge several provinces into one' button. Provinces of different states cannot be merged, reassign them in the States Editor first. Alternatively remove a province and repaint its territory to another one with the Paint brush
 
 ### Can you colour in the relief icons?
 
@@ -550,7 +550,7 @@ You can create a new Regiment using the Regiments Overview. In can open if you c
 
 ### How do I merge countries?
 
-To merge states (countries) open the States Editor from Tools and click on the "Merge several states into one" button at the dialog bottom. Then select states you want to merge
+To merge states (countries) open the States Editor from Tools and click the "Annex states" button (crown icon) at the dialog bottom. Click the state that annexes the others on the map, then click the states to annex; hold Shift to keep annexing several. A confirmation lists what will be removed, so a mis-click can be cancelled. To pick from a list instead, use the "Merge several states into one" button next to it and tick the states to merge
 
 ### How to start a war?
 

--- a/src/components/annex-mode.ts
+++ b/src/components/annex-mode.ts
@@ -1,0 +1,127 @@
+// Map mode shared by the states and provinces editors: click the annexing entity, then the ones it absorbs
+import { select } from "d3";
+import { ensureEl, getPointer } from "@/utils";
+import { clearMainTip, tip } from "./tooltips";
+import { applyDefaultViewboxEvents } from "./viewbox-events";
+
+interface AnnexModeOptions {
+  buttonId: string;
+  bodySectionId: string;
+  mode: number;
+  noun: string;
+  ownerOf: (cellId: number) => number;
+  colorOf: (id: number) => string;
+  nameOf: (id: number) => string;
+  rejectReason?: (parentId: number, id: number) => string | undefined;
+  commit: (parentId: number, annexed: number[]) => void;
+}
+
+export function createAnnexMode(options: AnnexModeOptions) {
+  const { buttonId, bodySectionId, mode, noun, ownerOf, colorOf, nameOf, rejectReason, commit } = options;
+  let parent = 0;
+  const staged = new Set<number>();
+
+  const isActive = () => customization === mode;
+  const preview = () => select("#debug").select("g.annex-preview");
+
+  function toggle(): void {
+    if (isActive()) finish();
+    else enter();
+  }
+
+  function enter(): void {
+    customization = mode;
+    ensureEl(buttonId).classList.add("pressed");
+    select("#debug").append("g").attr("class", "annex-preview");
+    tip(`Click the ${noun} that annexes, then the ${noun}s it absorbs. Hold Shift to keep annexing`, true);
+    select<SVGElement, unknown>("#viewbox").style("cursor", "crosshair").on("click", onClick);
+    setRowsInert(true);
+  }
+
+  function onClick(this: SVGElement, event: MouseEvent): void {
+    const [x, y] = getPointer(event, this);
+    const cell = Pack.findCell(x, y);
+    if (cell === undefined || pack.cells.h[cell] < 20) {
+      tip(`Click on a land cell to pick a ${noun}`, false, "error");
+      return;
+    }
+
+    const id = ownerOf(cell);
+    if (!id) {
+      tip(`There is no ${noun} here`, false, "error");
+      return;
+    }
+
+    if (!parent) {
+      parent = id;
+      drawEntity(id, "annex-parent", 0.3);
+      tip(`Annexing into ${nameOf(id)}. Click the ${noun}s to annex. Hold Shift to keep annexing`, true);
+      return;
+    }
+
+    if (id === parent) {
+      tip(`${nameOf(id)} is the annexing ${noun}`, false, "error");
+      return;
+    }
+
+    const reason = rejectReason?.(parent, id);
+    if (reason) {
+      tip(reason, false, "error");
+      return;
+    }
+
+    if (staged.has(id)) {
+      staged.delete(id);
+      preview().select(`g[data-id='${id}']`).remove();
+    } else {
+      staged.add(id);
+      drawEntity(id, "annex-child", 0.7);
+    }
+
+    if (!event.shiftKey) finish();
+  }
+
+  function drawEntity(id: number, className: string, opacity: number): void {
+    const color = colorOf(parent);
+    const group = preview().append("g").attr("data-id", id).attr("class", className).attr("opacity", opacity);
+    const { h } = pack.cells;
+    for (let i = 0; i < h.length; i++) {
+      if (h[i] < 20 || ownerOf(i) !== id) continue;
+      group
+        .append("polygon")
+        .attr("points", String(Pack.getPolygon(i)))
+        .attr("fill", color)
+        .attr("stroke", color);
+    }
+  }
+
+  function setRowsInert(inert: boolean): void {
+    ensureEl(bodySectionId)
+      .querySelectorAll<HTMLElement>("div > input, select, span, svg")
+      .forEach(e => {
+        if (inert) e.style.pointerEvents = "none";
+        else e.style.removeProperty("pointer-events");
+      });
+  }
+
+  function finish(): void {
+    const parentId = parent;
+    const annexed = [...staged];
+    exit();
+    if (parentId && annexed.length) commit(parentId, annexed);
+  }
+
+  function exit(): void {
+    if (!isActive()) return;
+    customization = 0;
+    parent = 0;
+    staged.clear();
+    preview().remove();
+    applyDefaultViewboxEvents();
+    clearMainTip();
+    setRowsInert(false);
+    ensureEl(buttonId).classList.remove("pressed");
+  }
+
+  return { toggle, exit };
+}

--- a/src/components/annex-mode.ts
+++ b/src/components/annex-mode.ts
@@ -7,7 +7,6 @@ import { applyDefaultViewboxEvents } from "./viewbox-events";
 interface AnnexModeOptions {
   buttonId: string;
   bodySectionId: string;
-  mode: number;
   noun: string;
   ownerOf: (cellId: number) => number;
   colorOf: (id: number) => string;
@@ -16,21 +15,25 @@ interface AnnexModeOptions {
   commit: (parentId: number, annexed: number[]) => void;
 }
 
+// any non-zero customization keeps the other editors, saving and regeneration off while annexing
+const ANNEX_MODE = 17;
+
 export function createAnnexMode(options: AnnexModeOptions) {
-  const { buttonId, bodySectionId, mode, noun, ownerOf, colorOf, nameOf, rejectReason, commit } = options;
+  const { buttonId, bodySectionId, noun, ownerOf, colorOf, nameOf, rejectReason, commit } = options;
+  let active = false;
   let parent = 0;
   const staged = new Set<number>();
 
-  const isActive = () => customization === mode;
   const preview = () => select("#debug").select("g.annex-preview");
 
   function toggle(): void {
-    if (isActive()) finish();
+    if (active) finish();
     else enter();
   }
 
   function enter(): void {
-    customization = mode;
+    active = true;
+    customization = ANNEX_MODE;
     ensureEl(buttonId).classList.add("pressed");
     select("#debug").append("g").attr("class", "annex-preview");
     tip(`Click the ${noun} that annexes, then the ${noun}s it absorbs. Hold Shift to keep annexing`, true);
@@ -112,7 +115,8 @@ export function createAnnexMode(options: AnnexModeOptions) {
   }
 
   function exit(): void {
-    if (!isActive()) return;
+    if (!active) return;
+    active = false;
     customization = 0;
     parent = 0;
     staged.clear();

--- a/src/controllers/provinces-editor.ts
+++ b/src/controllers/provinces-editor.ts
@@ -1376,7 +1376,6 @@ function confirmProvincesMerge(provincesToMerge: number[], primaryProvinceId: nu
 const provincesAnnex = createAnnexMode({
   buttonId: "provincesAnnex",
   bodySectionId: "provincesBodySection",
-  mode: 18,
   noun: "province",
   ownerOf: cellId => pack.cells.province[cellId],
   colorOf: provinceId => pack.provinces[provinceId].color,

--- a/src/controllers/provinces-editor.ts
+++ b/src/controllers/provinces-editor.ts
@@ -1,4 +1,5 @@
-import { color as d3Color, easeSinIn, interpolate, interpolateString, select, stratify, transition, treemap } from "d3";
+import { color as d3Color, easeSinIn, interpolate, select, stratify, transition, treemap } from "d3";
+import { createAnnexMode } from "@/components/annex-mode";
 import { closeDialogs, confirmationDialog, destroyDialog, updateDialog } from "@/components/dialog/dialog-helpers";
 import { applyLineHighlighting } from "@/components/dialog/highlighting";
 import { bindColumnSorting, sortDataByColumns } from "@/components/dialog/sorting";
@@ -21,7 +22,7 @@ import type { Province } from "@/generators/provinces-generator";
 import { redrawEmblem, redrawEmblems, removeEmblem } from "@/renderers/draw-emblems";
 import { EmblemRenderer } from "@/renderers/emblems/renderer";
 import { fog, unfog } from "@/renderers/overlays/fogging";
-import { highlightElement } from "@/renderers/overlays/highlight";
+import { highlightElement, highlightOutline } from "@/renderers/overlays/highlight";
 import { applyOption, downloadFile, getArea, getAreaUnit, getFileName, speak } from "@/utils";
 import { ensureEl, findEl, getPointer, getRandomColor, isLand, P, rand, rn, si, unique } from "../utils";
 
@@ -157,6 +158,11 @@ function renderDialog(): void {
         ></button>
         <button id="provincesMerge" data-tip="Merge several provinces into one" class="icon-layer-group"></button>
         <button
+          id="provincesAnnex"
+          data-tip="Annex provinces: click the annexing province, then the provinces of the same state it absorbs. Hold Shift to keep annexing"
+          class="icon-crown"
+        ></button>
+        <button
           id="provincesRemoveAll"
           data-tip="Remove all provinces. States will remain as they are"
           class="icon-trash"
@@ -189,6 +195,7 @@ function renderDialog(): void {
   ensureEl("provincesRelease").addEventListener("click", triggerProvincesRelease);
   ensureEl("provincesAdd").addEventListener("click", enterAddProvinceMode);
   ensureEl("provincesMerge").addEventListener("click", openProvinceMergeDialog);
+  ensureEl("provincesAnnex").addEventListener("click", provincesAnnex.toggle);
   ensureEl("provincesRecolor").addEventListener("click", recolorProvinces);
 
   ensureEl("provincesBodySection").addEventListener("click", (ev: Event) => {
@@ -1250,6 +1257,7 @@ function removeAllProvinces(): void {
 
 function closeProvincesEditor(): void {
   if (customization === 12) exitAddProvinceMode();
+  provincesAnnex.exit();
   $("#provincesEditor").dialog("destroy");
   ensureEl("provincesEditor").remove();
 }
@@ -1282,15 +1290,13 @@ function openProvinceMergeDialog(): void {
     return;
   }
 
-  const emblem = (i: number): string =>
-    /* html */ `<svg class="coaIcon" viewBox="0 0 200 200"><use href="#provinceCOA${i}"></use></svg>`;
   const provincesSelector = provincesToMerge
     .map(
       p => /* html */ `
     <div data-id="${p.i}" data-tip="${p.fullName || p.name}" style="cursor:default">
       <input type="radio" name="rulingProvince" value="${p.i}" />
       <input id="selectProvince${p.i}" class="checkbox" type="checkbox" name="provincesToMerge" value="${p.i}" />
-      <label for="selectProvince${p.i}" class="checkbox-label"><fill-box fill="${p.color}" disabled></fill-box>${emblem(p.i)}${p.name}</label>
+      <label for="selectProvince${p.i}" class="checkbox-label"><fill-box fill="${p.color}" disabled></fill-box>${provinceEmblem(p.i)}${p.name}</label>
     </div>
   `
     )
@@ -1338,20 +1344,7 @@ function openProvinceMergeDialog(): void {
           return;
         }
 
-        confirmationDialog({
-          title: "Merge provinces",
-          message: /* html */ `
-            <p>The following provinces will be <strong>removed</strong>: ${provincesToMergeIds
-              .map(provinceId => `${emblem(provinceId)}${pack.provinces[provinceId].name}`)
-              .join(", ")}.</p>
-            <p>Removed provinces data (burgs and cells) will be assigned to ${emblem(primaryProvinceId)}${pack.provinces[primaryProvinceId].name}.</p>
-            <p>Are you sure you want to merge provinces? This action cannot be reverted.</p>`,
-          confirm: "Merge",
-          onConfirm: () => {
-            mergeProvinces(provincesToMergeIds, primaryProvinceId);
-            $(this).dialog("close");
-          }
-        });
+        confirmProvincesMerge(provincesToMergeIds, primaryProvinceId, () => $(this).dialog("close"));
       },
       Cancel: function (this: HTMLElement) {
         $(this).dialog("close");
@@ -1359,6 +1352,41 @@ function openProvinceMergeDialog(): void {
     }
   });
 }
+
+const provinceEmblem = (i: number): string =>
+  /* html */ `<svg class="coaIcon" viewBox="0 0 200 200"><use href="#provinceCOA${i}"></use></svg>`;
+
+function confirmProvincesMerge(provincesToMerge: number[], primaryProvinceId: number, onConfirm?: () => void): void {
+  confirmationDialog({
+    title: "Merge provinces",
+    message: /* html */ `
+      <p>The following provinces will be <strong>removed</strong>: ${provincesToMerge
+        .map(provinceId => `${provinceEmblem(provinceId)}${pack.provinces[provinceId].name}`)
+        .join(", ")}.</p>
+      <p>Removed provinces data (burgs and cells) will be assigned to ${provinceEmblem(primaryProvinceId)}${pack.provinces[primaryProvinceId].name}.</p>
+      <p>Are you sure you want to merge provinces? This action cannot be reverted.</p>`,
+    confirm: "Merge",
+    onConfirm: () => {
+      mergeProvinces(provincesToMerge, primaryProvinceId);
+      onConfirm?.();
+    }
+  });
+}
+
+const provincesAnnex = createAnnexMode({
+  buttonId: "provincesAnnex",
+  bodySectionId: "provincesBodySection",
+  mode: 18,
+  noun: "province",
+  ownerOf: cellId => pack.cells.province[cellId],
+  colorOf: provinceId => pack.provinces[provinceId].color,
+  nameOf: provinceId => pack.provinces[provinceId].name,
+  rejectReason: (primaryId, provinceId) =>
+    pack.provinces[provinceId].state === pack.provinces[primaryId].state
+      ? undefined
+      : `${pack.provinces[provinceId].name} belongs to another state. Merge states first, or pick a province of ${pack.states[pack.provinces[primaryId].state].name}`,
+  commit: (primaryProvinceId, provincesToMerge) => confirmProvincesMerge(provincesToMerge, primaryProvinceId)
+});
 
 function highlightProvinceOnMergeHover(event: Event): void {
   if (!Layers.isOn("provinces")) return;
@@ -1368,24 +1396,7 @@ function highlightProvinceOnMergeHover(event: Event): void {
   if (!d) return;
 
   provinceHighlightOff(event);
-
-  const path = select("#debug")
-    .append("path")
-    .attr("class", "highlight")
-    .attr("d", d)
-    .attr("fill", "none")
-    .attr("stroke", "red")
-    .attr("stroke-width", 1)
-    .attr("opacity", 1)
-    .attr("filter", "url(#blur1)");
-
-  const totalLength = (path.node() as SVGPathElement).getTotalLength();
-  const duration = (totalLength + 5000) / 2;
-  const interp = interpolateString(`0, ${totalLength}`, `${totalLength}, ${totalLength}`);
-  path
-    .transition()
-    .duration(duration)
-    .attrTween("stroke-dasharray", () => interp);
+  highlightOutline(d);
 }
 
 function cleanupMergedProvince(provinceId: number): void {

--- a/src/controllers/states-editor.ts
+++ b/src/controllers/states-editor.ts
@@ -1676,7 +1676,6 @@ function confirmStatesMerge(statesToMerge: number[], rulingStateId: number, onCo
 const statesAnnex = createAnnexMode({
   buttonId: "statesAnnex",
   bodySectionId: "statesBodySection",
-  mode: 17,
   noun: "state",
   ownerOf: cellId => pack.cells.state[cellId],
   colorOf: stateId => pack.states[stateId].color ?? "#999999",
@@ -1692,10 +1691,6 @@ function mergeStates(statesToMerge: number[], rulingStateId: number): void {
   statesToMerge.forEach(stateId => {
     const state = pack.states[stateId];
     state.removed = true;
-
-    select("#statesBody").select(`#state${stateId}`).remove();
-    select("#statesBody").select(`#state-gap${stateId}`).remove();
-    select("#statesHalo").select(`#state-border${stateId}`).remove();
     delete pack.states[stateId].label;
 
     removeEmblem("state", stateId);
@@ -1750,8 +1745,7 @@ function mergeStates(statesToMerge: number[], rulingStateId: number): void {
 
   if (!pack.states[rulingStateId].label) delete pack.states[rulingStateId].label;
 
-  Layers.show("states", "borders");
-  Layers.draw("burgIcons", "labels", "provinces");
+  Layers.draw("states", "borders", "burgIcons", "labels", "provinces");
   refreshStatesEditor();
 }
 

--- a/src/controllers/states-editor.ts
+++ b/src/controllers/states-editor.ts
@@ -1,4 +1,5 @@
-import { interpolateString, max, pack as packLayout, select, stratify } from "d3";
+import { max, pack as packLayout, select, stratify } from "d3";
+import { createAnnexMode } from "@/components/annex-mode";
 import { closeDialogs, confirmationDialog, destroyDialog, updateDialog } from "@/components/dialog/dialog-helpers";
 import { applyLineHighlighting } from "@/components/dialog/highlighting";
 import { bindColumnSorting, sortDataByColumns } from "@/components/dialog/sorting";
@@ -22,7 +23,7 @@ import { redrawEmblem, redrawEmblems, removeEmblem } from "@/renderers/draw-embl
 import { clearLegend, drawLegend } from "@/renderers/draw-legend";
 import { EmblemRenderer } from "@/renderers/emblems/renderer";
 import { fog, unfog } from "@/renderers/overlays/fogging";
-import { highlightElement } from "@/renderers/overlays/highlight";
+import { highlightElement, highlightOutline } from "@/renderers/overlays/highlight";
 import { applyOption, downloadFile, getArea, getAreaUnit, getFileName, speak } from "@/utils";
 import {
   ensureEl,
@@ -203,6 +204,7 @@ function renderDialog(): void {
 
       <button id="statesAdd" data-tip="Add a new state. Hold Shift to add multiple" class="icon-plus"></button>
       <button id="statesMerge" data-tip="Merge several states into one" class="icon-layer-group"></button>
+      <button id="statesAnnex" data-tip="Annex states: click the annexing state, then the states it absorbs. Hold Shift to keep annexing" class="icon-crown"></button>
       <button id="statesExport" data-tip="Save state-related data as a text file (.csv)" class="icon-download"></button>
     </div>
   </div>`;
@@ -229,6 +231,7 @@ function renderDialog(): void {
   ensureEl("statesManually").addEventListener("click", openPaintEditor);
   ensureEl("statesAdd").addEventListener("click", enterAddStateMode);
   ensureEl("statesMerge").addEventListener("click", openStateMergeDialog);
+  ensureEl("statesAnnex").addEventListener("click", statesAnnex.toggle);
   ensureEl("statesExport").addEventListener("click", downloadStatesCsv);
 
   ensureEl("statesBodySection").addEventListener("click", event => {
@@ -267,6 +270,7 @@ function renderDialog(): void {
 
 function closeStatesEditor(): void {
   if (customization === 3) exitAddStateMode();
+  statesAnnex.exit();
   select("#debug").selectAll(".highlight").remove();
   destroyDialog(dialogId);
 }
@@ -480,25 +484,7 @@ function stateHighlightOn(event: any): void {
 
   const state = +event.target.dataset.id;
   if (customization || !state) return;
-  const d = select("#regions").select(`#state${state}`).attr("d");
-
-  const path = select("#debug")
-    .append("path")
-    .attr("class", "highlight")
-    .attr("d", d)
-    .attr("fill", "none")
-    .attr("stroke", "red")
-    .attr("stroke-width", 1)
-    .attr("opacity", 1)
-    .attr("filter", "url(#blur1)");
-
-  const totalLength = (path.node() as SVGPathElement).getTotalLength();
-  const duration = (totalLength + 5000) / 2;
-  const interpolate = interpolateString(`0, ${totalLength}`, `${totalLength}, ${totalLength}`);
-  path
-    .transition()
-    .duration(duration)
-    .attrTween("stroke-dasharray", () => interpolate);
+  highlightOutline(select("#regions").select(`#state${state}`).attr("d"));
 }
 
 function stateHighlightOff(): void {
@@ -1588,9 +1574,10 @@ function exitAddStateMode(): void {
   if (statesAdd.classList.contains("pressed")) statesAdd.classList.remove("pressed");
 }
 
+const stateEmblem = (i: number) =>
+  /* html */ `<svg class="coaIcon" viewBox="0 0 200 200"><use href="#stateCOA${i}"></use></svg>`;
+
 function openStateMergeDialog(): void {
-  const emblem = (i: number) =>
-    /* html */ `<svg class="coaIcon" viewBox="0 0 200 200"><use href="#stateCOA${i}"></use></svg>`;
   const validStates = pack.states.filter(s => s.i && !s.removed);
 
   const statesSelector = validStates
@@ -1599,7 +1586,7 @@ function openStateMergeDialog(): void {
       <div data-id="${s.i}" data-tip="${s.fullName}" style="cursor:default">
         <input type="radio" name="rulingState" value="${s.i}" />
         <input id="selectState${s.i}" class="checkbox" type="checkbox" name="statesToMerge" value="${s.i}" />
-        <label for="selectState${s.i}" class="checkbox-label"><fill-box fill="${s.color}" disabled></fill-box>${emblem(s.i)}${s.fullName}</label>
+        <label for="selectState${s.i}" class="checkbox-label"><fill-box fill="${s.color}" disabled></fill-box>${stateEmblem(s.i)}${s.fullName}</label>
       </div>
     `
     )
@@ -1634,24 +1621,7 @@ function openStateMergeDialog(): void {
     if (!d) return;
 
     stateHighlightOff();
-
-    const path = select("#debug")
-      .append("path")
-      .attr("class", "highlight")
-      .attr("d", d)
-      .attr("fill", "none")
-      .attr("stroke", "red")
-      .attr("stroke-width", 1)
-      .attr("opacity", 1)
-      .attr("filter", "url(#blur1)");
-
-    const totalLength = (path.node() as SVGPathElement).getTotalLength();
-    const duration = (totalLength + 5000) / 2;
-    const interpolate = interpolateString(`0, ${totalLength}`, `${totalLength}, ${totalLength}`);
-    path
-      .transition()
-      .duration(duration)
-      .attrTween("stroke-dasharray", () => interpolate);
+    highlightOutline(d);
   }
 
   $("#alert").dialog({
@@ -1667,7 +1637,6 @@ function openStateMergeDialog(): void {
           tip("Please select a state to merge into", false, "error");
           return;
         }
-        const rullingState = pack.states[rulingStateId];
 
         const statesToMerge = formData
           .getAll("statesToMerge")
@@ -1678,96 +1647,112 @@ function openStateMergeDialog(): void {
           return;
         }
 
-        confirmationDialog({
-          title: "Merge states",
-          // prettier-ignore
-          message: /* html */ `
-            <p>The following states will be <strong>removed</strong>: ${statesToMerge.map(stateId => `${emblem(stateId)}${(pack.states)[stateId].name}`).join(", ")}.</p>
-            <p>Removed states data (burgs, provinces, regiments) will be assigned to ${emblem(rullingState.i)}${rullingState.name}.</p>
-            <p>Are you sure you want to merge states? This action cannot be reverted.</p>`,
-          confirm: "Merge",
-          onConfirm: () => {
-            mergeStates(statesToMerge, rulingStateId);
-            $(this).dialog("close");
-          }
-        });
+        confirmStatesMerge(statesToMerge, rulingStateId, () => $(this).dialog("close"));
       },
       Cancel: function (this: HTMLElement) {
         $(this).dialog("close");
       }
     }
   });
+}
 
-  function mergeStates(statesToMerge: number[], rulingStateId: number) {
-    const rulingState = pack.states[rulingStateId];
-    const rulingStateArmy = ensureEl(`army${rulingStateId}`);
+function confirmStatesMerge(statesToMerge: number[], rulingStateId: number, onConfirm?: () => void): void {
+  const rulingState = pack.states[rulingStateId];
+  confirmationDialog({
+    title: "Merge states",
+    // prettier-ignore
+    message: /* html */ `
+      <p>The following states will be <strong>removed</strong>: ${statesToMerge.map(stateId => `${stateEmblem(stateId)}${(pack.states)[stateId].name}`).join(", ")}.</p>
+      <p>Removed states data (burgs, provinces, regiments) will be assigned to ${stateEmblem(rulingState.i)}${rulingState.name}.</p>
+      <p>Are you sure you want to merge states? This action cannot be reverted.</p>`,
+    confirm: "Merge",
+    onConfirm: () => {
+      mergeStates(statesToMerge, rulingStateId);
+      onConfirm?.();
+    }
+  });
+}
 
-    // remove states to be merged
-    statesToMerge.forEach(stateId => {
-      const state = pack.states[stateId];
-      state.removed = true;
+const statesAnnex = createAnnexMode({
+  buttonId: "statesAnnex",
+  bodySectionId: "statesBodySection",
+  mode: 17,
+  noun: "state",
+  ownerOf: cellId => pack.cells.state[cellId],
+  colorOf: stateId => pack.states[stateId].color ?? "#999999",
+  nameOf: stateId => pack.states[stateId].name,
+  commit: (rulingStateId, statesToMerge) => confirmStatesMerge(statesToMerge, rulingStateId)
+});
 
-      select("#statesBody").select(`#state${stateId}`).remove();
-      select("#statesBody").select(`#state-gap${stateId}`).remove();
-      select("#statesHalo").select(`#state-border${stateId}`).remove();
-      delete pack.states[stateId].label;
+function mergeStates(statesToMerge: number[], rulingStateId: number): void {
+  const rulingState = pack.states[rulingStateId];
+  const rulingStateArmy = ensureEl(`army${rulingStateId}`);
 
-      removeEmblem("state", stateId);
+  // remove states to be merged
+  statesToMerge.forEach(stateId => {
+    const state = pack.states[stateId];
+    state.removed = true;
 
-      // add merged state regiments to the ruling state
-      (state.military || []).forEach((regiment: any) => {
-        const oldId = `regiment${stateId}-${regiment.i}`;
-        const newIndex = (rulingState.military || []).length;
-        (rulingState.military || []).push({ ...regiment, i: newIndex });
-        const newId = `regiment${rulingStateId}-${newIndex}`;
+    select("#statesBody").select(`#state${stateId}`).remove();
+    select("#statesBody").select(`#state-gap${stateId}`).remove();
+    select("#statesHalo").select(`#state-border${stateId}`).remove();
+    delete pack.states[stateId].label;
 
-        const note = notes.find(n => n.id === oldId);
-        if (note) note.id = newId;
+    removeEmblem("state", stateId);
 
-        const element = document.getElementById(oldId);
-        if (element) {
-          element.id = newId;
-          element.dataset.state = String(rulingStateId);
-          element.dataset.id = String(newIndex);
-          rulingStateArmy.appendChild(element);
-        }
-      });
+    // add merged state regiments to the ruling state
+    (state.military || []).forEach((regiment: any) => {
+      const oldId = `regiment${stateId}-${regiment.i}`;
+      const newIndex = (rulingState.military || []).length;
+      (rulingState.military || []).push({ ...regiment, i: newIndex });
+      const newId = `regiment${rulingStateId}-${newIndex}`;
 
-      select(`#armies g#army${stateId}`).remove();
-    });
+      const note = notes.find(n => n.id === oldId);
+      if (note) note.id = newId;
 
-    // reassing burgs
-    pack.burgs.forEach(burg => {
-      if (statesToMerge.includes(burg.state ?? 0)) {
-        if (burg.capital) {
-          burg.capital = 0;
-          Burgs.changeGroup(burg, null);
-        }
-        burg.state = rulingStateId;
+      const element = document.getElementById(oldId);
+      if (element) {
+        element.id = newId;
+        element.dataset.state = String(rulingStateId);
+        element.dataset.id = String(newIndex);
+        rulingStateArmy.appendChild(element);
       }
     });
 
-    // reassign provinces
-    pack.provinces.forEach(province => {
-      if (statesToMerge.includes(province.state)) province.state = rulingStateId;
-    });
+    select(`#armies g#army${stateId}`).remove();
+  });
 
-    // reassing cells
-    pack.cells.state.forEach((s: number, i: number) => {
-      if (statesToMerge.includes(s)) pack.cells.state[i] = rulingStateId;
-    });
+  // reassing burgs
+  pack.burgs.forEach(burg => {
+    if (statesToMerge.includes(burg.state ?? 0)) {
+      if (burg.capital) {
+        burg.capital = 0;
+        Burgs.changeGroup(burg, null);
+      }
+      burg.state = rulingStateId;
+    }
+  });
 
-    unfog();
-    select("#debug").selectAll(".highlight").remove();
+  // reassign provinces
+  pack.provinces.forEach(province => {
+    if (statesToMerge.includes(province.state)) province.state = rulingStateId;
+  });
 
-    States.getPoles();
+  // reassing cells
+  pack.cells.state.forEach((s: number, i: number) => {
+    if (statesToMerge.includes(s)) pack.cells.state[i] = rulingStateId;
+  });
 
-    if (!pack.states[rulingStateId].label) delete pack.states[rulingStateId].label;
+  unfog();
+  select("#debug").selectAll(".highlight").remove();
 
-    Layers.show("states", "borders");
-    Layers.draw("burgIcons", "labels", "provinces");
-    refreshStatesEditor();
-  }
+  States.getPoles();
+
+  if (!pack.states[rulingStateId].label) delete pack.states[rulingStateId].label;
+
+  Layers.show("states", "borders");
+  Layers.draw("burgIcons", "labels", "provinces");
+  refreshStatesEditor();
 }
 
 function downloadStatesCsv(): void {

--- a/src/renderers/overlays/highlight.ts
+++ b/src/renderers/overlays/highlight.ts
@@ -1,4 +1,4 @@
-import { easeBounceOut, easeLinear, easeSinIn, select, transition } from "d3";
+import { easeBounceOut, easeLinear, easeSinIn, interpolateString, select, transition } from "d3";
 import { parseTransform } from "@/utils";
 
 const debugLayer = () => select<SVGGElement, unknown>("#debug");
@@ -102,4 +102,26 @@ export function highlightEmblemElement(type: string, element: { i: number; [key:
     .attr("stroke-dashoffset", d => d[2])
     .attr("opacity", 0)
     .remove();
+}
+
+/** Trace a path outline in red, animated along its length. Removed by the callers' highlight-off */
+export function highlightOutline(d: string | null): void {
+  if (!d) return;
+  const path = debugLayer()
+    .append("path")
+    .attr("class", "highlight")
+    .attr("d", d)
+    .attr("fill", "none")
+    .attr("stroke", "red")
+    .attr("stroke-width", 1)
+    .attr("opacity", 1)
+    .attr("filter", "url(#blur1)");
+
+  const totalLength = (path.node() as SVGPathElement).getTotalLength();
+  const duration = (totalLength + 5000) / 2;
+  const interpolate = interpolateString(`0, ${totalLength}`, `${totalLength}, ${totalLength}`);
+  path
+    .transition()
+    .duration(duration)
+    .attrTween("stroke-dasharray", () => interpolate);
 }

--- a/tests/e2e/annex-mode.spec.ts
+++ b/tests/e2e/annex-mode.spec.ts
@@ -1,0 +1,202 @@
+import {test, expect, type Page} from "@playwright/test";
+
+// Map click at a pack coordinate; callers filter out points hidden under a dialog or the options panel
+async function clickMapAt(page: Page, point: [number, number]) {
+  const screen = await page.evaluate(([x, y]) => {
+    const viewbox = document.getElementById("viewbox") as unknown as SVGGraphicsElement;
+    const p = new DOMPoint(x, y).matrixTransform(viewbox.getScreenCTM()!);
+    return {x: p.x, y: p.y};
+  }, point);
+  await page.mouse.click(screen.x, screen.y);
+}
+
+async function isMapVisibleAt(page: Page, point: [number, number]) {
+  return page.evaluate(([x, y]) => {
+    const viewbox = document.getElementById("viewbox") as unknown as SVGGraphicsElement;
+    const p = new DOMPoint(x, y).matrixTransform(viewbox.getScreenCTM()!);
+    return Boolean(document.elementFromPoint(p.x, p.y)?.closest("#map"));
+  }, point);
+}
+
+async function openEditor(page: Page, buttonId: string, dialogId: string) {
+  await page.click("#optionsTrigger");
+  await page.click("#toolsTab");
+  await page.click(`#${buttonId}`);
+  await page.waitForSelector(`#${dialogId}`, {state: "visible", timeout: 5000});
+  await page.waitForTimeout(300);
+}
+
+const confirmButton = ".ui-dialog:has(#alert) .ui-dialog-buttonpane button:first-child";
+const cancelButton = ".ui-dialog:has(#alert) .ui-dialog-buttonpane button:last-child";
+
+test.describe("Annex by clicking on the map", () => {
+  test.beforeEach(async ({context, page}) => {
+    await context.clearCookies();
+    await page.goto("/");
+    await page.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+    await page.goto("/?seed=test-annex&width=1280&height=720");
+    await page.waitForFunction(() => (window as any).mapId !== undefined, {timeout: 60000});
+    await page.waitForTimeout(500);
+  });
+
+  async function pickTwoStates(page: Page) {
+    const candidates: {i: number; pole: [number, number]}[] = await page.evaluate(() =>
+      (window as any).pack.states
+        .filter((s: any) => s.i && !s.removed)
+        .map((s: any) => ({i: s.i, pole: (window as any).pack.cells.p[s.center]}))
+    );
+    const visible: {i: number; pole: [number, number]}[] = [];
+    for (const c of candidates) {
+      if (await isMapVisibleAt(page, c.pole)) visible.push(c);
+      if (visible.length === 2) break;
+    }
+    expect(visible.length).toBe(2);
+    return visible;
+  }
+
+  test("annexes a state into the first clicked state after confirmation", async ({page}) => {
+    await openEditor(page, "editStatesButton", "statesEditor");
+    const [parent, child] = await pickTwoStates(page);
+
+    await page.click("#statesAnnex");
+    await expect(page.locator("#statesAnnex")).toHaveClass(/pressed/);
+
+    await clickMapAt(page, parent.pole);
+    await clickMapAt(page, child.pole);
+
+    await page.waitForSelector(confirmButton, {state: "visible", timeout: 3000});
+    await expect(page.locator(".ui-dialog:has(#alert)")).toContainText("removed");
+    await page.click(confirmButton);
+    await page.waitForTimeout(300);
+
+    const result = await page.evaluate(
+      ([p, c]) => {
+        const {states, cells} = (window as any).pack;
+        let childCells = 0;
+        for (let i = 0; i < cells.state.length; i++) if (cells.state[i] === c) childCells++;
+        return {removed: Boolean(states[c].removed), parentAlive: !states[p].removed, childCells};
+      },
+      [parent.i, child.i]
+    );
+    expect(result).toEqual({removed: true, parentAlive: true, childCells: 0});
+    await expect(page.locator("#statesAnnex")).not.toHaveClass(/pressed/);
+    expect(await page.evaluate(() => (0, eval)("customization"))).toBe(0);
+  });
+
+  test("cancelling the confirmation leaves states untouched and clears the preview", async ({page}) => {
+    await openEditor(page, "editStatesButton", "statesEditor");
+    const [parent, child] = await pickTwoStates(page);
+
+    await page.click("#statesAnnex");
+    await clickMapAt(page, parent.pole);
+    await clickMapAt(page, child.pole);
+
+    await page.waitForSelector(cancelButton, {state: "visible", timeout: 3000});
+    await page.click(cancelButton);
+    await page.waitForTimeout(300);
+
+    const removed = await page.evaluate(c => Boolean((window as any).pack.states[c].removed), child.i);
+    expect(removed).toBe(false);
+    expect(await page.locator("#debug .annex-preview").count()).toBe(0);
+    await expect(page.locator("#statesAnnex")).not.toHaveClass(/pressed/);
+  });
+
+  test("shift keeps the mode open so several states can be staged", async ({page}) => {
+    await openEditor(page, "editStatesButton", "statesEditor");
+    const [parent, child] = await pickTwoStates(page);
+
+    await page.click("#statesAnnex");
+    await clickMapAt(page, parent.pole);
+    await page.keyboard.down("Shift");
+    await clickMapAt(page, child.pole);
+    await page.keyboard.up("Shift");
+
+    expect(await page.locator(".ui-dialog:has(#alert):visible").count()).toBe(0);
+    await expect(page.locator("#statesAnnex")).toHaveClass(/pressed/);
+    expect(await page.locator("#debug .annex-preview polygon").count()).toBeGreaterThan(0);
+
+    // pressing the button again ends the session and asks for confirmation
+    await page.click("#statesAnnex");
+    await page.waitForSelector(confirmButton, {state: "visible", timeout: 3000});
+    await page.click(cancelButton);
+  });
+
+  test("annexes a province into another province of the same state", async ({page}) => {
+    await openEditor(page, "editProvincesButton", "provincesEditor");
+
+    const candidates: {i: number; state: number; pole: [number, number]}[] = await page.evaluate(() =>
+      (window as any).pack.provinces
+        .filter((p: any) => p.i && !p.removed)
+        .map((p: any) => ({i: p.i, state: p.state, pole: (window as any).pack.cells.p[p.center]}))
+    );
+    let pair: typeof candidates | undefined;
+    for (const a of candidates) {
+      if (!(await isMapVisibleAt(page, a.pole))) continue;
+      for (const b of candidates) {
+        if (b.i === a.i || b.state !== a.state) continue;
+        if (await isMapVisibleAt(page, b.pole)) {
+          pair = [a, b];
+          break;
+        }
+      }
+      if (pair) break;
+    }
+    expect(pair).toBeDefined();
+    const [parent, child] = pair!;
+
+    await page.click("#provincesAnnex");
+    await clickMapAt(page, parent.pole);
+    await clickMapAt(page, child.pole);
+
+    await page.waitForSelector(confirmButton, {state: "visible", timeout: 3000});
+    await page.click(confirmButton);
+    await page.waitForTimeout(300);
+
+    const result = await page.evaluate(
+      ([p, c]) => {
+        const {provinces, cells} = (window as any).pack;
+        let childCells = 0;
+        for (let i = 0; i < cells.province.length; i++) if (cells.province[i] === c) childCells++;
+        return {removed: Boolean(provinces[c].removed), parentAlive: !provinces[p].removed, childCells};
+      },
+      [parent.i, child.i]
+    );
+    expect(result).toEqual({removed: true, parentAlive: true, childCells: 0});
+    await expect(page.locator("#provincesAnnex")).not.toHaveClass(/pressed/);
+  });
+
+  test("refuses to annex a province from a different state", async ({page}) => {
+    await openEditor(page, "editProvincesButton", "provincesEditor");
+
+    const candidates: {i: number; state: number; pole: [number, number]}[] = await page.evaluate(() =>
+      (window as any).pack.provinces
+        .filter((p: any) => p.i && !p.removed)
+        .map((p: any) => ({i: p.i, state: p.state, pole: (window as any).pack.cells.p[p.center]}))
+    );
+    let pair: typeof candidates | undefined;
+    for (const a of candidates) {
+      if (!(await isMapVisibleAt(page, a.pole))) continue;
+      const b = candidates.find(x => x.state !== a.state);
+      if (b && (await isMapVisibleAt(page, b.pole))) {
+        pair = [a, b];
+        break;
+      }
+    }
+    expect(pair).toBeDefined();
+    const [parent, foreign] = pair!;
+
+    await page.click("#provincesAnnex");
+    await clickMapAt(page, parent.pole);
+    await clickMapAt(page, foreign.pole);
+    await page.waitForTimeout(200);
+
+    expect(await page.locator(".ui-dialog:has(#alert):visible").count()).toBe(0);
+    await expect(page.locator("#provincesAnnex")).toHaveClass(/pressed/);
+    expect(await page.locator("#debug .annex-preview .annex-child").count()).toBe(0);
+    const removed = await page.evaluate(c => Boolean((window as any).pack.provinces[c].removed), foreign.i);
+    expect(removed).toBe(false);
+  });
+});

--- a/tests/e2e/annex-mode.spec.ts
+++ b/tests/e2e/annex-mode.spec.ts
@@ -69,8 +69,13 @@ test.describe("Annex by clicking on the map", () => {
 
     await page.waitForSelector(confirmButton, {state: "visible", timeout: 3000});
     await expect(page.locator(".ui-dialog:has(#alert)")).toContainText("removed");
+    const parentFill = await page.locator(`#statesBody #state${parent.i}`).getAttribute("d");
     await page.click(confirmButton);
     await page.waitForTimeout(300);
+
+    // the states layer is redrawn: the annexing state's fill now covers the annexed cells
+    expect(await page.locator(`#statesBody #state${parent.i}`).getAttribute("d")).not.toBe(parentFill);
+    expect(await page.locator(`#statesBody #state${child.i}`).count()).toBe(0);
 
     const result = await page.evaluate(
       ([p, c]) => {


### PR DESCRIPTION
Fixes #1659. Also covers the Trello card "Merge provinces with one tool".

## What

Both the States and Provinces editors get an **Annex** button (crown icon) beside Merge.

1. Press Annex, click the state or province that annexes the others on the map.
2. Click the ones it absorbs. Each staged entity is previewed in the parent's colour; clicking it again unstages it.
3. A plain click ends the session, **Shift** keeps it open for more. Pressing the button again also ends it.
4. Ending with staged entities opens the existing merge confirmation listing what will be removed. Cancel, closing the editor, or Escape discards the staging, so a mis-click is never applied.

Provinces refuse a pick from another state with a tip naming the state to pick from, matching the merge dialog's rule.

## How

- `src/components/annex-mode.ts` holds the mode. Each editor drives it with its own owner lookup, colour, name, optional reject rule and commit call.
- `mergeStates` moves out of the merge dialog to module scope and both merge confirmations are extracted, so the dialog and the annex mode share them. The large hunk in `states-editor.ts` is mostly `mergeStates` losing one indent level.
- Three identical copies of the animated red outline collapse into `highlightOutline` in `renderers/overlays/highlight.ts`.
- Wiki Knowledge Base entries for merging countries and provinces now lead with the annex flow and keep the list dialog as the alternative.

## Tests

`tests/e2e/annex-mode.spec.ts`: states annex with confirmation, cancel leaves data and preview untouched, Shift multi-stage, provinces annex, cross-state refusal. Existing states specs still pass.

## Follow-ups (not in this PR)

- #1465 "Merge State as Province" fits as an "annex as province" checkbox on the same confirmation.
- Cultures and religions have no merge operation at all; raised as idea #1779.

