### PR TITLE
fix: spurious "New version released" prompt when editing notes

### DIFF
--- a/src/controllers/notes-editor.ts
+++ b/src/controllers/notes-editor.ts
@@ -1,7 +1,7 @@
 import { confirmationDialog, destroyDialog } from "@/components/dialog/dialog-helpers";
 import { tip } from "@/components/tooltips";
 import { highlightElement } from "@/renderers/overlays/highlight";
-import { downloadFile, getFileName, speak, uploadFile } from "@/utils";
+import { downloadFile, getFileName, loadScript, speak, uploadFile } from "@/utils";
 import { ensureEl } from "../utils";
 
 interface Note {
@@ -104,26 +104,17 @@ function closeNotesEditor(): void {
   ensureEl("notesEditor").remove();
 }
 
+// A classic script, not import(): Vite reports a failed dynamic import as a missing chunk, which the
+// app shell answers with a reload prompt. The pre-init keeps TinyMCE from doubling ".min" onto its assets
 async function initEditor(): Promise<void> {
   if (!window.tinymce) {
-    const url = "https://azgaar.github.io/Fantasy-Map-Generator/libs/tinymce/tinymce.min.js";
-    try {
-      await import(/* @vite-ignore */ url);
-    } catch {
-      // error may be caused by failed request being cached, try again with random hash
-      try {
-        const hash = Math.random().toString(36).substring(2, 15);
-        await import(/* @vite-ignore */ `${url}#${hash}`);
-      } catch (error) {
-        console.error(error);
-      }
-    }
+    window.tinyMCEPreInit = { base: "libs/tinymce", suffix: "" };
+    await loadScript("libs/tinymce/tinymce.min.js").catch(console.error);
   }
 
   const tinymce = window.tinymce;
   if (!tinymce) return;
 
-  tinymce._setBaseUrl("https://azgaar.github.io/Fantasy-Map-Generator/libs/tinymce");
   tinymce.init({
     license_key: "gpl",
     selector: "#notesLegend",

--- a/src/services/io/cloud.ts
+++ b/src/services/io/cloud.ts
@@ -9,6 +9,7 @@
 
 import { tip } from "@/components/tooltips";
 import { isElectron } from "@/services/platform";
+import { loadScript } from "@/utils";
 
 export interface CloudFile {
   name: string;
@@ -49,17 +50,6 @@ const setRefreshToken = (provider: string, key: string) => localStorage.setItem(
 const getRefreshToken = (provider: string) => localStorage.getItem(`${lSKey(provider)}-refresh`);
 const setTokenExpiry = (provider: string, ts: number) => localStorage.setItem(`${lSKey(provider)}-expires`, String(ts));
 const getTokenExpiry = (provider: string) => Number(localStorage.getItem(`${lSKey(provider)}-expires`)) || undefined;
-
-// load a classic library bundle that registers a runtime global (e.g. window.Dropbox)
-function loadScript(src: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const script = document.createElement("script");
-    script.src = src;
-    script.onload = () => resolve();
-    script.onerror = () => reject(new Error(`Cannot load script ${src}`));
-    document.head.append(script);
-  });
-}
 
 const dropbox: DropboxProvider = {
   name: "dropbox",

--- a/src/services/io/export.ts
+++ b/src/services/io/export.ts
@@ -17,6 +17,7 @@ import {
   getCoordinates,
   getFileName,
   getFriendlyHeight,
+  loadScript,
   rn,
   unique
 } from "@/utils";
@@ -883,17 +884,6 @@ function saveGeoJsonZones(): void {
 
   const fileName = `${getFileName("Zones")}.geojson`;
   downloadFile(JSON.stringify(json), fileName, "application/json");
-}
-
-// load a classic library bundle that registers a runtime global (e.g. window.JSZip)
-function loadScript(src: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const script = document.createElement("script");
-    script.src = src;
-    script.onload = () => resolve();
-    script.onerror = () => reject(new Error(`Cannot load script ${src}`));
-    document.head.append(script);
-  });
 }
 
 // reached lazily via Services.ExportMap

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -148,9 +148,9 @@ declare global {
   var rn: (value: number, decimals?: number) => number;
   var openURL: (url: string) => void;
 
+  var tinyMCEPreInit: { base: string; suffix: string } | undefined;
   var tinymce:
     | {
-        _setBaseUrl: (url: string) => void;
         init: (config: Record<string, unknown>) => void;
         remove: () => void;
         activeEditor?: { getContent: () => string; setContent: (content: string) => void };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -25,7 +25,7 @@ import { drawCellsValue, drawPath, drawPoint, drawPolygons, drawRouteConnections
 import { downloadFile, getFileName, uploadFile } from "./fileUtils";
 import { distanceSquared, rollups } from "./functionUtils";
 import { isLand, isWater, SEA_LEVEL } from "./heightUtils";
-import { applyOption, ensureEl, findEl, getComposedPath, getNextId, getPointer } from "./nodeUtils";
+import { applyOption, ensureEl, findEl, getComposedPath, getNextId, getPointer, loadScript } from "./nodeUtils";
 import { connectVertices, findPath, getIsolines, getPolesOfInaccessibility, getVertexPath } from "./pathUtils";
 import { biased, each, gauss, generateSeed, getNumberInRange, P, Pint, ra, rand, rw } from "./probabilityUtils";
 import { findAllInQuadtree } from "./quadtree";
@@ -201,6 +201,7 @@ export {
   lim,
   link,
   list,
+  loadScript,
   minmax,
   normalize,
   nth,

--- a/src/utils/nodeUtils.ts
+++ b/src/utils/nodeUtils.ts
@@ -102,3 +102,14 @@ declare global {
     findEl: typeof findEl;
   }
 }
+
+// load a classic library bundle that registers a runtime global (e.g. window.JSZip)
+export function loadScript(src: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = src;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error(`Cannot load script ${src}`));
+    document.head.append(script);
+  });
+}

--- a/tests/e2e/notes-editor.spec.ts
+++ b/tests/e2e/notes-editor.spec.ts
@@ -1,0 +1,29 @@
+import {test, expect, type Page} from "@playwright/test";
+
+async function openNotesEditor(page: Page) {
+  await page.goto("/?seed=test-notes&width=1280&height=720");
+  await page.waitForFunction(() => (window as any).mapId !== undefined, {timeout: 60000});
+  await page.click("#optionsTrigger");
+  await page.click("#toolsTab");
+  await page.click("#editNotesButton");
+  await page.waitForSelector("#notesEditor", {state: "visible", timeout: 5000});
+}
+
+test.describe("Notes Editor", () => {
+  test("loads the rich-text editor from the bundled library", async ({page}) => {
+    await openNotesEditor(page);
+    await expect(page.locator("#notesEditor .tox-tinymce")).toBeVisible({timeout: 10000});
+  });
+
+  // The library is fetched at runtime and can fail (offline, blocked by the desktop CSP).
+  // That failure must not surface as the "new version released" reload prompt
+  test("opens as a plain editor without a reload prompt when the library cannot load", async ({page}) => {
+    await page.route("**/tinymce/tinymce.min.js*", route => route.abort());
+    await openNotesEditor(page);
+    await page.waitForTimeout(1500);
+
+    expect(await page.locator(".ui-dialog:has(#alert):visible").count()).toBe(0);
+    expect(await page.locator("#notesEditor .tox-tinymce").count()).toBe(0);
+    await expect(page.locator("#notesLegend")).not.toBeEmpty();
+  });
+});


### PR DESCRIPTION
Fixes #1660.

## Root cause

`vite build` wraps every dynamic `import()`, including the `/* @vite-ignore */` one the notes editor used to fetch TinyMCE from azgaar.github.io, in its preload helper. When that import fails the helper fires `vite:preloadError`, and `app-shell.ts` has answered that event with the "New version released" reload prompt since #1560. So the prompt appears whenever the TinyMCE fetch fails, not only after a release.

In the desktop app the fetch always fails: the CSP added in 1.149.0 allows scripts from the app itself only. Hence the prompt on every note, and the rich editor silently falling back to a plain textarea. On the web the same prompt shows whenever azgaar.github.io is unreachable.

## Fix

- TinyMCE already ships in `public/libs`. Load that copy with a classic `<script>` through the shared `loadScript` util, which `cloud.ts` and `export.ts` each carried a private copy of. A script tag failure stays local to the notes editor, and the desktop CSP allows it.
- Loaded from a script tag, TinyMCE 7 infers a `.min` suffix from its own file name and requests `theme.min.min.js`. Its `tinyMCEPreInit` hook sets the base and an empty suffix up front, replacing the old `_setBaseUrl` call. The retry-with-random-hash workaround only made sense for a cached module import and is gone.

## Tests

`tests/e2e/notes-editor.spec.ts`: one test aborts the TinyMCE request and asserts no reload prompt and a working plain editor (fails before this change), the other asserts the rich editor renders from the bundled copy. Note the first only exercises the bug on a built bundle, since the dev server does not wrap imports; the CI suite runs on a preview build.

Verified on the production web build. The packaged desktop app itself was not launched; its path differs only by the CSP the bundled copy now satisfies.
