### PR TITLE
fix: fit the label stroke width and letter spacing slider ranges to the group

### DIFF
--- a/public/modules/ui/style.js
+++ b/public/modules/ui/style.js
@@ -84,6 +84,27 @@ function getColor(value, scheme = getColorScheme("bright")) {
 // Toggle style sections on element select
 styleElementSelect.addEventListener("change", selectStyleElement);
 
+// label groups differ ~10x in font size, so the absolute sliders get a drag range fitted to the group;
+// values are stored unscaled and a stored value beyond the fitted range keeps the range wide enough
+const defaultRanges = {
+  strokeMax: styleStrokeWidthInput.getAttribute("max"),
+  spacingMin: styleLetterSpacingInput.getAttribute("min"),
+  spacingMax: styleLetterSpacingInput.getAttribute("max")
+};
+
+function fitLabelRanges(fontSize, attrs) {
+  const spacing = +attrs["letter-spacing"] || 0;
+  styleStrokeWidthInput.setAttribute("max", Math.max(rn(fontSize / 2, 2), +attrs["stroke-width"] || 0));
+  styleLetterSpacingInput.setAttribute("min", Math.min(-rn(fontSize / 10, 2), spacing));
+  styleLetterSpacingInput.setAttribute("max", Math.max(rn(fontSize / 2, 2), spacing));
+}
+
+function resetLabelRanges() {
+  styleStrokeWidthInput.setAttribute("max", defaultRanges.strokeMax);
+  styleLetterSpacingInput.setAttribute("min", defaultRanges.spacingMin);
+  styleLetterSpacingInput.setAttribute("max", defaultRanges.spacingMax);
+}
+
 // groups the editor addresses by name; everything else is styled as a whole
 const GROUPED_STYLE_ELEMENTS = ["anchors", "borders", "burgIcons", "coastline", "lakes", "labels", "routes", "terrs"];
 
@@ -95,6 +116,7 @@ function selectStyleElement() {
   const el = d3.select("#" + styleElement);
 
   styleElements.querySelectorAll("tbody").forEach(e => (e.style.display = "none")); // hide all sections
+  resetLabelRanges();
 
   // show alert line if layer is not visible
   const isLayerOff = styleElement !== "ocean" && (el.style("display") === "none" || !el.selectAll("*").size());
@@ -274,13 +296,15 @@ function selectStyleElement() {
     styleSize.style.display = "block";
     styleFillInput.value = styleFillOutput.value = attrs.fill || "#3e3e4b";
     styleStrokeInput.value = styleStrokeOutput.value = attrs.stroke || "#3a3a3a";
+    const fontSize = parseFloat(attrs["font-size"]) || 18;
+    fitLabelRanges(fontSize, attrs);
     styleStrokeWidthInput.value = attrs["stroke-width"] ?? 0;
     styleLetterSpacingInput.value = attrs["letter-spacing"] ?? 0;
     styleShadowInput.value = getTextShadow(attrs.style);
 
     styleFont.style.display = "block";
     styleSelectFont.value = attrs["font-family"];
-    styleFontSize.value = parseFloat(attrs["font-size"]) || 18;
+    styleFontSize.value = fontSize;
 
     styleFontShift.style.display = "block";
     const { dx, dy } = getLabelShift(attrs.style);
@@ -973,6 +997,7 @@ function changeFontSize(el, size) {
   if (styleElementSelect.value === "labels") {
     el.attr("font-size", `${size}%`).attr("data-size", null);
     if (groupStyle) groupStyle.attrs["font-size"] = `${size}%`;
+    fitLabelRanges(size, groupStyle?.attrs || {});
     return;
   }
 

--- a/src/components/slider-input.ts
+++ b/src/components/slider-input.ts
@@ -21,6 +21,8 @@ template.innerHTML = /* html */ `
 `;
 
 class SliderInput extends HTMLElement {
+  static observedAttributes = ["min", "max", "step"];
+
   constructor() {
     super();
     this.appendChild(template.content.cloneNode(true));
@@ -37,6 +39,11 @@ class SliderInput extends HTMLElement {
     number.addEventListener("input", this.handleEvent.bind(this));
     range.addEventListener("change", this.handleEvent.bind(this));
     number.addEventListener("change", this.handleEvent.bind(this));
+  }
+
+  attributeChangedCallback(name: string, _old: string | null, value: string | null) {
+    if (value === null) return;
+    for (const input of this.querySelectorAll<HTMLInputElement>("input")) input.setAttribute(name, value);
   }
 
   handleEvent(e: Event) {

--- a/src/index.html
+++ b/src/index.html
@@ -5179,7 +5179,7 @@
     <script defer src="modules/ui/style-presets.js?v=75cc6072"></script>
     <script defer src="modules/ui/options.js?v=d2008f94"></script>
     <script defer src="main.js?v=369ec61c"></script>
-    <script defer src="modules/ui/style.js?v=75385c7b"></script>
+    <script defer src="modules/ui/style.js?v=f3fba4a5"></script>
     <script defer src="libs/rgbquant.min.js"></script>
     <script defer src="libs/jquery.ui.touch-punch.min.js"></script>
   </body>

--- a/tests/e2e/style-label-ranges.spec.ts
+++ b/tests/e2e/style-label-ranges.spec.ts
@@ -1,0 +1,64 @@
+import {expect, test, type Page} from "@playwright/test";
+
+// Slider ranges as the editor shows them for a label group; values stay absolute, only the drag range follows the group
+async function openLabelGroup(page: Page, group: string) {
+  await page.evaluate(g => (window as any).editStyle("labels", g), group);
+  return page.evaluate(() => {
+    const range = (id: string) => {
+      const input = document.querySelector<HTMLInputElement>(`#${id} input[type=range]`)!;
+      return {min: +input.min, max: +input.max, value: +input.value};
+    };
+    return {
+      fontSize: +(document.getElementById("styleFontSize") as HTMLInputElement).value,
+      strokeWidth: range("styleStrokeWidthInput"),
+      letterSpacing: range("styleLetterSpacingInput")
+    };
+  });
+}
+
+test.describe("Style editor label slider ranges", () => {
+  test.beforeEach(async ({page}) => {
+    await page.goto("/?seed=test-style-ranges&width=1280&height=720");
+    await page.waitForFunction(() => (window as any).mapId !== undefined, {timeout: 60000});
+  });
+
+  test("stroke width and letter spacing ranges follow the group font size", async ({page}) => {
+    const river = await openLabelGroup(page, "river");
+    expect(river.fontSize).toBeLessThan(5);
+    expect(river.strokeWidth.max).toBeCloseTo(river.fontSize / 2, 2);
+    expect(river.letterSpacing.max).toBeCloseTo(river.fontSize / 2, 2);
+    expect(river.letterSpacing.min).toBeCloseTo(-river.fontSize / 10, 2);
+
+    const state = await openLabelGroup(page, "state");
+    expect(state.fontSize).toBeGreaterThan(9);
+    expect(state.strokeWidth.max).toBeCloseTo(state.fontSize / 2, 2);
+  });
+
+  test("changing the font size refits the ranges", async ({page}) => {
+    await openLabelGroup(page, "river");
+    await page.fill("#styleFontSize", "10");
+    await page.dispatchEvent("#styleFontSize", "change");
+    const max = await page.evaluate(
+      () => +document.querySelector<HTMLInputElement>("#styleStrokeWidthInput input[type=range]")!.max
+    );
+    expect(max).toBe(5);
+  });
+
+  test("a stored value beyond the fitted range stays reachable", async ({page}) => {
+    await page.evaluate(() => {
+      (window as any).styles.labels.groups.river.attrs["stroke-width"] = 4;
+    });
+    const river = await openLabelGroup(page, "river");
+    expect(river.strokeWidth.value).toBe(4);
+    expect(river.strokeWidth.max).toBeGreaterThanOrEqual(4);
+  });
+
+  test("other elements get the default ranges back", async ({page}) => {
+    await openLabelGroup(page, "river");
+    await page.evaluate(() => (window as any).editStyle("borders"));
+    const max = await page.evaluate(
+      () => +document.querySelector<HTMLInputElement>("#styleStrokeWidthInput input[type=range]")!.max
+    );
+    expect(max).toBe(10);
+  });
+});


### PR DESCRIPTION
Fixes #1592.

Follows the decision on the issue: values stay absolute, the slider's drag range follows the label group.

## Problem

Stroke width and letter spacing use one fixed range for every label group, while group font sizes run from 2 (river, route) to 22 (state). On a river label a single pixel of slider travel already exceeds the usable band, so the smallest nudge swamps the text.

## Change

- **Label groups**: the stroke width range ends at half the group's font size; letter spacing runs from a tenth below zero to half above. A stored value beyond the fitted range widens it so the value stays reachable. The number input still accepts anything.
- **Every other element** gets the ranges declared in `index.html` back, read once at load rather than duplicated.
- **Font size edits** (input, plus, minus) refit the ranges live.
- `slider-input` now observes `min`, `max` and `step`; it previously read them once in the constructor, so nothing could change them after mount.

Text shadow is a free-text CSS field, not a slider, so it is unchanged.

## Tests

`tests/e2e/style-label-ranges.spec.ts`: ranges follow the group, refit on font size change, stored value stays reachable, defaults return for other elements. The existing style editor event and persistence specs pass unchanged.
