### PR TITLE
fix: validate the stored label and burg group registries

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -55,9 +55,9 @@ let options = {
   prec: 100, // precipitation modifier in %
   showBurgPreview: true,
   burgs: {
-    groups: JSON.safeParse(localStorage.getItem("burg-groups")) || Burgs.getDefaultGroups()
+    groups: Burgs.parseStoredGroups(localStorage.getItem("burg-groups"))
   },
-  labels: JSON.safeParse(localStorage.getItem("options-labels")) || Labels.getDefaultOptions(),
+  labels: Labels.parseStoredOptions(localStorage.getItem("options-labels")),
   emblems: { showAll: false },
   trade: {
     animation: JSON.safeParse(localStorage.getItem("trade-animation")) || TradeAnimation.getDefaultOptions()

--- a/public/modules/ui/options.js
+++ b/public/modules/ui/options.js
@@ -602,8 +602,8 @@ function randomizeOptions() {
 
   // a loaded map's migrated group registries are map data, not session preferences: re-seed
   // from the same source boot uses, so new maps get the user's saved groups or the defaults
-  options.burgs.groups = JSON.safeParse(localStorage.getItem("burg-groups")) || Burgs.getDefaultGroups();
-  options.labels = JSON.safeParse(localStorage.getItem("options-labels")) || Labels.getDefaultOptions();
+  options.burgs.groups = Burgs.parseStoredGroups(localStorage.getItem("burg-groups"));
+  options.labels = Labels.parseStoredOptions(localStorage.getItem("options-labels"));
 
   // 'Options' settings
   if (randomize || !stored("points")) changeCellsDensity(4); // reset to default, no need to randomize

--- a/src/generators/burgs-generator.test.ts
+++ b/src/generators/burgs-generator.test.ts
@@ -446,3 +446,34 @@ describe("ensureBurgGroupStyles", () => {
     expect(anchors.groups.fortresses).toEqual(townAnchor);
   });
 });
+
+describe("BurgsModule.parseStoredGroups", () => {
+  let Burgs: any;
+
+  beforeEach(async () => {
+    globalThis.TIME = false;
+    globalThis.window = globalThis.window || ({} as any);
+    await import("./burgs-generator");
+    Burgs = (globalThis as any).Burgs;
+  });
+
+  it("falls back to the defaults when the stored value holds no usable group", () => {
+    const defaults = Burgs.getDefaultGroups();
+    expect(Burgs.parseStoredGroups(null)).toEqual(defaults);
+    expect(Burgs.parseStoredGroups("[]")).toEqual(defaults);
+    expect(Burgs.parseStoredGroups("not json")).toEqual(defaults);
+    expect(Burgs.parseStoredGroups(JSON.stringify([{ order: 1 }]))).toEqual(defaults);
+  });
+
+  it("keeps usable stored groups and drops the rest", () => {
+    const usable = { name: "outpost", order: 3 };
+    const stored = JSON.stringify([usable, { order: 4 }, { name: "noOrder" }]);
+    const groups = Burgs.parseStoredGroups(stored);
+    expect(groups.map((group: any) => group.name)).toEqual(["outpost"]);
+  });
+
+  it("always leaves a default group for burg assignment to fall back on", () => {
+    const groups = Burgs.parseStoredGroups(JSON.stringify([{ name: "outpost", order: 3 }]));
+    expect(groups.filter((group: any) => group.isDefault).length).toBe(1);
+  });
+});

--- a/src/generators/burgs-generator.ts
+++ b/src/generators/burgs-generator.ts
@@ -2,6 +2,7 @@ import { quadtree } from "d3-quadtree";
 import { Emblems } from "@/generators/emblems-generator";
 import type { BurgGroup } from "@/types/burg-groups";
 import type { Emblem } from "@/types/emblems";
+import { safeParseJSON } from "@/utils/stringUtils";
 import { each, ensureEl, gauss, minmax, normalize, P, rn } from "../utils";
 import { type CultureType, DEFAULT_CULTURE_TYPE } from "./cultures-generator";
 import { NON_NAVIGABLE_LAKE_GROUPS } from "./features";
@@ -395,6 +396,19 @@ class BurgModule {
     burg.temple = Number(
       (religion && theocracy && P(0.5)) || pop > 50 || (pop > 35 && P(0.75)) || (pop > 20 && P(0.5))
     );
+  }
+
+  /** burg assignment needs a named, ordered group and a default to fall back on: a value persisted
+   * by an older build can satisfy neither and still parse */
+  parseStoredGroups(stored: string | null): BurgGroup[] {
+    const parsed = stored ? safeParseJSON(stored) : null;
+    const groups: BurgGroup[] = Array.isArray(parsed)
+      ? parsed.filter(group => typeof group?.name === "string" && typeof group?.order === "number")
+      : [];
+    if (!groups.length) return this.getDefaultGroups();
+
+    if (!groups.some(group => group.isDefault)) groups[0].isDefault = true;
+    return groups;
   }
 
   getDefaultGroups(): BurgGroup[] {

--- a/src/generators/labels-generator.test.ts
+++ b/src/generators/labels-generator.test.ts
@@ -1,5 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
+import { LABEL_TYPES } from "./labels-generator";
+
 let LabelsModule: typeof import("./labels-generator").LabelsModule;
 let labels: import("./labels-generator").LabelsModule;
 
@@ -78,5 +80,46 @@ describe("ensureBurgLabelGroups", () => {
     const count = options.labels.groups.length;
     labels.ensureBurgLabelGroups();
     expect(options.labels.groups.length).toBe(count);
+  });
+});
+
+describe("parseStoredOptions", () => {
+  it("restores label types whose groups are missing from the stored value", () => {
+    const stored = JSON.stringify({ resizeOnZoom: true, showAll: false, groups: [] });
+    const parsed = labels.parseStoredOptions(stored);
+    for (const type of LABEL_TYPES) {
+      expect(parsed.groups.some(group => group.type === type)).toBe(true);
+    }
+  });
+
+  it("keeps stored groups the renderer can use", () => {
+    const custom = { name: "outpost", type: "burg", zoom: { min: 3, max: 40 } };
+    const parsed = labels.parseStoredOptions(JSON.stringify({ groups: [custom] }));
+    expect(parsed.groups).toContainEqual(custom);
+  });
+
+  it("drops groups that are missing a name, a known type or zoom bounds", () => {
+    const groups = [
+      { type: "burg", zoom: { min: 1, max: 2 } },
+      { name: "ghost", type: "spaceship", zoom: { min: 1, max: 2 } },
+      { name: "noZoom", type: "burg" }
+    ];
+    const parsed = labels.parseStoredOptions(JSON.stringify({ groups }));
+    const names = parsed.groups.map(group => group.name);
+    expect(names.includes("ghost")).toBe(false);
+    expect(names.includes("noZoom")).toBe(false);
+  });
+
+  it("falls back to the defaults when the stored value is absent or unusable", () => {
+    const defaults = labels.getDefaultOptions();
+    expect(labels.parseStoredOptions(null)).toEqual(defaults);
+    expect(labels.parseStoredOptions("not json")).toEqual(defaults);
+    expect(labels.parseStoredOptions("[1,2,3]")).toEqual(defaults);
+  });
+
+  it("keeps stored flags but repairs ones of the wrong type", () => {
+    const parsed = labels.parseStoredOptions(JSON.stringify({ resizeOnZoom: false, showAll: "yes" }));
+    expect(parsed.resizeOnZoom).toBe(false);
+    expect(parsed.showAll).toBe(labels.getDefaultOptions().showAll);
   });
 });

--- a/src/generators/labels-generator.ts
+++ b/src/generators/labels-generator.ts
@@ -1,5 +1,6 @@
 import type { LayerId } from "@/components/layers";
 import type { Point } from "@/types/global";
+import { safeParseJSON } from "@/utils/stringUtils";
 
 export const LABEL_TYPES = ["state", "province", "burg", "river", "route", "added"] as const;
 
@@ -131,6 +132,29 @@ export class LabelsModule {
       resizeOnZoom: true,
       showAll: false,
       groups: this.getDefaultGroups()
+    };
+  }
+
+  /** a value persisted by an older build can be structurally valid and still leave the renderer with
+   * nothing to draw, so drop groups it cannot use and restore any type left without one */
+  parseStoredOptions(stored: string | null) {
+    const defaults = this.getDefaultOptions();
+    const parsed = stored ? safeParseJSON(stored) : null;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return defaults;
+
+    const isUsable = (group: LabelGroup) =>
+      Boolean(group?.name) && (LABEL_TYPES as readonly string[]).includes(group?.type) && Boolean(group?.zoom);
+    const groups: LabelGroup[] = Array.isArray(parsed.groups) ? parsed.groups.filter(isUsable) : [];
+    for (const type of LABEL_TYPES) {
+      if (groups.some(group => group.type === type)) continue;
+      groups.push(...defaults.groups.filter(group => group.type === type));
+    }
+
+    const flag = (value: unknown, fallback: boolean) => (typeof value === "boolean" ? value : fallback);
+    return {
+      resizeOnZoom: flag(parsed.resizeOnZoom, defaults.resizeOnZoom),
+      showAll: flag(parsed.showAll, defaults.showAll),
+      groups
     };
   }
 

--- a/src/index.html
+++ b/src/index.html
@@ -5177,8 +5177,8 @@
     <script defer src="libs/polylabel.min.js?v1.105.0"></script>
     <script defer src="libs/simplify.js?v1.105.6"></script>
     <script defer src="modules/ui/style-presets.js?v=75cc6072"></script>
-    <script defer src="modules/ui/options.js?v=d2008f94"></script>
-    <script defer src="main.js?v=369ec61c"></script>
+    <script defer src="modules/ui/options.js?v=d54a07a0"></script>
+    <script defer src="main.js?v=f3989db8"></script>
     <script defer src="modules/ui/style.js?v=75385c7b"></script>
     <script defer src="libs/rgbquant.min.js"></script>
     <script defer src="libs/jquery.ui.touch-punch.min.js"></script>

--- a/tests/e2e/stored-options.spec.ts
+++ b/tests/e2e/stored-options.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test";
+
+// a value written by an older build can be structurally valid and still leave the renderer with
+// nothing to draw; it is read on boot and again in randomizeOptions, so both sites have to validate
+const STALE = {
+  "options-labels": '{"resizeOnZoom":true,"showAll":false,"groups":[]}',
+  "burg-groups": "[]"
+};
+
+async function generateMap(page: import("@playwright/test").Page) {
+  await page.goto("/");
+  await page.waitForSelector("#mapToLoad", { state: "attached", timeout: 60000 });
+  await page.waitForFunction(() => (window as any).mapId !== undefined, { timeout: 120000 });
+  await page.waitForTimeout(1000);
+
+  return page.evaluate(() => {
+    const labels = document.getElementById("labels");
+    return {
+      groups: labels?.children.length ?? 0,
+      labelTexts: labels?.querySelectorAll("text").length ?? 0,
+      // `options` is a global binding from main.js, not a window property
+      labelGroups: (0, eval)("options.labels.groups.length"),
+      burgGroups: (0, eval)("options.burgs.groups.length")
+    };
+  });
+}
+
+test("a stale stored group registry does not leave a new map without labels", async ({ page }) => {
+  await page.goto("/");
+  await page.evaluate(stale => {
+    localStorage.clear();
+    for (const [key, value] of Object.entries(stale)) localStorage.setItem(key, value);
+  }, STALE);
+
+  const { groups, labelTexts, labelGroups, burgGroups } = await generateMap(page);
+
+  expect(labelGroups).toBeGreaterThan(0);
+  expect(burgGroups).toBeGreaterThan(0);
+  expect(groups).toBeGreaterThan(0);
+  expect(labelTexts).toBeGreaterThan(0);
+});


### PR DESCRIPTION
Closes #1771.

`options.labels` and `options.burgs.groups` are seeded straight from `localStorage` with no
validation. A value written by an older build can be structurally valid and still leave the renderer
with nothing to draw, and because it is re-read for every new map, it keeps doing so until the user
clears site data. Reported on Discord as a corrupt `.map` file; the file was fine.

The stored value that caused it:

```json
{"resizeOnZoom": true, "showAll": false, "groups": []}
```

Every key present, every type correct, zero labels on every new map.

### What this changes

`Labels.parseStoredOptions` and `Burgs.parseStoredGroups` now own the parse. They drop entries the
renderer cannot use, restore any label type left without a group, keep a default burg group for
assignment to fall back on, and fall back to the defaults when the stored value is unusable.

Both keys are read in **two** places — once at boot in `public/main.js` and again in
`randomizeOptions()` in `public/modules/ui/options.js`. Fixing only the boot site passes every unit
test and still leaves the browser broken; both now go through the validating parse.

### Why presence checks are not enough

`options.labels ??= Labels.getDefaultOptions()` in `load.ts` is a presence check, and it passes the
value above straight through. Nothing is missing — `groups` is simply empty. Catching this needs
invariant checks: every label type has a group, every burg group has a name and an order, and one of
them is the default. That distinction matters for the planned unified options json, where
"fill in the gaps" as a strategy would ship with this hole still open.

It also raises the stakes. Today a bad `options-labels` costs you labels. One blob covering every
option domain means one bad value can take out all of them at once — and since that blob is stored
in the `.map` file as well as `localStorage`, it starts travelling inside save files rather than
staying in one browser. Validation wants to land with the unification, not after it. Same class as
the persisted `threeD.isOn` crash from the #1666 review.

### Tests

- `src/generators/labels-generator.test.ts` — restoring missing types, keeping usable stored groups,
  dropping malformed ones, falling back on garbage, repairing flags of the wrong type
- `src/generators/burgs-generator.test.ts` — falling back when no group is usable, dropping unusable
  entries, always leaving a default group
- `tests/e2e/stored-options.spec.ts` — plants the stale value, generates a map, asserts labels are
  drawn. Verified to fail without the `public/` changes and pass with them; the unit tests alone
  passed while the second read site was still broken.

`npm test` 568 passing, `tsc --noEmit` clean, `biome check` clean.
