### PR TITLE
docs: document the label group Mode setting for state names

### DIFF
--- a/docs/wiki/Knowledge Base.md
+++ b/docs/wiki/Knowledge Base.md
@@ -32,6 +32,10 @@ To get a blank map go Tools -> Heightmap -> Erase and use the brushes on the top
 
 Labels are shown and hidden based on zoom bounds defined per label group. Open Tools -> Labels and click on the groups configuration button. There you can check 'Show all labels' to ignore zoom bounds completely, or raise the max zoom value for a specific group
 
+### How do I force state labels to show the full state name?
+
+The name form is set per label group and no longer in Options, where it used to be the 'stateLabelsMode' setting. Open Tools -> Labels, click on the groups configuration button and set the state group's 'Mode' to 'full'. The default 'auto' uses the full name when it fits the state's area well enough and switches to the short name when it does not, while 'short' always uses the short name. Mode applies to state and province groups only
+
 ### How do I import an image? Can I put an image to create world based on it?
 
 Yes, it can be done via the Image Converter. Go to Tools -> Heightmap -> Erase -> Image converter


### PR DESCRIPTION
# Description

The Configure Label Groups dialog has a per-group `Mode` column (`auto`/`short`/`full`) that decides whether a state or province label shows the short or the full name, but nothing in the wiki mentions it. Users who remember the old global `stateLabelsMode` option look for it in Options, do not find it, and the nearest documented label-group setting — 'Show all labels' — is about zoom visibility, not the name form. The two get conflated.

This adds one Knowledge Base entry, next to the existing zoom-visibility one, covering where the setting moved to, what each mode does, and that it applies to state and province groups only.

Documented behaviour verified against `src/controllers/labels-group-editor.ts` (the three modes, `isModeApplicable` limiting it to state and province), `src/renderers/labels/fit-state-label.ts` (`full` forces the full name, `auto` falls back by fitted font size), and `src/services/io/auto-update.ts` / `src/services/io/load.ts` (the migration from `options.stateLabelsMode` to per-group `mode`).

Docs only — no code, no behaviour change, so no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
