### PR TITLE
fix: keep the zones type filter applied while the editor dialog is closed

### DIFF
--- a/src/controllers/zones-editor.ts
+++ b/src/controllers/zones-editor.ts
@@ -1,7 +1,6 @@
 import { select, sum } from "d3";
 import { closeDialogs, confirmationDialog, destroyDialog, updateDialog } from "@/components/dialog/dialog-helpers";
 import { applyLineHighlighting } from "@/components/dialog/highlighting";
-import { dialogState } from "@/components/dialog/state";
 import {
   type EditorColumn,
   initColumnVisibility,
@@ -16,13 +15,13 @@ import { tip } from "@/components/tooltips";
 import { Controllers } from "@/controllers";
 import type { Zone } from "@/generators/zones-generator";
 import { clearLegend, drawLegend } from "@/renderers/draw-legend";
+import { zonesFilter } from "@/renderers/draw-zones";
 import { fog, unfog } from "@/renderers/overlays/fogging";
 import { downloadFile, getArea, getAreaUnit, getFileName } from "@/utils";
 import { ensureEl, rn, si, unique } from "../utils";
 
 const dialogId = "zonesEditor" as const;
 const position = { my: "right top", at: "right-10 top+10", of: "svg", collision: "fit" };
-let filterState: { type: string };
 
 type ZoneRow = { zone: Zone; area: number; rural: number; urban: number; population: number };
 const columns: EditorColumn<ZoneRow>[] = [
@@ -36,7 +35,6 @@ const columns: EditorColumn<ZoneRow>[] = [
 const zonesTable = initEditorTable<ZoneRow>({ getData: getZonesData, onUpdate: renderZonesPage });
 
 function open(): void {
-  filterState = dialogState.get(dialogId, "filters", () => ({ type: "all" }));
   closeDialogs("#zonesEditor, .stable");
   Layers.show("zones");
 
@@ -157,18 +155,21 @@ function closeZonesEditor(): void {
 function updateFilters(): void {
   const filterSelect = ensureEl<HTMLSelectElement>("zonesFilterType");
   const types = unique(pack.zones.map(zone => zone.type));
-  if (!types.includes(filterState.type)) filterState.type = "all";
+  if (!types.includes(zonesFilter.type)) {
+    zonesFilter.type = "all";
+    Layers.draw("zones"); // the filtered-out type is gone, the map must stop hiding zones
+  }
 
   filterSelect.innerHTML = `<option value='all'>all</option>${types
     .map(type => `<option value="${type}">${type}</option>`)
     .join("")}`;
-  filterSelect.value = filterState.type;
-  dialogState.set(dialogId, "filters", filterState);
+  filterSelect.value = zonesFilter.type;
 }
 
 // add line for each zone
 function getZonesData(): ZoneRow[] {
-  const zones = filterState.type === "all" ? pack.zones : pack.zones.filter(zone => zone.type === filterState.type);
+  const filterBy = zonesFilter.type;
+  const zones = filterBy === "all" ? pack.zones : pack.zones.filter(zone => zone.type === filterBy);
   return zones.map(zone => {
     const area = getArea(sum(zone.cells.map(cell => pack.cells.area[cell])));
     const rural = sum(zone.cells.map(cell => pack.cells.pop[cell])) * populationRate;
@@ -234,8 +235,7 @@ function zoneHighlightOff(this: HTMLElement): void {
 }
 
 function filterZonesByType(): void {
-  filterState.type = ensureEl<HTMLSelectElement>("zonesFilterType").value;
-  dialogState.set(dialogId, "filters", filterState);
+  zonesFilter.type = ensureEl<HTMLSelectElement>("zonesFilterType").value;
   Layers.draw("zones");
   zonesTable.reset();
 }
@@ -336,8 +336,8 @@ function toggleLegend(): void {
     return;
   } // hide legend
 
-  const filterBy = filterState.type;
-  const isFiltered = filterBy && filterBy !== "all";
+  const filterBy = zonesFilter.type;
+  const isFiltered = filterBy !== "all";
   const visibleZones = pack.zones.filter(zone => !zone.hidden && (!isFiltered || zone.type === filterBy));
   const data = visibleZones.map(({ i, name, color }) => [`zone${i}`, color, name]);
   drawLegend("Zones", data);

--- a/src/renderers/draw-zones.test.ts
+++ b/src/renderers/draw-zones.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import { drawZones, zonesFilter } from "./draw-zones";
+
+// neighbours kept inside each zone so getVertexPath finds no border and returns an empty path
+const neighbours = [[], [2], [1], [4], [3], [6], [5], [8], [7]];
+
+beforeEach(() => {
+  document.body.innerHTML = /* html */ `<svg><g id="zones"></g></svg>`;
+  globalThis.pack = {
+    cells: { c: neighbours },
+    zones: [
+      { i: 0, name: "Invasion of Yl", type: "Invasion", color: "#ff0000", cells: [1, 2] },
+      { i: 1, name: "Invasion of Ea", type: "Invasion", color: "#ff0000", cells: [3, 4] },
+      { i: 2, name: "Rebels", type: "Rebels", color: "#00ff00", cells: [5, 6] },
+      { i: 3, name: "Plague", type: "Disease", color: "#0000ff", cells: [7, 8], hidden: true },
+      { i: 4, name: "Empty", type: "Flood", color: "#ffff00", cells: [] }
+    ]
+  } as unknown as typeof globalThis.pack;
+  zonesFilter.type = "all";
+});
+
+const drawnIds = () => Array.from(document.querySelectorAll("#zones path"), path => path.getAttribute("data-id"));
+
+describe("drawZones", () => {
+  it("draws every zone that is neither hidden nor empty", () => {
+    drawZones();
+
+    expect(drawnIds()).toEqual(["0", "1", "2"]);
+  });
+
+  it("draws only zones of the selected type", () => {
+    zonesFilter.type = "Invasion";
+
+    drawZones();
+
+    expect(drawnIds()).toEqual(["0", "1"]);
+  });
+
+  // #1810: the paint editor destroys the dialog holding the filter select
+  it("keeps filtering while the zones editor dialog is absent", () => {
+    zonesFilter.type = "Rebels";
+    expect(document.getElementById("zonesFilterType")).toBeNull();
+
+    drawZones();
+
+    expect(drawnIds()).toEqual(["2"]);
+  });
+
+  it("still excludes a hidden zone whose type is selected", () => {
+    zonesFilter.type = "Disease";
+
+    drawZones();
+
+    expect(drawnIds()).toEqual([]);
+  });
+});

--- a/src/renderers/draw-zones.ts
+++ b/src/renderers/draw-zones.ts
@@ -1,9 +1,12 @@
 import type { Zone } from "@/generators/zones-generator";
-import { ensureEl, findEl, getVertexPath } from "@/utils";
+import { ensureEl, getVertexPath } from "@/utils";
+
+// not read off the editor's select: the paint editor destroys that dialog mid-redraw (#1810)
+export const zonesFilter = { type: "all" };
 
 export function drawZones(): void {
-  const filterBy = findEl<HTMLSelectElement>("zonesFilterType")?.value;
-  const isFiltered = filterBy && filterBy !== "all";
+  const { type: filterBy } = zonesFilter;
+  const isFiltered = filterBy !== "all";
   const visibleZones = pack.zones.filter(
     ({ hidden, cells, type }) => !hidden && cells.length && (!isFiltered || type === filterBy)
   );

--- a/src/services/io/load.ts
+++ b/src/services/io/load.ts
@@ -6,6 +6,7 @@ import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { GraphOverride } from "@/generators/graph-override";
 import { invalidateEmblems } from "@/renderers/draw-emblems";
 import { clearLegend } from "@/renderers/draw-legend";
+import { zonesFilter } from "@/renderers/draw-zones";
 import { Services } from "@/services";
 import { declareFont } from "@/services/fonts";
 import { clearCache, compareVersions, isValidVersion, parseMapVersion, VERSION } from "@/services/versioning";
@@ -332,6 +333,7 @@ async function parseLoadedData(data: string[], mapVersion: string | null): Promi
     select("#map").remove();
     document.body.insertAdjacentHTML("afterbegin", data[5]);
     invalidateEmblems(); // the viewport scene belongs to the map that was just dropped
+    zonesFilter.type = "all"; // the dropped map's zone types say nothing about the loaded one
 
     // TODO: check if we need it or if LayersRegistry resolves it automatically?
     const viewbox = select("#viewbox");


### PR DESCRIPTION
Fixes #1810.

## The bug

`drawZones` read the filter straight off `#zonesFilterType` — the `<select>` that lives inside the zones editor dialog:

```js
const filterBy = findEl<HTMLSelectElement>("zonesFilterType")?.value;
```

The paint editor closes its parent dialog on open (`paint-editor.ts`), and the zones editor's close handler destroys **and removes** the element. `onApply` runs before `close(onClose)` reopens it, so `applyZonePaint`'s `Layers.draw("zones")` lands in the window where the select does not exist: `isFiltered` is falsy and every zone is drawn. The editor then reopens with the filter intact, which is why the dialog looks correct and only the map is wrong.

It is easy to miss because it self-heals — any later redraw (a zoom, a pan, a layer toggle) happens while the dialog exists again and restores the filtered view.

## Two more symptoms, same cause

Verified in the browser on `master`, filter set to `Invasion` (2 of 12 zones matching):

| | filtered | actually drawn |
|---|---|---|
| filter set, editor open | 2 | 2 |
| close the editor, any redraw | 2 | **12** |
| layer off → reopen editor (filter restored from storage) | 2 | **12** |

The last one has nothing to do with painting: the select reads `Invasion` and the table shows 2 rows while the map draws all 12.

## The fix

Hold the filter in the renderer rather than reading it back out of the DOM:

```js
export const zonesFilter = {type: "all"};
```

The editor writes to it, and `getZonesData` / `toggleLegend` already used the same state the table does — `drawZones` was the only place reaching into the dialog. All three symptoms go away, and no renderer depends on an editor's DOM any more.

## Behaviour change worth flagging

The zones filter is no longer persisted through `dialogState`, and is reset on map load. Previously a stored filter could come back on a freshly loaded map and hide zones with no editor open to explain why (the third row above). This does make zones the only editor whose filter does not survive a reload — happy to restore persistence if you would rather keep it consistent with the other editors, but a *map* filter that silently hides data seemed worse than a forgotten one.

## Testing

- New `src/renderers/draw-zones.test.ts` — 4 tests, including a regression test asserting the filter still applies while the dialog is absent. Mutation-checked: restoring the old DOM read fails 3 of them.
- `tsc --noEmit` clean, 648 unit tests pass, `biome ci` clean.
- e2e `zones-export.spec.ts` and `layers.spec.ts` — 34 passed.
- Manually verified in the browser: the #1810 repro, both sibling symptoms, and save-map → load-it-back (filter comes back as `all`).
