### PR TITLE
Fill the dev board's field values automatically

### DIFF
--- a/.github/workflows/board-reconcile.yml
+++ b/.github/workflows/board-reconcile.yml
@@ -1,0 +1,36 @@
+name: Dev board reconcile
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Plan only, write nothing"
+        type: boolean
+        default: true
+  issues:
+    types: [opened, edited, labeled, unlabeled, reopened]
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: board-reconcile
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+      - name: Reconcile
+        env:
+          PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run && '1' || '' }}
+        run: node scripts/board-reconcile.mjs

--- a/.github/workflows/board-reconcile.yml
+++ b/.github/workflows/board-reconcile.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
   contents: read
 
 concurrency:

--- a/.github/workflows/theme-label.yml
+++ b/.github/workflows/theme-label.yml
@@ -15,63 +15,18 @@ jobs:
   theme:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v5
       - uses: actions/github-script@v7
         with:
           script: |
-            const DROPDOWN = {
-              "States / Provinces / Diplomacy": "theme: states-diplomacy",
-              "Import / Export / Save": "theme: import-export",
-              "UI / Editors": "theme: ui-editors",
-              "Cultures / Religions / Society": "theme: cultures-society",
-              "Burgs & Population": "theme: burgs-population",
-              "Labels & Styling": "theme: labels-styling",
-              "Climate / Biomes / Terrain": "theme: climate-terrain",
-              "Markers / Notes / Zones": "theme: markers-zones",
-              "Military": "theme: military",
-              "Rivers / Lakes / Coast": "theme: rivers-water",
-              "Integrations & External": "theme: integrations",
-              "Architecture / Performance": "theme: architecture",
-              "Routes & Roads": "theme: routes"
-            };
-            const KEYWORDS = {
-              "theme: states-diplomacy": ["state", "states", "province", "provinces", "diplomacy", "war", "alliance", "country", "nation", "border", "annex", "vassal", "empire", "kingdom", "realm", "territory"],
-              "theme: import-export": ["export", "import", "save", "load", "backup", "geojson", "json", "download", "upload", "dropbox", "file"],
-              "theme: ui-editors": ["editor", "ui", "dialog", "menu", "button", "window", "panel", "hotkey", "shortcut", "interface", "tooltip", "overview", "filter", "brush", "paint", "undo", "drag"],
-              "theme: cultures-society": ["culture", "cultures", "religion", "religions", "race", "species", "language", "namebase", "namesbase", "society", "folk", "deity", "government"],
-              "theme: burgs-population": ["burg", "burgs", "city", "cities", "town", "towns", "population", "settlement", "village", "urban", "port"],
-              "theme: labels-styling": ["label", "labels", "font", "style", "color", "colour", "texture", "legend", "emblem", "coa", "heraldry", "opacity", "stroke", "preset"],
-              "theme: climate-terrain": ["climate", "biome", "biomes", "temperature", "precipitation", "heightmap", "terrain", "elevation", "height", "relief", "mountain", "wind", "erosion", "latitude"],
-              "theme: markers-zones": ["marker", "markers", "note", "notes", "zone", "zones", "icon", "pin", "annotation"],
-              "theme: military": ["military", "regiment", "regiments", "army", "unit", "units", "troop", "battle", "garrison"],
-              "theme: rivers-water": ["river", "rivers", "lake", "lakes", "coast", "ocean", "sea", "island", "shore", "delta"],
-              "theme: integrations": ["api", "integration", "foundry", "roll20", "plugin", "discord", "watabou", "armoria", "android", "vtt", "translation", "localization"],
-              "theme: architecture": ["performance", "refactor", "codebase", "typescript", "memory", "optimize", "bundle", "browser", "wasm", "pwa", "offline", "architecture", "vite"],
-              "theme: routes": ["route", "routes", "road", "roads", "path", "trail", "bridge"]
-            };
+            const { classifyTheme } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/theme-classify.mjs`);
 
             const isDiscussion = !!context.payload.discussion;
             const target = context.payload.discussion || context.payload.issue;
             const existing = (target.labels || []).map(l => (typeof l === "string" ? l : l.name));
             if (existing.some(l => l.startsWith("theme:"))) return;
 
-            let label = null;
-            const m = (target.body || "").match(/###\s*Theme\s*\n+\s*(.+)/i);
-            if (m) label = DROPDOWN[m[1].trim()] || null;
-
-            if (!label) {
-              const words = s => (s || "").toLowerCase().match(/[a-z]{2,}/g) || [];
-              const title = new Set(words(target.title));
-              const body = new Set(words(target.body).slice(0, 250));
-              let best = 0;
-              for (const [lbl, kws] of Object.entries(KEYWORDS)) {
-                let score = 0;
-                for (const k of kws) score += (title.has(k) ? 3 : 0) + (body.has(k) ? 1 : 0);
-                if (score > best) { best = score; label = lbl; }
-              }
-              if (best < 3) label = null; // require a title hit or several body hits
-            }
-
-            const apply = label || "needs-theme";
+            const apply = classifyTheme(target.title, target.body);
             if (isDiscussion) {
               const q = await github.graphql(
                 `query($owner:String!,$repo:String!,$name:String!){repository(owner:$owner,name:$repo){label(name:$name){id}}}`,

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Run Unit tests
         run: npm run test
+
+      - name: Run script tests
+        run: npm run test:scripts

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "electron": "node scripts/electron.mjs",
     "test": "vitest",
     "test:e2e": "playwright test",
+    "test:scripts": "node --test scripts/*.test.mjs",
     "lint": "biome check --write",
     "sync-version": "node scripts/sync-version.js",
     "stamp-assets": "node scripts/stamp-assets.js",

--- a/scripts/board-fields.mjs
+++ b/scripts/board-fields.mjs
@@ -1,0 +1,57 @@
+export const PROJECT_ID = "PVT_kwHOAZPlEs4Bh_N6";
+
+export const FIELD_IDS = {
+  status: "PVTSSF_lAHOAZPlEs4Bh_N6zhg416I",
+  priority: "PVTSSF_lAHOAZPlEs4Bh_N6zhg42Vs",
+  size: "PVTSSF_lAHOAZPlEs4Bh_N6zhg42Vw",
+  theme: "PVTSSF_lAHOAZPlEs4Bh_N6zhhNn90"
+};
+
+export const PRIORITY_OPTIONS = {
+  "P0 – Urgent": "79628723",
+  "P1 – High": "0a877460",
+  "P2 – Medium": "da944a9c",
+  "P3 – Low": "804f2a2e",
+  "P4 – Wishlist": "858a4c33"
+};
+
+export const SIZE_OPTIONS = {
+  XS: "6c6483d2",
+  S: "f784b110",
+  M: "7515a9f1",
+  L: "817d0097",
+  XL: "db339eb2",
+  XXL: "e5dad745"
+};
+
+export const THEME_OPTIONS = {
+  "States/Diplomacy": "16ba953c",
+  "Import/Export": "e75de3bf",
+  "UI/Editors": "a26a80ce",
+  "Cultures/Society": "d6146993",
+  "Burgs/Population": "10011b09",
+  "Labels/Styling": "9e035db7",
+  "Climate/Terrain": "c3d2bf64",
+  "Markers/Zones": "2c3889ca",
+  Military: "66c7b261",
+  "Rivers/Water": "5d9ede48",
+  Integrations: "fd582190",
+  Architecture: "84ddcb70",
+  Routes: "43975b24"
+};
+
+export const THEME_LABEL_TO_OPTION = {
+  "theme: states-diplomacy": "States/Diplomacy",
+  "theme: import-export": "Import/Export",
+  "theme: ui-editors": "UI/Editors",
+  "theme: cultures-society": "Cultures/Society",
+  "theme: burgs-population": "Burgs/Population",
+  "theme: labels-styling": "Labels/Styling",
+  "theme: climate-terrain": "Climate/Terrain",
+  "theme: markers-zones": "Markers/Zones",
+  "theme: military": "Military",
+  "theme: rivers-water": "Rivers/Water",
+  "theme: integrations": "Integrations",
+  "theme: architecture": "Architecture",
+  "theme: routes": "Routes"
+};

--- a/scripts/board-plan.mjs
+++ b/scripts/board-plan.mjs
@@ -1,0 +1,43 @@
+import { PRIORITY_OPTIONS, SIZE_OPTIONS } from "./board-fields.mjs";
+
+const PRIORITY_BY_CODE = new Map(
+  Object.keys(PRIORITY_OPTIONS).map(name => [name.slice(0, 2).toUpperCase(), name])
+);
+
+const normalise = value => value.replace(/[-‒–—―]/g, "-").replace(/\s+/g, " ").trim();
+
+function resolvePriority(raw) {
+  const cleaned = normalise(raw);
+  const byCode = PRIORITY_BY_CODE.get(cleaned.slice(0, 2).toUpperCase());
+  if (!byCode) return null;
+  const rest = cleaned.slice(2).replace(/^[\s-]+/, "");
+  if (rest && normalise(byCode).slice(2).replace(/^[\s-]+/, "").toLowerCase() !== rest.toLowerCase())
+    return null;
+  return byCode;
+}
+
+function resolveSize(raw) {
+  const cleaned = normalise(raw).toUpperCase();
+  return Object.hasOwn(SIZE_OPTIONS, cleaned) ? cleaned : null;
+}
+
+export function parseTriage(body) {
+  const errors = [];
+  const block = (body || "").match(/###\s*Triage\s*\n([\s\S]*?)(?=\n###\s|\s*$)/i);
+  if (!block) return { priority: null, size: null, errors };
+
+  const read = key => {
+    const m = block[1].match(new RegExp(`^\\s*${key}\\s*:\\s*(.+)$`, "im"));
+    return m ? m[1].trim() : null;
+  };
+
+  const rawPriority = read("Priority");
+  const rawSize = read("Size");
+  const priority = rawPriority ? resolvePriority(rawPriority) : null;
+  const size = rawSize ? resolveSize(rawSize) : null;
+
+  if (rawPriority && !priority) errors.push(`unknown Priority value: ${rawPriority}`);
+  if (rawSize && !size) errors.push(`unknown Size value: ${rawSize}`);
+
+  return { priority, size, errors };
+}

--- a/scripts/board-plan.mjs
+++ b/scripts/board-plan.mjs
@@ -108,6 +108,7 @@ export function itemsFromGraphql(nodes) {
       title: content.title || "",
       body: content.body || "",
       labels: (content.labels?.nodes || []).map(l => l.name),
+      repository: content.repository?.nameWithOwner ?? null,
       fields
     });
   }

--- a/scripts/board-plan.mjs
+++ b/scripts/board-plan.mjs
@@ -1,4 +1,10 @@
-import { PRIORITY_OPTIONS, SIZE_OPTIONS } from "./board-fields.mjs";
+import {
+  FIELD_IDS,
+  PRIORITY_OPTIONS,
+  SIZE_OPTIONS,
+  THEME_LABEL_TO_OPTION,
+  THEME_OPTIONS
+} from "./board-fields.mjs";
 
 const PRIORITY_BY_CODE = new Map(
   Object.keys(PRIORITY_OPTIONS).map(name => [name.slice(0, 2).toUpperCase(), name])
@@ -40,4 +46,44 @@ export function parseTriage(body) {
   if (rawSize && !size) errors.push(`unknown Size value: ${rawSize}`);
 
   return { priority, size, errors };
+}
+
+const FIELDS = {
+  theme: { id: FIELD_IDS.theme, label: "Theme", options: THEME_OPTIONS },
+  priority: { id: FIELD_IDS.priority, label: "Priority", options: PRIORITY_OPTIONS },
+  size: { id: FIELD_IDS.size, label: "Size", options: SIZE_OPTIONS }
+};
+
+export function planFieldWrites(item) {
+  const writes = [];
+  const drift = [];
+
+  const consider = (field, optionName) => {
+    if (!optionName) return;
+    const current = item.fields[field];
+    if (current === optionName) return;
+    if (current) {
+      drift.push(
+        `#${item.number}: ${FIELDS[field].label} is "${current}" but its source says "${optionName}"`
+      );
+      return;
+    }
+    writes.push({
+      number: item.number,
+      field,
+      optionName,
+      optionId: FIELDS[field].options[optionName]
+    });
+  };
+
+  const themeLabels = item.labels.filter(l => Object.hasOwn(THEME_LABEL_TO_OPTION, l));
+  if (themeLabels.length > 1) drift.push(`#${item.number}: two theme labels, ${themeLabels.join(", ")}`);
+  else if (themeLabels.length === 1) consider("theme", THEME_LABEL_TO_OPTION[themeLabels[0]]);
+
+  const triage = parseTriage(item.body);
+  for (const error of triage.errors) drift.push(`#${item.number}: ${error}`);
+  consider("priority", triage.priority);
+  consider("size", triage.size);
+
+  return { writes, drift };
 }

--- a/scripts/board-plan.mjs
+++ b/scripts/board-plan.mjs
@@ -5,6 +5,7 @@ import {
   THEME_LABEL_TO_OPTION,
   THEME_OPTIONS
 } from "./board-fields.mjs";
+import { classifyTheme } from "./theme-classify.mjs";
 
 const PRIORITY_BY_CODE = new Map(
   Object.keys(PRIORITY_OPTIONS).map(name => [name.slice(0, 2).toUpperCase(), name])
@@ -111,4 +112,9 @@ export function itemsFromGraphql(nodes) {
     });
   }
   return items;
+}
+
+export function planLabelWrites(item) {
+  if (item.labels.some(l => l.startsWith("theme:") || l === "needs-theme")) return [];
+  return [{ number: item.number, label: classifyTheme(item.title, item.body) }];
 }

--- a/scripts/board-plan.mjs
+++ b/scripts/board-plan.mjs
@@ -1,11 +1,9 @@
-import {
-  FIELD_IDS,
-  PRIORITY_OPTIONS,
-  SIZE_OPTIONS,
-  THEME_LABEL_TO_OPTION,
-  THEME_OPTIONS
-} from "./board-fields.mjs";
+import { PRIORITY_OPTIONS, SIZE_OPTIONS, THEME_LABEL_TO_OPTION, THEME_OPTIONS } from "./board-fields.mjs";
 import { classifyTheme } from "./theme-classify.mjs";
+
+const THEME_OPTION_TO_LABEL = Object.fromEntries(
+  Object.entries(THEME_LABEL_TO_OPTION).map(([label, option]) => [option, label])
+);
 
 const PRIORITY_BY_CODE = new Map(
   Object.keys(PRIORITY_OPTIONS).map(name => [name.slice(0, 2).toUpperCase(), name])
@@ -44,15 +42,17 @@ export function parseTriage(body) {
   const size = rawSize ? resolveSize(rawSize) : null;
 
   if (rawPriority && !priority) errors.push(`unknown Priority value: ${rawPriority}`);
+  else if (!priority) errors.push("Triage block present but no Priority value found");
   if (rawSize && !size) errors.push(`unknown Size value: ${rawSize}`);
+  else if (!size) errors.push("Triage block present but no Size value found");
 
   return { priority, size, errors };
 }
 
 const FIELDS = {
-  theme: { id: FIELD_IDS.theme, label: "Theme", options: THEME_OPTIONS },
-  priority: { id: FIELD_IDS.priority, label: "Priority", options: PRIORITY_OPTIONS },
-  size: { id: FIELD_IDS.size, label: "Size", options: SIZE_OPTIONS }
+  theme: { label: "Theme", options: THEME_OPTIONS },
+  priority: { label: "Priority", options: PRIORITY_OPTIONS },
+  size: { label: "Size", options: SIZE_OPTIONS }
 };
 
 export function planFieldWrites(item) {
@@ -77,9 +77,14 @@ export function planFieldWrites(item) {
     });
   };
 
-  const themeLabels = item.labels.filter(l => Object.hasOwn(THEME_LABEL_TO_OPTION, l));
-  if (themeLabels.length > 1) drift.push(`#${item.number}: two theme labels, ${themeLabels.join(", ")}`);
-  else if (themeLabels.length === 1) consider("theme", THEME_LABEL_TO_OPTION[themeLabels[0]]);
+  const allThemeLabels = item.labels.filter(l => l.startsWith("theme:"));
+  const unmappedThemeLabels = allThemeLabels.filter(l => !Object.hasOwn(THEME_LABEL_TO_OPTION, l));
+
+  if (allThemeLabels.length > 1)
+    drift.push(`#${item.number}: ${allThemeLabels.length} theme labels, ${allThemeLabels.join(", ")}`);
+  else if (unmappedThemeLabels.length === 1)
+    drift.push(`#${item.number}: unmapped theme label "${unmappedThemeLabels[0]}"`);
+  else if (allThemeLabels.length === 1) consider("theme", THEME_LABEL_TO_OPTION[allThemeLabels[0]]);
 
   const triage = parseTriage(item.body);
   for (const error of triage.errors) drift.push(`#${item.number}: ${error}`);
@@ -116,6 +121,13 @@ export function itemsFromGraphql(nodes) {
 }
 
 export function planLabelWrites(item) {
-  if (item.labels.some(l => l.startsWith("theme:") || l === "needs-theme")) return [];
-  return [{ number: item.number, label: classifyTheme(item.title, item.body) }];
+  if (item.labels.some(l => l.startsWith("theme:") || l === "needs-theme")) return { writes: [], drift: [] };
+
+  const fromField = item.fields.theme ? THEME_OPTION_TO_LABEL[item.fields.theme] : null;
+  const label = fromField || classifyTheme(item.title, item.body);
+
+  if (label === "needs-theme")
+    return { writes: [], drift: [`#${item.number}: no theme label and the title/body do not classify`] };
+
+  return { writes: [{ number: item.number, label }], drift: [] };
 }

--- a/scripts/board-plan.mjs
+++ b/scripts/board-plan.mjs
@@ -87,3 +87,28 @@ export function planFieldWrites(item) {
 
   return { writes, drift };
 }
+
+const FIELD_BY_NAME = { Theme: "theme", Priority: "priority", Size: "size" };
+
+export function itemsFromGraphql(nodes) {
+  const items = [];
+  for (const node of nodes) {
+    const content = node.content || {};
+    if (!content.number) continue;
+    const fields = { theme: null, priority: null, size: null };
+    for (const value of node.fieldValues.nodes) {
+      const key = FIELD_BY_NAME[value?.field?.name];
+      if (key) fields[key] = value.name;
+    }
+    items.push({
+      id: node.id,
+      number: content.number,
+      type: content.__typename,
+      title: content.title || "",
+      body: content.body || "",
+      labels: (content.labels?.nodes || []).map(l => l.name),
+      fields
+    });
+  }
+  return items;
+}

--- a/scripts/board-plan.test.mjs
+++ b/scripts/board-plan.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { parseTriage } from "./board-plan.mjs";
+import { parseTriage, planFieldWrites } from "./board-plan.mjs";
 
 test("parses an exact block", () => {
   const body = "### Triage\nPriority: P2 – Medium\nSize: M\n";
@@ -39,4 +39,76 @@ test("ignores other blocks around it", () => {
   const got = parseTriage(body);
   assert.equal(got.priority, "P0 – Urgent");
   assert.equal(got.size, "XXL");
+});
+
+const item = over => ({
+  number: 1812,
+  type: "Issue",
+  labels: [],
+  body: "",
+  fields: { theme: null, priority: null, size: null },
+  ...over
+});
+
+test("fills an empty Theme from a single theme label", () => {
+  const { writes, drift } = planFieldWrites(item({ labels: ["bug", "theme: burgs-population"] }));
+  assert.deepEqual(drift, []);
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0].field, "theme");
+  assert.equal(writes[0].optionName, "Burgs/Population");
+  assert.equal(writes[0].optionId, "10011b09");
+});
+
+test("never overwrites a Theme a human already set", () => {
+  const { writes, drift } = planFieldWrites(
+    item({ labels: ["theme: military"], fields: { theme: "Routes", priority: null, size: null } })
+  );
+  assert.deepEqual(writes, []);
+  assert.equal(drift.length, 1);
+  assert.match(drift[0], /Theme/);
+});
+
+test("refuses to choose between two theme labels", () => {
+  const { writes, drift } = planFieldWrites(
+    item({ labels: ["theme: ui-editors", "theme: markers-zones"] })
+  );
+  assert.deepEqual(writes, []);
+  assert.equal(drift.length, 1);
+  assert.match(drift[0], /two theme labels/);
+});
+
+test("fills Priority and Size from a triage block", () => {
+  const { writes } = planFieldWrites(item({ body: "### Triage\nPriority: P3 – Low\nSize: S\n" }));
+  assert.deepEqual(
+    writes.map(w => [w.field, w.optionName]),
+    [
+      ["priority", "P3 – Low"],
+      ["size", "S"]
+    ]
+  );
+});
+
+test("never overwrites a Priority a human already set", () => {
+  const { writes, drift } = planFieldWrites(
+    item({
+      body: "### Triage\nPriority: P3 – Low\nSize: S\n",
+      fields: { theme: null, priority: "P1 – High", size: null }
+    })
+  );
+  assert.deepEqual(
+    writes.map(w => w.field),
+    ["size"]
+  );
+  assert.equal(drift.length, 1);
+  assert.match(drift[0], /Priority/);
+});
+
+test("surfaces an unparseable triage value as drift and writes nothing", () => {
+  const { writes, drift } = planFieldWrites(item({ body: "### Triage\nPriority: soon\nSize: big\n" }));
+  assert.deepEqual(writes, []);
+  assert.equal(drift.length, 2);
+});
+
+test("writes nothing for an item with no labels and no block", () => {
+  assert.deepEqual(planFieldWrites(item({})), { writes: [], drift: [] });
 });

--- a/scripts/board-plan.test.mjs
+++ b/scripts/board-plan.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { parseTriage, planFieldWrites } from "./board-plan.mjs";
+import { itemsFromGraphql, parseTriage, planFieldWrites, planLabelWrites } from "./board-plan.mjs";
 
 test("parses an exact block", () => {
   const body = "### Triage\nPriority: P2 – Medium\nSize: M\n";
@@ -75,11 +75,28 @@ test("refuses to choose between two theme labels", () => {
   );
   assert.deepEqual(writes, []);
   assert.equal(drift.length, 1);
-  assert.match(drift[0], /two theme labels/);
+  assert.match(drift[0], /2 theme labels/);
+});
+
+test("surfaces an unmapped theme label as drift instead of silently ignoring it", () => {
+  const { writes, drift } = planFieldWrites(item({ labels: ["theme: performance"] }));
+  assert.deepEqual(writes, []);
+  assert.equal(drift.length, 1);
+  assert.match(drift[0], /unmapped theme label/);
+  assert.match(drift[0], /theme: performance/);
+});
+
+test("counts an unmapped theme label toward the conflict guard", () => {
+  const { writes, drift } = planFieldWrites(
+    item({ labels: ["theme: ui-editors", "theme: performance"] })
+  );
+  assert.deepEqual(writes, []);
+  assert.equal(drift.length, 1);
+  assert.match(drift[0], /2 theme labels/);
 });
 
 test("fills Priority and Size from a triage block", () => {
-  const { writes } = planFieldWrites(item({ body: "### Triage\nPriority: P3 – Low\nSize: S\n" }));
+  const { writes, drift } = planFieldWrites(item({ body: "### Triage\nPriority: P3 – Low\nSize: S\n" }));
   assert.deepEqual(
     writes.map(w => [w.field, w.optionName]),
     [
@@ -87,6 +104,7 @@ test("fills Priority and Size from a triage block", () => {
       ["size", "S"]
     ]
   );
+  assert.deepEqual(drift, []);
 });
 
 test("never overwrites a Priority a human already set", () => {
@@ -114,7 +132,15 @@ test("writes nothing for an item with no labels and no block", () => {
   assert.deepEqual(planFieldWrites(item({})), { writes: [], drift: [] });
 });
 
-import { itemsFromGraphql } from "./board-plan.mjs";
+test("surfaces a triage block missing a value as drift instead of staying silent", () => {
+  const { writes, drift } = planFieldWrites(item({ body: "### Triage\nPriority: P2 – Medium\n" }));
+  assert.deepEqual(
+    writes.map(w => w.field),
+    ["priority"]
+  );
+  assert.equal(drift.length, 1);
+  assert.match(drift[0], /no Size value/);
+});
 
 const node = {
   id: "PVTI_abc",
@@ -158,24 +184,45 @@ test("drops draft items that have no content number", () => {
   assert.deepEqual(itemsFromGraphql([{ id: "PVTI_x", fieldValues: { nodes: [] }, content: {} }]), []);
 });
 
-import { planLabelWrites } from "./board-plan.mjs";
-
 test("labels a pull request that has no theme label", () => {
   const got = planLabelWrites(
     item({ number: 1666, type: "PullRequest", labels: [], title: "Regiment icons overlap" })
   );
-  assert.deepEqual(got, [{ number: 1666, label: "theme: military" }]);
+  assert.deepEqual(got, { writes: [{ number: 1666, label: "theme: military" }], drift: [] });
 });
 
 test("leaves an item that already has a theme label alone", () => {
-  assert.deepEqual(planLabelWrites(item({ labels: ["theme: routes"], title: "Regiments" })), []);
+  assert.deepEqual(planLabelWrites(item({ labels: ["theme: routes"], title: "Regiments" })), {
+    writes: [],
+    drift: []
+  });
 });
 
 test("leaves an item already marked needs-theme alone", () => {
-  assert.deepEqual(planLabelWrites(item({ labels: ["needs-theme"], title: "Regiments" })), []);
+  assert.deepEqual(planLabelWrites(item({ labels: ["needs-theme"], title: "Regiments" })), {
+    writes: [],
+    drift: []
+  });
 });
 
-test("marks an unclassifiable item needs-theme", () => {
+// Old intent (pre-fix): an unclassifiable item got a permanent "needs-theme" label, which fought
+// a maintainer who deliberately removed it. New intent: surface it as drift, write nothing, and
+// let theme-label.yml's creation-time needs-theme label (untouched by this script) stand.
+test("surfaces an unclassifiable item as drift instead of writing needs-theme", () => {
   const got = planLabelWrites(item({ number: 9, title: "Something odd", body: "please help" }));
-  assert.deepEqual(got, [{ number: 9, label: "needs-theme" }]);
+  assert.deepEqual(got.writes, []);
+  assert.equal(got.drift.length, 1);
+  assert.match(got.drift[0], /#9/);
+});
+
+test("derives the label from a human-set Theme field instead of guessing", () => {
+  const got = planLabelWrites(
+    item({
+      number: 1780,
+      title: "Editor dialogs snap back",
+      body: "unrelated text with no theme keywords",
+      fields: { theme: "UI/Editors", priority: null, size: null }
+    })
+  );
+  assert.deepEqual(got, { writes: [{ number: 1780, label: "theme: ui-editors" }], drift: [] });
 });

--- a/scripts/board-plan.test.mjs
+++ b/scripts/board-plan.test.mjs
@@ -45,6 +45,7 @@ const item = over => ({
   number: 1812,
   type: "Issue",
   labels: [],
+  title: "",
   body: "",
   fields: { theme: null, priority: null, size: null },
   ...over
@@ -146,4 +147,26 @@ test("maps a graphql node onto the planner's item shape", () => {
 
 test("drops draft items that have no content number", () => {
   assert.deepEqual(itemsFromGraphql([{ id: "PVTI_x", fieldValues: { nodes: [] }, content: {} }]), []);
+});
+
+import { planLabelWrites } from "./board-plan.mjs";
+
+test("labels a pull request that has no theme label", () => {
+  const got = planLabelWrites(
+    item({ number: 1666, type: "PullRequest", labels: [], title: "Regiment icons overlap" })
+  );
+  assert.deepEqual(got, [{ number: 1666, label: "theme: military" }]);
+});
+
+test("leaves an item that already has a theme label alone", () => {
+  assert.deepEqual(planLabelWrites(item({ labels: ["theme: routes"], title: "Regiments" })), []);
+});
+
+test("leaves an item already marked needs-theme alone", () => {
+  assert.deepEqual(planLabelWrites(item({ labels: ["needs-theme"], title: "Regiments" })), []);
+});
+
+test("marks an unclassifiable item needs-theme", () => {
+  const got = planLabelWrites(item({ number: 9, title: "Something odd", body: "please help" }));
+  assert.deepEqual(got, [{ number: 9, label: "needs-theme" }]);
 });

--- a/scripts/board-plan.test.mjs
+++ b/scripts/board-plan.test.mjs
@@ -112,3 +112,38 @@ test("surfaces an unparseable triage value as drift and writes nothing", () => {
 test("writes nothing for an item with no labels and no block", () => {
   assert.deepEqual(planFieldWrites(item({})), { writes: [], drift: [] });
 });
+
+import { itemsFromGraphql } from "./board-plan.mjs";
+
+const node = {
+  id: "PVTI_abc",
+  fieldValues: {
+    nodes: [
+      {},
+      { name: "Backlog", field: { name: "Status" } },
+      { name: "UI/Editors", field: { name: "Theme" } }
+    ]
+  },
+  content: {
+    __typename: "Issue",
+    number: 1780,
+    title: "Editor dialogs snap back",
+    body: "### Theme\n\nUI / Editors",
+    labels: { nodes: [{ name: "bug" }, { name: "theme: ui-editors" }] }
+  }
+};
+
+test("maps a graphql node onto the planner's item shape", () => {
+  const [got] = itemsFromGraphql([node]);
+  assert.equal(got.id, "PVTI_abc");
+  assert.equal(got.number, 1780);
+  assert.equal(got.type, "Issue");
+  assert.deepEqual(got.labels, ["bug", "theme: ui-editors"]);
+  assert.equal(got.fields.theme, "UI/Editors");
+  assert.equal(got.fields.priority, null);
+  assert.equal(got.fields.size, null);
+});
+
+test("drops draft items that have no content number", () => {
+  assert.deepEqual(itemsFromGraphql([{ id: "PVTI_x", fieldValues: { nodes: [] }, content: {} }]), []);
+});

--- a/scripts/board-plan.test.mjs
+++ b/scripts/board-plan.test.mjs
@@ -130,7 +130,8 @@ const node = {
     number: 1780,
     title: "Editor dialogs snap back",
     body: "### Theme\n\nUI / Editors",
-    labels: { nodes: [{ name: "bug" }, { name: "theme: ui-editors" }] }
+    labels: { nodes: [{ name: "bug" }, { name: "theme: ui-editors" }] },
+    repository: { nameWithOwner: "Azgaar/Fantasy-Map-Generator" }
   }
 };
 
@@ -140,9 +141,17 @@ test("maps a graphql node onto the planner's item shape", () => {
   assert.equal(got.number, 1780);
   assert.equal(got.type, "Issue");
   assert.deepEqual(got.labels, ["bug", "theme: ui-editors"]);
+  assert.equal(got.repository, "Azgaar/Fantasy-Map-Generator");
   assert.equal(got.fields.theme, "UI/Editors");
   assert.equal(got.fields.priority, null);
   assert.equal(got.fields.size, null);
+});
+
+test("reports a missing repository as null rather than guessing", () => {
+  const [got] = itemsFromGraphql([
+    { id: "PVTI_y", fieldValues: { nodes: [] }, content: { __typename: "Issue", number: 42, labels: { nodes: [] } } }
+  ]);
+  assert.equal(got.repository, null);
 });
 
 test("drops draft items that have no content number", () => {

--- a/scripts/board-plan.test.mjs
+++ b/scripts/board-plan.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseTriage } from "./board-plan.mjs";
+
+test("parses an exact block", () => {
+  const body = "### Triage\nPriority: P2 – Medium\nSize: M\n";
+  assert.deepEqual(parseTriage(body), { priority: "P2 – Medium", size: "M", errors: [] });
+});
+
+test("accepts a hyphen where an en dash belongs", () => {
+  const body = "### Triage\nPriority: P1 - High\nSize: XL\n";
+  assert.equal(parseTriage(body).priority, "P1 – High");
+});
+
+test("accepts a bare priority code", () => {
+  const body = "### Triage\nPriority: P4\nSize: s\n";
+  const got = parseTriage(body);
+  assert.equal(got.priority, "P4 – Wishlist");
+  assert.equal(got.size, "S");
+});
+
+test("returns nothing when there is no block", () => {
+  assert.deepEqual(parseTriage("### Describe the bug\n\nit broke"), {
+    priority: null,
+    size: null,
+    errors: []
+  });
+});
+
+test("reports an unknown value instead of guessing", () => {
+  const got = parseTriage("### Triage\nPriority: Urgent-ish\nSize: Medium\n");
+  assert.equal(got.priority, null);
+  assert.equal(got.size, null);
+  assert.equal(got.errors.length, 2);
+});
+
+test("ignores other blocks around it", () => {
+  const body = "### Theme\n\nMilitary\n\n### Triage\nPriority: P0 – Urgent\nSize: XXL\n\n### Notes\nblah";
+  const got = parseTriage(body);
+  assert.equal(got.priority, "P0 – Urgent");
+  assert.equal(got.size, "XXL");
+});

--- a/scripts/board-reconcile.mjs
+++ b/scripts/board-reconcile.mjs
@@ -45,14 +45,14 @@ query($owner: String!, $number: Int!, $cursor: String) {
               number
               title
               body
-              labels(first: 20) { nodes { name } }
+              labels(first: 100) { nodes { name } }
               repository { nameWithOwner }
             }
             ... on PullRequest {
               number
               title
               body
-              labels(first: 20) { nodes { name } }
+              labels(first: 100) { nodes { name } }
               repository { nameWithOwner }
             }
           }
@@ -126,7 +126,10 @@ async function reportTokenFailure(message) {
     `https://api.github.com/search/issues?q=${encodeURIComponent(`repo:${REPO} is:issue is:open in:title "${title}"`)}`,
     { headers: { authorization: `bearer ${process.env.GITHUB_TOKEN}` } }
   );
-  if (!search.ok) return;
+  if (!search.ok) {
+    console.error(`failed to search for existing token-failure issue: ${search.status} ${await search.text()}`);
+    return;
+  }
   const found = (await search.json()).items || [];
   const body = `The board reconciler could not write to the project.\n\n\`\`\`\n${message}\n\`\`\`\n\nRenew the classic PAT (\`project\` scope only) and update the \`PROJECT_TOKEN\` repository secret. Label writes are unaffected and keep working meanwhile.`;
   if (found.length) return;
@@ -173,7 +176,9 @@ async function main() {
     const planned = planFieldWrites(item);
     fieldWrites.push(...planned.writes.map(write => ({ ...write, itemId: item.id })));
     drift.push(...planned.drift);
-    labelWrites.push(...planLabelWrites(item));
+    const plannedLabels = planLabelWrites(item);
+    labelWrites.push(...plannedLabels.writes);
+    drift.push(...plannedLabels.drift);
   }
 
   const lines = [
@@ -218,10 +223,9 @@ async function main() {
     try {
       await addLabel(write.number, write.label);
     } catch (error) {
-      if (isAuthFailure(error) && !authFailureReported) {
-        await reportTokenFailure(String(error));
-        authFailureReported = true;
-      }
+      // addLabel authenticates with GITHUB_TOKEN, not PROJECT_TOKEN — never route its
+      // failures (locked issue, abuse detection, a missing pull-requests scope) through
+      // reportTokenFailure, which would misdiagnose a healthy PAT on Azgaar's tracker.
       labelFailures.push(`#${write.number} ${write.label}: ${error.message ?? error}`);
     }
   }

--- a/scripts/board-reconcile.mjs
+++ b/scripts/board-reconcile.mjs
@@ -2,7 +2,7 @@ import { appendFileSync } from "node:fs";
 import { FIELD_IDS, PROJECT_ID } from "./board-fields.mjs";
 import { itemsFromGraphql, planFieldWrites, planLabelWrites } from "./board-plan.mjs";
 
-const DRY_RUN = process.env.DRY_RUN === "1";
+const DRY_RUN = Boolean(process.env.DRY_RUN);
 const REPO = process.env.GITHUB_REPOSITORY || "Azgaar/Fantasy-Map-Generator";
 const PROJECT_NUMBER = 3;
 const OWNER = REPO.split("/")[0];
@@ -14,8 +14,12 @@ async function graphql(token, query, variables) {
     body: JSON.stringify({ query, variables })
   });
   const payload = await response.json();
-  if (!response.ok || payload.errors)
-    throw new Error(`graphql ${response.status}: ${JSON.stringify(payload.errors || payload)}`);
+  if (!response.ok || payload.errors) {
+    const error = new Error(`graphql ${response.status}: ${JSON.stringify(payload.errors || payload)}`);
+    error.status = response.status;
+    error.errors = payload.errors;
+    throw error;
+  }
   return payload.data;
 }
 
@@ -27,7 +31,7 @@ query($owner: String!, $number: Int!, $cursor: String) {
         pageInfo { hasNextPage endCursor }
         nodes {
           id
-          fieldValues(first: 20) {
+          fieldValues(first: 50) {
             nodes {
               ... on ProjectV2ItemFieldSingleSelectValue {
                 name
@@ -37,8 +41,20 @@ query($owner: String!, $number: Int!, $cursor: String) {
           }
           content {
             __typename
-            ... on Issue { number title body labels(first: 20) { nodes { name } } }
-            ... on PullRequest { number title body labels(first: 20) { nodes { name } } }
+            ... on Issue {
+              number
+              title
+              body
+              labels(first: 20) { nodes { name } }
+              repository { nameWithOwner }
+            }
+            ... on PullRequest {
+              number
+              title
+              body
+              labels(first: 20) { nodes { name } }
+              repository { nameWithOwner }
+            }
           }
         }
       }
@@ -53,11 +69,21 @@ mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
   ) { projectV2Item { id } }
 }`;
 
-// Only an auth failure warrants opening the "renew your token" issue on Azgaar's tracker.
-// A transient 502, rate limit, or network blip must rethrow and let the next hourly run retry.
+// Only a genuine auth failure warrants opening the "renew your token" issue on Azgaar's tracker.
+// A transient 502, a secondary rate limit, or a network blip must rethrow and let the next hourly
+// run retry. A token that authenticates but lacks project scope comes back as HTTP 200 with a
+// GraphQL error of type INSUFFICIENT_SCOPES/FORBIDDEN (or a SAML-enforcement message) — that is
+// as much an auth failure as a 401, so it is checked separately from the HTTP status.
 function isAuthFailure(error) {
-  const message = String(error?.message ?? error);
-  return /\b401\b|\b403\b|bad credentials/i.test(message);
+  const status = error?.status;
+  if (status === 401) return true;
+  if (status === 403) return !/rate limit/i.test(String(error?.message ?? error));
+
+  const graphqlErrors = Array.isArray(error?.errors) ? error.errors : [];
+  if (graphqlErrors.some(e => /INSUFFICIENT_SCOPES|FORBIDDEN/i.test(e?.type || "") || /SAML/i.test(e?.message || "")))
+    return true;
+
+  return /bad credentials/i.test(String(error?.message ?? error));
 }
 
 async function readBoard(token) {
@@ -87,7 +113,11 @@ async function addLabel(number, label) {
     },
     body: JSON.stringify({ labels: [label] })
   });
-  if (!response.ok) throw new Error(`label ${number} ${response.status}: ${await response.text()}`);
+  if (!response.ok) {
+    const error = new Error(`label ${number} ${response.status}: ${await response.text()}`);
+    error.status = response.status;
+    throw error;
+  }
 }
 
 async function reportTokenFailure(message) {
@@ -96,10 +126,11 @@ async function reportTokenFailure(message) {
     `https://api.github.com/search/issues?q=${encodeURIComponent(`repo:${REPO} is:issue is:open in:title "${title}"`)}`,
     { headers: { authorization: `bearer ${process.env.GITHUB_TOKEN}` } }
   );
+  if (!search.ok) return;
   const found = (await search.json()).items || [];
   const body = `The board reconciler could not write to the project.\n\n\`\`\`\n${message}\n\`\`\`\n\nRenew the classic PAT (\`project\` scope only) and update the \`PROJECT_TOKEN\` repository secret. Label writes are unaffected and keep working meanwhile.`;
   if (found.length) return;
-  await fetch(`https://api.github.com/repos/${REPO}/issues`, {
+  const response = await fetch(`https://api.github.com/repos/${REPO}/issues`, {
     method: "POST",
     headers: {
       authorization: `bearer ${process.env.GITHUB_TOKEN}`,
@@ -108,6 +139,7 @@ async function reportTokenFailure(message) {
     },
     body: JSON.stringify({ title, body })
   });
+  if (!response.ok) console.error(`failed to file token-failure issue: ${response.status} ${await response.text()}`);
 }
 
 function summarise(lines) {
@@ -120,17 +152,23 @@ async function main() {
   const token = process.env.PROJECT_TOKEN;
   if (!token) throw new Error("PROJECT_TOKEN is not set");
 
-  let items;
+  let allItems;
   try {
-    items = await readBoard(token);
+    allItems = await readBoard(token);
   } catch (error) {
     if (isAuthFailure(error)) await reportTokenFailure(String(error));
     throw error;
   }
 
+  const drift = [];
+  const items = allItems.filter(item => {
+    if (item.repository === REPO) return true;
+    drift.push(`#${item.number}: skipped, repository ${item.repository ?? "unknown"} does not match ${REPO}`);
+    return false;
+  });
+
   const fieldWrites = [];
   const labelWrites = [];
-  const drift = [];
   for (const item of items) {
     const planned = planFieldWrites(item);
     fieldWrites.push(...planned.writes.map(write => ({ ...write, itemId: item.id })));
@@ -153,6 +191,13 @@ async function main() {
     return;
   }
 
+  // Per-item isolation: one un-writable item (transferred, locked, archived, or otherwise
+  // rejected) must not block every write queued behind it. Failures are collected, reported in
+  // the summary, and turn the run red — but the loop always runs to completion.
+  const fieldFailures = [];
+  const labelFailures = [];
+  let authFailureReported = false;
+
   for (const write of fieldWrites) {
     try {
       await graphql(token, SET_FIELD, {
@@ -162,13 +207,36 @@ async function main() {
         option: write.optionId
       });
     } catch (error) {
-      if (isAuthFailure(error)) await reportTokenFailure(String(error));
-      throw error;
+      if (isAuthFailure(error) && !authFailureReported) {
+        await reportTokenFailure(String(error));
+        authFailureReported = true;
+      }
+      fieldFailures.push(`#${write.number} ${write.field}: ${error.message ?? error}`);
     }
   }
-  for (const write of labelWrites) await addLabel(write.number, write.label);
+  for (const write of labelWrites) {
+    try {
+      await addLabel(write.number, write.label);
+    } catch (error) {
+      if (isAuthFailure(error) && !authFailureReported) {
+        await reportTokenFailure(String(error));
+        authFailureReported = true;
+      }
+      labelFailures.push(`#${write.number} ${write.label}: ${error.message ?? error}`);
+    }
+  }
+
+  if (fieldFailures.length || labelFailures.length) {
+    lines.push(
+      "",
+      "### Write failures",
+      ...fieldFailures.map(f => `- field ${f}`),
+      ...labelFailures.map(f => `- label ${f}`)
+    );
+  }
 
   summarise(lines);
+  if (fieldFailures.length || labelFailures.length) process.exitCode = 1;
 }
 
 main().catch(error => {

--- a/scripts/board-reconcile.mjs
+++ b/scripts/board-reconcile.mjs
@@ -1,0 +1,177 @@
+import { appendFileSync } from "node:fs";
+import { FIELD_IDS, PROJECT_ID } from "./board-fields.mjs";
+import { itemsFromGraphql, planFieldWrites, planLabelWrites } from "./board-plan.mjs";
+
+const DRY_RUN = process.env.DRY_RUN === "1";
+const REPO = process.env.GITHUB_REPOSITORY || "Azgaar/Fantasy-Map-Generator";
+const PROJECT_NUMBER = 3;
+const OWNER = REPO.split("/")[0];
+
+async function graphql(token, query, variables) {
+  const response = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: { authorization: `bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({ query, variables })
+  });
+  const payload = await response.json();
+  if (!response.ok || payload.errors)
+    throw new Error(`graphql ${response.status}: ${JSON.stringify(payload.errors || payload)}`);
+  return payload.data;
+}
+
+const ITEMS_QUERY = `
+query($owner: String!, $number: Int!, $cursor: String) {
+  user(login: $owner) {
+    projectV2(number: $number) {
+      items(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          fieldValues(first: 20) {
+            nodes {
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { ... on ProjectV2SingleSelectField { name } }
+              }
+            }
+          }
+          content {
+            __typename
+            ... on Issue { number title body labels(first: 20) { nodes { name } } }
+            ... on PullRequest { number title body labels(first: 20) { nodes { name } } }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const SET_FIELD = `
+mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+  updateProjectV2ItemFieldValue(
+    input: { projectId: $project, itemId: $item, fieldId: $field, value: { singleSelectOptionId: $option } }
+  ) { projectV2Item { id } }
+}`;
+
+// Only an auth failure warrants opening the "renew your token" issue on Azgaar's tracker.
+// A transient 502, rate limit, or network blip must rethrow and let the next hourly run retry.
+function isAuthFailure(error) {
+  const message = String(error?.message ?? error);
+  return /\b401\b|\b403\b|bad credentials/i.test(message);
+}
+
+async function readBoard(token) {
+  const nodes = [];
+  let cursor = null;
+  for (;;) {
+    const data = await graphql(token, ITEMS_QUERY, {
+      owner: OWNER,
+      number: PROJECT_NUMBER,
+      cursor
+    });
+    const page = data.user.projectV2.items;
+    nodes.push(...page.nodes);
+    if (!page.pageInfo.hasNextPage) break;
+    cursor = page.pageInfo.endCursor;
+  }
+  return itemsFromGraphql(nodes);
+}
+
+async function addLabel(number, label) {
+  const response = await fetch(`https://api.github.com/repos/${REPO}/issues/${number}/labels`, {
+    method: "POST",
+    headers: {
+      authorization: `bearer ${process.env.GITHUB_TOKEN}`,
+      accept: "application/vnd.github+json",
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({ labels: [label] })
+  });
+  if (!response.ok) throw new Error(`label ${number} ${response.status}: ${await response.text()}`);
+}
+
+async function reportTokenFailure(message) {
+  const title = "Dev board automation: PROJECT_TOKEN needs renewing";
+  const search = await fetch(
+    `https://api.github.com/search/issues?q=${encodeURIComponent(`repo:${REPO} is:issue is:open in:title "${title}"`)}`,
+    { headers: { authorization: `bearer ${process.env.GITHUB_TOKEN}` } }
+  );
+  const found = (await search.json()).items || [];
+  const body = `The board reconciler could not write to the project.\n\n\`\`\`\n${message}\n\`\`\`\n\nRenew the classic PAT (\`project\` scope only) and update the \`PROJECT_TOKEN\` repository secret. Label writes are unaffected and keep working meanwhile.`;
+  if (found.length) return;
+  await fetch(`https://api.github.com/repos/${REPO}/issues`, {
+    method: "POST",
+    headers: {
+      authorization: `bearer ${process.env.GITHUB_TOKEN}`,
+      accept: "application/vnd.github+json",
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({ title, body })
+  });
+}
+
+function summarise(lines) {
+  const text = lines.join("\n");
+  console.log(text);
+  if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${text}\n`);
+}
+
+async function main() {
+  const token = process.env.PROJECT_TOKEN;
+  if (!token) throw new Error("PROJECT_TOKEN is not set");
+
+  let items;
+  try {
+    items = await readBoard(token);
+  } catch (error) {
+    if (isAuthFailure(error)) await reportTokenFailure(String(error));
+    throw error;
+  }
+
+  const fieldWrites = [];
+  const labelWrites = [];
+  const drift = [];
+  for (const item of items) {
+    const planned = planFieldWrites(item);
+    fieldWrites.push(...planned.writes.map(write => ({ ...write, itemId: item.id })));
+    drift.push(...planned.drift);
+    labelWrites.push(...planLabelWrites(item));
+  }
+
+  const lines = [
+    `## Dev board reconcile${DRY_RUN ? " (dry run)" : ""}`,
+    "",
+    `${items.length} items · ${fieldWrites.length} field writes · ${labelWrites.length} label writes · ${drift.length} drift`,
+    ""
+  ];
+  for (const write of fieldWrites) lines.push(`- set #${write.number} ${write.field} = ${write.optionName}`);
+  for (const write of labelWrites) lines.push(`- label #${write.number} ${write.label}`);
+  if (drift.length) lines.push("", "### Drift (not corrected)", ...drift.map(d => `- ${d}`));
+
+  if (DRY_RUN) {
+    summarise(lines);
+    return;
+  }
+
+  for (const write of fieldWrites) {
+    try {
+      await graphql(token, SET_FIELD, {
+        project: PROJECT_ID,
+        item: write.itemId,
+        field: FIELD_IDS[write.field],
+        option: write.optionId
+      });
+    } catch (error) {
+      if (isAuthFailure(error)) await reportTokenFailure(String(error));
+      throw error;
+    }
+  }
+  for (const write of labelWrites) await addLabel(write.number, write.label);
+
+  summarise(lines);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/theme-classify.mjs
+++ b/scripts/theme-classify.mjs
@@ -1,0 +1,58 @@
+export const DROPDOWN = {
+  "States / Provinces / Diplomacy": "theme: states-diplomacy",
+  "Import / Export / Save": "theme: import-export",
+  "UI / Editors": "theme: ui-editors",
+  "Cultures / Religions / Society": "theme: cultures-society",
+  "Burgs & Population": "theme: burgs-population",
+  "Labels & Styling": "theme: labels-styling",
+  "Climate / Biomes / Terrain": "theme: climate-terrain",
+  "Markers / Notes / Zones": "theme: markers-zones",
+  Military: "theme: military",
+  "Rivers / Lakes / Coast": "theme: rivers-water",
+  "Integrations & External": "theme: integrations",
+  "Architecture / Performance": "theme: architecture",
+  "Routes & Roads": "theme: routes"
+};
+
+export const KEYWORDS = {
+  "theme: states-diplomacy": ["state", "states", "province", "provinces", "diplomacy", "war", "alliance", "country", "nation", "border", "annex", "vassal", "empire", "kingdom", "realm", "territory"],
+  "theme: import-export": ["export", "import", "save", "load", "backup", "geojson", "json", "download", "upload", "dropbox", "file"],
+  "theme: ui-editors": ["editor", "ui", "dialog", "menu", "button", "window", "panel", "hotkey", "shortcut", "interface", "tooltip", "overview", "filter", "brush", "paint", "undo", "drag"],
+  "theme: cultures-society": ["culture", "cultures", "religion", "religions", "race", "species", "language", "namebase", "namesbase", "society", "folk", "deity", "government"],
+  "theme: burgs-population": ["burg", "burgs", "city", "cities", "town", "towns", "population", "settlement", "village", "urban", "port"],
+  "theme: labels-styling": ["label", "labels", "font", "style", "color", "colour", "texture", "legend", "emblem", "coa", "heraldry", "opacity", "stroke", "preset"],
+  "theme: climate-terrain": ["climate", "biome", "biomes", "temperature", "precipitation", "heightmap", "terrain", "elevation", "height", "relief", "mountain", "wind", "erosion", "latitude"],
+  "theme: markers-zones": ["marker", "markers", "note", "notes", "zone", "zones", "icon", "pin", "annotation"],
+  "theme: military": ["military", "regiment", "regiments", "army", "unit", "units", "troop", "battle", "garrison"],
+  "theme: rivers-water": ["river", "rivers", "lake", "lakes", "coast", "ocean", "sea", "island", "shore", "delta"],
+  "theme: integrations": ["api", "integration", "foundry", "roll20", "plugin", "discord", "watabou", "armoria", "android", "vtt", "translation", "localization"],
+  "theme: architecture": ["performance", "refactor", "codebase", "typescript", "memory", "optimize", "bundle", "browser", "wasm", "pwa", "offline", "architecture", "vite"],
+  "theme: routes": ["route", "routes", "road", "roads", "path", "trail", "bridge"]
+};
+
+const words = s => (s || "").toLowerCase().match(/[a-z]{2,}/g) || [];
+
+export function themeFromBody(body) {
+  const m = (body || "").match(/###\s*Theme\s*\n+\s*(.+)/i);
+  return m ? DROPDOWN[m[1].trim()] || null : null;
+}
+
+export function themeFromKeywords(title, body) {
+  const inTitle = new Set(words(title));
+  const inBody = new Set(words(body).slice(0, 250));
+  let best = 0;
+  let label = null;
+  for (const [candidate, kws] of Object.entries(KEYWORDS)) {
+    let score = 0;
+    for (const k of kws) score += (inTitle.has(k) ? 3 : 0) + (inBody.has(k) ? 1 : 0);
+    if (score > best) {
+      best = score;
+      label = candidate;
+    }
+  }
+  return best < 3 ? null : label;
+}
+
+export function classifyTheme(title, body) {
+  return themeFromBody(body) || themeFromKeywords(title, body) || "needs-theme";
+}

--- a/scripts/theme-classify.test.mjs
+++ b/scripts/theme-classify.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { classifyTheme, themeFromBody, themeFromKeywords } from "./theme-classify.mjs";
+
+test("themeFromBody reads a dropdown answer", () => {
+  const body = "### Describe the bug\n\nIt breaks\n\n### Theme\n\nMilitary\n\n### System\n\nFirefox";
+  assert.equal(themeFromBody(body), "theme: military");
+});
+
+test("themeFromBody returns null for an unrecognised answer", () => {
+  assert.equal(themeFromBody("### Theme\n\nNot sure"), null);
+});
+
+test("themeFromBody returns null when there is no heading", () => {
+  assert.equal(themeFromBody("just some prose about rivers"), null);
+});
+
+test("themeFromKeywords scores a title hit above a body hit", () => {
+  assert.equal(themeFromKeywords("Regiment icons overlap", ""), "theme: military");
+});
+
+test("themeFromKeywords returns null below threshold", () => {
+  assert.equal(themeFromKeywords("Something odd happened", "please help"), null);
+});
+
+test("classifyTheme prefers the dropdown over keywords", () => {
+  const body = "### Theme\n\nMilitary\n\nthis text is all about rivers lakes and coast";
+  assert.equal(classifyTheme("rivers", body), "theme: military");
+});
+
+test("classifyTheme falls back to needs-theme", () => {
+  assert.equal(classifyTheme("Something odd happened", "please help"), "needs-theme");
+});


### PR DESCRIPTION
You asked whether the dev board could be automated because updating it by hand is a chore. This does the part that is genuinely mechanical, and deliberately does not do the part that isn't.

## What it does

A single reconciler runs hourly, reads the whole board, and writes only what is missing:

- **Theme field** is set from the item's `theme:` label.
- **`theme:` labels** are applied to items `theme-label.yml` never sees — it fires on `issues` and `discussion` only, which is why pull requests have none.
- **Priority and Size** are set from a `### Triage` block in the issue body, when one is present. Nothing writes one today; that is the hook for the Discord intake bot, where a human moderator picks both values before approving.

## What it will not do

**Nothing is ever guessed, and nothing a human set is ever overwritten.** Two invariants, both enforced in code and covered by tests:

1. It only ever *fills an empty field*. If you have set a value, it is never changed — even when a label disagrees with it. Disagreements are reported, never resolved.
2. Every value written traces to a label a human applied or a dropdown a human selected. Where the source is ambiguous — an item carrying two `theme:` labels — it writes nothing and reports it.

So an empty cell on the board keeps meaning "nobody has judged this yet", which is only true because nothing writes a guess into it. There is no model and no inference anywhere in this PR.

It also **never writes `needs-theme`.** `theme-label.yml` still applies that at creation, and you can delete it to mean "I looked, nothing fits" — if the reconciler re-applied it, your deletion would be undone within the hour. Items it cannot classify are listed in the run summary instead.

## Dry run against the board as it stands

118 items → **11 Theme fills, 14 label writes, 4 items reported, 0 Priority/Size writes.**

The reported items are #1658, #1805 and #1808 (title and body do not classify — a human call), and #1810, which carries both `theme: ui-editors` and `theme: markers-zones`, so it refuses to pick one.

The run is idempotent: a second run writes nothing, and a third writes nothing. It converges in two passes because an item that gets a label in run 1 gets its Theme field in run 2.

## About the change to `theme-label.yml`

That workflow already had the classifier inline, and the reconciler needs the same logic for pull requests. Rather than keep two copies of a 13-entry keyword table that would drift — and then theme the same item differently depending on which path saw it first — the classifier moves to `scripts/theme-classify.mjs` and both import it.

**The extraction is behaviour-identical, and I checked rather than assuming:** the `DROPDOWN` and `KEYWORDS` objects are `deepStrictEqual` to the originals, and running the old inline algorithm against the new one over 109 inputs — 100 real issues from this repo plus 9 adversarial cases (null title, null body, an unmapped dropdown answer, `###Theme` with no space, a body-only tie, a 5000-character title) — gives 0 mismatches. The scoring threshold is unchanged.

The workflow gains an `actions/checkout` step, which it needs to import the module.

## Before merging

**The secret is already in place** — thank you. It reads the `PROJECT_TOKEN` you created, and the name in the workflow matches. Recording why it had to be a *classic* PAT, for whoever reads this later: `GITHUB_TOKEN` cannot write to Projects v2 at all, and because the board is user-owned rather than org-owned, fine-grained PATs and GitHub App tokens do not work either — those cover organization projects only. It needs `project` scope and nothing else; both repos are public, so no `repo` scope.

**The cron is live on merge**, and the first run makes about 25 writes — most of them labels on merged pull requests, each notifying that PR's subscribers. Worth dispatching it once by hand first: `workflow_dispatch` defaults to `dry_run: true`, which prints the full plan and writes nothing. If the plan looks right, dispatch again with `dry_run: false`, and the hourly schedule takes it from there.

If the token ever lapses, the run stops and opens a single issue saying so, using the workflow's own token rather than the PAT.

If the token ever expires, the run opens a single issue saying so rather than failing quietly. That check is careful to fire only on genuine authentication failures, not on rate limits or transient errors.

## Testing

`npm run test:scripts` — 31 tests under Node's built-in runner, wired into `unit-tests.yml`. They live outside `src/`, so `vitest` does not collect them (its root is `./src`); hence the separate script. No new dependencies — global `fetch` and `node:` builtins only. The existing 648 unit tests are unaffected.
