### PR TITLE
Board reconciler: trust Triage blocks only from collaborators

### DIFF
--- a/.github/workflows/board-reconcile.yml
+++ b/.github/workflows/board-reconcile.yml
@@ -23,6 +23,9 @@ concurrency:
 
 jobs:
   reconcile:
+    # The board and its field ids belong to this repository's owner. A fork carrying this file
+    # would read a different (or no) board and has no PROJECT_TOKEN, so it must not run here.
+    if: github.repository == 'Azgaar/Fantasy-Map-Generator'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -33,5 +36,6 @@ jobs:
         env:
           PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRUSTED_TRIAGE_LOGINS: ${{ vars.TRUSTED_TRIAGE_LOGINS }}
           DRY_RUN: ${{ inputs.dry_run && '1' || '' }}
         run: node scripts/board-reconcile.mjs

--- a/.github/workflows/theme-label.yml
+++ b/.github/workflows/theme-label.yml
@@ -19,7 +19,13 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            const { classifyTheme } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/theme-classify.mjs`);
+            let classifyTheme;
+            try {
+              ({ classifyTheme } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/theme-classify.mjs`));
+            } catch (error) {
+              core.warning(`theme classifier could not be loaded, applying needs-theme: ${error.message}`);
+              classifyTheme = () => "needs-theme";
+            }
 
             const isDiscussion = !!context.payload.discussion;
             const target = context.payload.discussion || context.payload.issue;

--- a/scripts/board-plan.mjs
+++ b/scripts/board-plan.mjs
@@ -28,7 +28,7 @@ function resolveSize(raw) {
 
 export function parseTriage(body) {
   const errors = [];
-  const block = (body || "").match(/###\s*Triage\s*\n([\s\S]*?)(?=\n###\s|\s*$)/i);
+  const block = (body || "").match(/###\s*Triage[ \t\r]*\n([\s\S]*?)(?=\n###\s|\s*$)/i);
   if (!block) return { priority: null, size: null, errors };
 
   const read = key => {
@@ -55,7 +55,15 @@ const FIELDS = {
   size: { label: "Size", options: SIZE_OPTIONS }
 };
 
-export function planFieldWrites(item) {
+// Anyone can edit the body of an issue they filed, so a Triage block is only a moderator's decision
+// when the author is one. Collaborators qualify by association; the intake bot, which writes under
+// its own login, qualifies by allowlist.
+const TRUSTED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+
+const isTrustedAuthor = (item, trustedLogins) =>
+  TRUSTED_ASSOCIATIONS.has(item.authorAssociation) || trustedLogins.has(item.author);
+
+export function planFieldWrites(item, trustedLogins = new Set()) {
   const writes = [];
   const drift = [];
 
@@ -86,10 +94,16 @@ export function planFieldWrites(item) {
     drift.push(`#${item.number}: unmapped theme label "${unmappedThemeLabels[0]}"`);
   else if (allThemeLabels.length === 1) consider("theme", THEME_LABEL_TO_OPTION[allThemeLabels[0]]);
 
-  const triage = parseTriage(item.body);
-  for (const error of triage.errors) drift.push(`#${item.number}: ${error}`);
-  consider("priority", triage.priority);
-  consider("size", triage.size);
+  if (isTrustedAuthor(item, trustedLogins)) {
+    const triage = parseTriage(item.body);
+    for (const error of triage.errors) drift.push(`#${item.number}: ${error}`);
+    consider("priority", triage.priority);
+    consider("size", triage.size);
+  } else if (/###\s*Triage/i.test(item.body)) {
+    drift.push(
+      `#${item.number}: Triage block ignored, author ${item.author ?? "unknown"} is ${item.authorAssociation ?? "unknown"}, not a collaborator`
+    );
+  }
 
   return { writes, drift };
 }
@@ -114,6 +128,8 @@ export function itemsFromGraphql(nodes) {
       body: content.body || "",
       labels: (content.labels?.nodes || []).map(l => l.name),
       repository: content.repository?.nameWithOwner ?? null,
+      authorAssociation: content.authorAssociation ?? null,
+      author: content.author?.login ?? null,
       fields
     });
   }

--- a/scripts/board-plan.test.mjs
+++ b/scripts/board-plan.test.mjs
@@ -34,6 +34,19 @@ test("reports an unknown value instead of guessing", () => {
   assert.equal(got.errors.length, 2);
 });
 
+test("reads nothing from an empty block followed by another section", () => {
+  const body = "### Triage\n\n### Additional context\nPriority: P0 – Urgent\nSize: XS\n";
+  const got = parseTriage(body);
+  assert.equal(got.priority, null);
+  assert.equal(got.size, null);
+  assert.equal(got.errors.length, 2);
+});
+
+test("parses a block with CRLF line endings", () => {
+  const body = "### Describe the bug\r\n\r\nit broke\r\n\r\n### Triage\r\nPriority: P1 – High\r\nSize: L\r\n";
+  assert.deepEqual(parseTriage(body), { priority: "P1 – High", size: "L", errors: [] });
+});
+
 test("ignores other blocks around it", () => {
   const body = "### Theme\n\nMilitary\n\n### Triage\nPriority: P0 – Urgent\nSize: XXL\n\n### Notes\nblah";
   const got = parseTriage(body);
@@ -48,7 +61,60 @@ const item = over => ({
   title: "",
   body: "",
   fields: { theme: null, priority: null, size: null },
+  authorAssociation: "COLLABORATOR",
   ...over
+});
+
+const TRIAGE = "### Triage\nPriority: P2 – Medium\nSize: M\n";
+
+test("ignores a triage block from an author who is not a collaborator", () => {
+  for (const authorAssociation of ["NONE", "CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR", undefined]) {
+    const { writes, drift } = planFieldWrites(item({ body: TRIAGE, authorAssociation }));
+    assert.deepEqual(writes, [], `wrote for ${authorAssociation}`);
+    assert.equal(drift.length, 1);
+    assert.match(drift[0], /Triage block ignored/);
+  }
+});
+
+test("honours a triage block from an owner, member or collaborator", () => {
+  for (const authorAssociation of ["OWNER", "MEMBER", "COLLABORATOR"]) {
+    const { writes, drift } = planFieldWrites(item({ body: TRIAGE, authorAssociation }));
+    assert.deepEqual(
+      writes.map(w => w.field),
+      ["priority", "size"],
+      `did not write for ${authorAssociation}`
+    );
+    assert.deepEqual(drift, []);
+  }
+});
+
+test("stays silent for an untrusted author with no triage block", () => {
+  assert.deepEqual(planFieldWrites(item({ authorAssociation: "NONE" })), { writes: [], drift: [] });
+});
+
+test("honours a triage block from an allowlisted login regardless of association", () => {
+  const trusted = new Set(["fmg-bot[bot]"]);
+  const bot = item({ body: TRIAGE, authorAssociation: "NONE", author: "fmg-bot[bot]" });
+  assert.deepEqual(
+    planFieldWrites(bot, trusted).writes.map(w => w.field),
+    ["priority", "size"]
+  );
+  const stranger = item({ body: TRIAGE, authorAssociation: "NONE", author: "someone-else" });
+  assert.deepEqual(planFieldWrites(stranger, trusted).writes, []);
+});
+
+test("ignores attribution lines that follow the triage block without a heading", () => {
+  const body =
+    "### Triage\nPriority: P2 – Medium\nSize: M\n\n---\n\nReported via Discord by `@someone` — https://discord.com/channels/1/2/3\n";
+  const { writes, drift } = planFieldWrites(item({ body }));
+  assert.deepEqual(
+    writes.map(w => [w.field, w.optionName]),
+    [
+      ["priority", "P2 – Medium"],
+      ["size", "M"]
+    ]
+  );
+  assert.deepEqual(drift, []);
 });
 
 test("fills an empty Theme from a single theme label", () => {
@@ -157,9 +223,22 @@ const node = {
     title: "Editor dialogs snap back",
     body: "### Theme\n\nUI / Editors",
     labels: { nodes: [{ name: "bug" }, { name: "theme: ui-editors" }] },
-    repository: { nameWithOwner: "Azgaar/Fantasy-Map-Generator" }
+    repository: { nameWithOwner: "Azgaar/Fantasy-Map-Generator" },
+    authorAssociation: "NONE",
+    author: { login: "reporter" }
   }
 };
+
+test("carries the author association and login through, and null when absent", () => {
+  const [got] = itemsFromGraphql([node]);
+  assert.equal(got.authorAssociation, "NONE");
+  assert.equal(got.author, "reporter");
+  const [bare] = itemsFromGraphql([
+    { id: "PVTI_z", fieldValues: { nodes: [] }, content: { __typename: "Issue", number: 7, labels: { nodes: [] } } }
+  ]);
+  assert.equal(bare.authorAssociation, null);
+  assert.equal(bare.author, null);
+});
 
 test("maps a graphql node onto the planner's item shape", () => {
   const [got] = itemsFromGraphql([node]);

--- a/scripts/board-reconcile.mjs
+++ b/scripts/board-reconcile.mjs
@@ -4,6 +4,12 @@ import { itemsFromGraphql, planFieldWrites, planLabelWrites } from "./board-plan
 
 const DRY_RUN = Boolean(process.env.DRY_RUN);
 const REPO = process.env.GITHUB_REPOSITORY || "Azgaar/Fantasy-Map-Generator";
+const TRUSTED_LOGINS = new Set(
+  (process.env.TRUSTED_TRIAGE_LOGINS || "")
+    .split(",")
+    .map(s => s.trim())
+    .filter(Boolean)
+);
 const PROJECT_NUMBER = 3;
 const OWNER = REPO.split("/")[0];
 
@@ -47,6 +53,8 @@ query($owner: String!, $number: Int!, $cursor: String) {
               body
               labels(first: 100) { nodes { name } }
               repository { nameWithOwner }
+              authorAssociation
+              author { login }
             }
             ... on PullRequest {
               number
@@ -54,6 +62,8 @@ query($owner: String!, $number: Int!, $cursor: String) {
               body
               labels(first: 100) { nodes { name } }
               repository { nameWithOwner }
+              authorAssociation
+              author { login }
             }
           }
         }
@@ -173,7 +183,7 @@ async function main() {
   const fieldWrites = [];
   const labelWrites = [];
   for (const item of items) {
-    const planned = planFieldWrites(item);
+    const planned = planFieldWrites(item, TRUSTED_LOGINS);
     fieldWrites.push(...planned.writes.map(write => ({ ...write, itemId: item.id })));
     drift.push(...planned.drift);
     const plannedLabels = planLabelWrites(item);


### PR DESCRIPTION
Follow-up to #1818, from a review of the code as it runs. One hole that should not have shipped, and three smaller things.

## The hole: any reporter could set their own Priority

The reconciler reads a `### Triage` block from the issue body to fill Priority and Size. Nothing checked *who wrote it*. Since anyone can edit the body of an issue they filed, and the workflow runs on `issues: edited`, a reporter could add three lines to their own bug and have it show as `P0 – Urgent` on your board within minutes — looking exactly like a moderator had triaged it.

Nothing exploited it, and fill-only meant you could always override, but the field was supposed to mean "someone you trust judged this", and it didn't.

Now a block counts only when the issue author's association is `OWNER`, `MEMBER` or `COLLABORATOR`, or their login is in a repository variable `TRUSTED_TRIAGE_LOGINS` (comma-separated). The variable is for the Discord intake bot once it exists, since it will write under its own identity — it can stay unset until then, which means "collaborators only". An ignored block is listed in the run summary rather than silently dropped, so a reporter who tries it is visible.

## The three smaller things

**An empty Triage block read values from the next section.** The heading regex swallowed the blank line after `### Triage`, so a body with an empty block followed by, say, `### Additional context` containing a `Priority:` line would write that value. Contrived, but it is a value nobody put in the block. Fixed, and the parser now explicitly handles the `\r\n` line endings the web form submits — the tests had only ever used `\n`.

**The workflow would go red on every fork.** It reads the board by repository owner but writes with this repository's hardcoded project id. A fork carrying the file — mine, at the next sync — would fail with `PROJECT_TOKEN is not set` on every issue event. The job is now gated on `github.repository`.

**The labeler had no fallback.** `theme-label.yml` imports the shared classifier at runtime. If that ever failed, a new issue got no label at all. It now falls back to `needs-theme` with a warning. Worth noting: that import has not yet run in production — no issue has been filed since #1818 merged — so the first new issue is its first real execution, and this makes the failure mode visible rather than silent.

## Nothing to do on your side

Dry run against the board at this commit is identical to the last scheduled run: 0 field writes, 0 label writes, 9 items reported. 39 script tests pass, 8 of them new. No behaviour changes for anything already on the board.
