### PR TITLE
Keep pre-1.140 state labels and unstroked label groups as they were saved

### DIFF
--- a/src/services/io/auto-update.labels.test.ts
+++ b/src/services/io/auto-update.labels.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import "@/generators/added-labels";
+import "@/generators/features";
+import "@/generators/labels-generator";
+import "@/generators/styles";
+import { resolveVersionConflicts } from "./auto-update";
+
+// a pre-1.140 map: label styling lives on the svg groups, state labels are saved text
+const fixture = (states: string, labelsAttrs = "") => /* html */ `<svg id="map"><g id="viewbox">
+  <g id="labels" ${labelsAttrs}>
+    <g id="burgLabels">
+      <g id="towns" fill="#3e3e4b" stroke-width="3.02" font-family="Bitter" data-size="12.9" font-size="9.67"></g>
+      <g id="cities" fill="#ff0000" stroke="#8a0000" stroke-width="0.57" data-size="15" font-size="11.25"></g>
+    </g>
+    <g id="states" data-size="33" font-size="24.75" stroke="#000000" stroke-width="0.81">${states}</g>
+  </g>
+  <g id="textPaths">
+    <path id="textPath_stateLabel1" d="M0,0 L10,0"/>
+    <path id="textPath_stateLabel2" d="M0,0 L10,0"/>
+  </g>
+</g></svg>`;
+
+const label = (id: number, text: string) =>
+  `<text id="stateLabel${id}"><textPath href="#textPath_stateLabel${id}">${text}</textPath></text>`;
+
+describe("v1.140 label group migration", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    globalThis.notes = [];
+    globalThis.options = { labels: { groups: [] }, burgs: { groups: [] } } as unknown as typeof globalThis.options;
+    globalThis.pack = {
+      features: [],
+      burgs: [],
+      states: [
+        { i: 0, name: "Neutrals" },
+        { i: 1, name: "Liga Schwarzwaldzka", fullName: "Duchy of Ormsbonia" },
+        { i: 2, name: "Kept", fullName: "Duchy of Kept" }
+      ]
+    } as unknown as typeof globalThis.pack;
+    (globalThis as typeof globalThis & { getStylePreset: () => Promise<[string, object]> }).getStylePreset =
+      async () => ["default", {}];
+  });
+
+  it("does not invent a stroke for a label group that never had one", () => {
+    document.body.innerHTML = fixture("");
+    resolveVersionConflicts("1.139.9", []);
+
+    // #towns carried a stroke-width with no stroke, so nothing was ever stroked
+    expect(styles.labels.groups.towns.attrs["stroke-width"]).toBe(0);
+    expect(styles.labels.groups.cities.attrs.stroke).toBe("#8a0000");
+    expect(styles.labels.groups.cities.attrs["stroke-width"]).toBe(0.57);
+  });
+
+  it("keeps the stroke width when the stroke is inherited from an ancestor", () => {
+    document.body.innerHTML = fixture("", 'stroke="#123456"');
+    resolveVersionConflicts("1.139.9", []);
+
+    expect(styles.labels.groups.towns.attrs.stroke).toBe("#123456");
+    expect(styles.labels.groups.towns.attrs["stroke-width"]).toBe(3.02);
+  });
+
+  it("pins a state label whose saved text the renderer would not reproduce", () => {
+    document.body.innerHTML = fixture(label(1, "Liga Schwarzwaldzka") + label(2, "Duchy of Kept"));
+    resolveVersionConflicts("1.139.9", []);
+
+    // auto mode renders fullName, so a label that showed the short name must be pinned
+    expect(pack.states[1].label?.text).toBe("Liga Schwarzwaldzka");
+    expect(pack.states[2].label?.text).toBeUndefined();
+  });
+
+  it("does not pin a short-name label when the map's state label mode is short", () => {
+    (globalThis.options as unknown as { stateLabelsMode: string }).stateLabelsMode = "short";
+    document.body.innerHTML = fixture(label(1, "Liga Schwarzwaldzka"));
+    resolveVersionConflicts("1.139.9", []);
+
+    expect(pack.states[1].label?.text).toBeUndefined();
+  });
+});

--- a/src/services/io/auto-update.ts
+++ b/src/services/io/auto-update.ts
@@ -1432,17 +1432,22 @@ export async function resolveVersionConflicts(mapVersion: string, data: string[]
       if (!state) continue;
 
       const pathEl = document.getElementById(`textPath_${textEl.id}`) as SVGPathElement | null;
-      if (pathEl) state.label = getPathLabel({ textEl, pathEl, names: [state.name, state.fullName] });
+      // the renderer reproduces only one of the two names; a label showing the other must be pinned
+      const renderedName = stateMode === "short" ? state.name : state.fullName || state.name;
+      if (pathEl) state.label = getPathLabel({ textEl, pathEl, names: [renderedName] });
     }
 
     delete (options as any).stateLabelsMode; // migrated to group settings
 
     function deriveLabelsStyle(groupEl: SVGGElement): Record<string, string | number | null> {
+      // strokes inherit and default to none: a width with no stroke above it was never stroked
+      const stroke = groupEl.closest("[stroke]")?.getAttribute("stroke") || null;
+      const isStroked = stroke !== null && stroke !== "none";
       return {
         opacity: groupEl.hasAttribute("opacity") ? Number(groupEl.getAttribute("opacity")) : 1,
         fill: groupEl.getAttribute("fill") || "#000000",
-        stroke: groupEl.getAttribute("stroke") || "#000000",
-        "stroke-width": Number(groupEl.getAttribute("stroke-width")) || 0,
+        stroke: isStroked ? stroke : "#000000",
+        "stroke-width": isStroked ? Number(groupEl.getAttribute("stroke-width")) || 0 : 0,
         style: groupEl.getAttribute("style") || null,
         "letter-spacing": Number(groupEl.getAttribute("letter-spacing")) || 0,
         "font-size": `${Number(groupEl.dataset.size) || Number(groupEl.getAttribute("font-size")) || 18}%`,


### PR DESCRIPTION
Fixes #1824.

A map saved by 1.134 loaded in 1.151 with ten Polish state labels turned into generated English ones and every town name rendered as a black blob. Nothing in the file was wrong — the issue thread has the file evidence. Two steps of the v1.140 label migration were reading it unfaithfully, and both are in the same block.

## State labels

The harvest at the end of the block treated a saved label matching *either* `state.name` or `state.fullName` as reproducible from data, and dropped it. But the renderer reproduces only one of them: `fullName` in auto and full mode (`fit-state-label.ts:71` prefers the full name whenever it fits), `name` in short mode. A state renamed via `name` alone keeps its old generated `fullName`, so a label that had always shown "Liga Schwarzwaldzka" came back as "Duchy of Ormsbonia".

The harvest now passes only the name the group's mode would actually render. A saved label showing the other one is kept as `state.label.text`, the same pin the states editor already clears on the next rename (`states-editor.ts:616`), so nothing becomes permanently frozen.

**This is broader than the one report.** Any pre-1.140 map whose state labels showed the short name under auto mode now keeps them that way instead of switching to the full name on first load. That is the faithful outcome — it is what the map showed when it was saved — but it is a visible behaviour change for old maps, so saying it here rather than letting it surprise anyone.

## Unstroked label groups

`deriveLabelsStyle` defaulted a missing `stroke` to `#000000` while carrying `stroke-width` across unchanged. SVG strokes inherit and default to `none`, so a legacy `#towns` group with `stroke-width="3.02"` and no stroke anywhere above it was never stroked. After migration a 3px black stroke was painted over 7.5px glyphs with `paint-order: normal`. Computed style on a town label after load, for the record: `fill: rgb(62,62,75); stroke: rgb(0,0,0); stroke-width: 3.02px`.

The stroke is now resolved up the group chain with `closest("[stroke]")`, and a group with none gets a width of 0 rather than an invented colour. A group whose stroke comes from an ancestor keeps its width and takes the ancestor's colour, which it was always drawing with.

## Verification

- Four new jsdom tests run the real migration against a pre-1.140 fixture via `resolveVersionConflicts("1.139.9", …)`: three failed before the fix, one is a control that passed throughout.
- The user's **original, unrepaired** file loaded headlessly on this branch renders every state label in Polish and every town label as plain Bitter — the same result the hand repair in the issue produced, now from the file as-is.
- Full unit suite 652/652, `tsc` clean, Biome clean on both the pinned version and `latest`.

Net source change is 11 lines.
