### PR TITLE
Fix: grid overlay missing from exported images

### DIFF
--- a/src/services/io/export.ts
+++ b/src/services/io/export.ts
@@ -427,7 +427,7 @@ async function getMapURL(type: string, options: GetMapURLOptions = {}): Promise<
 
   // add grid pattern
   if (cloneEl.getElementById("gridOverlay")?.hasChildNodes()) {
-    const type = cloneEl.getElementById("gridOverlay")!.getAttribute("type");
+    const type = styles.grid.options.type || "pointyHex";
     const pattern = svgDefs.getElementById(`pattern_${type}`);
     if (pattern) cloneDefs.appendChild(pattern.cloneNode(true));
   }

--- a/tests/e2e/layer-scenarios.spec.ts
+++ b/tests/e2e/layer-scenarios.spec.ts
@@ -294,6 +294,24 @@ test.describe("layer scenarios", () => {
     expect(svg).toMatch(/<g[^>]*id="biomes"/);
   });
 
+  test("a visible grid keeps its pattern in the exported svg", async ({ page }) => {
+    await page.goto("/?seed=export-grid&width=1280&height=720");
+    await waitForMap(page);
+
+    await page.evaluate(() => Layers.show("grid"));
+    await page.waitForTimeout(500);
+
+    const svg = await page.evaluate(async () => {
+      const url = await (window as any).Services.ExportMap.getMapURL("svg", { fullMap: true });
+      return await (await fetch(url)).text();
+    });
+
+    // the grid rect fills with a pattern from #defElements, which the export has to copy into its own defs
+    const type = await page.evaluate(() => (window as any).styles.grid.options.type);
+    expect(svg).toMatch(new RegExp(`<g[^>]*id="gridOverlay"[^>]*>\\s*<rect[^>]*fill="url\\(#pattern_${type}\\)"`));
+    expect(svg).toMatch(new RegExp(`<pattern[^>]*id="pattern_${type}"`));
+  });
+
   test("a preset URL param applies that preset on load", async ({ page }) => {
     const errors = watchErrors(page);
     await page.goto("/?seed=url-preset&width=1280&height=720&preset=religions");


### PR DESCRIPTION
Users report that a visible grid layer is not included in exported images. Since the style migration (#1644, 1.150.0) the grid type lives in `styles.grid.options.type` and `drawGrid` no longer writes the `type` attribute on `#gridOverlay`, but `getMapURL` still read that attribute to pick the `<pattern>` to copy into the export defs. The lookup missed, the exported rect kept a `fill="url(#pattern_pointyHex)"` that resolved to nothing, and the grid rendered as empty in SVG, PNG and JPEG exports. Maps saved before 1.150.0 still carry the old attribute in their SVG, which is why only newer maps are affected.

Fix: resolve the pattern from the style store, with the same `pointyHex` fallback `drawGrid` uses.

Test: a new e2e case in `layer-scenarios.spec.ts` turns the grid layer on, runs an SVG export, and asserts the exported file contains the `<pattern>` the grid rect references. It failed before the change and passes after.