### PR TITLE
Render image icons in the marker type menu and escape icon markup

### DIFF
--- a/src/controllers/battle-screen.ts
+++ b/src/controllers/battle-screen.ts
@@ -6,7 +6,21 @@ import { tip } from "@/components/tooltips";
 import { moveRegiment } from "@/renderers/draw-military";
 import type { Marker } from "../generators/markers-generator";
 import type { Regiment } from "../generators/military-generator";
-import { capitalize, ensureEl, getAdjective, last, list, minmax, P, Pint, rand, rn, wiki } from "../utils";
+import {
+  capitalize,
+  ensureEl,
+  escapeHtml,
+  getAdjective,
+  isImageIcon,
+  last,
+  list,
+  minmax,
+  P,
+  Pint,
+  rand,
+  rn,
+  wiki
+} from "../utils";
 
 type Side = "attackers" | "defenders";
 
@@ -527,8 +541,8 @@ function addHeaders(): void {
 
   for (const u of options.map.military.units) {
     const label = capitalize(u.name.replace(/_/g, " "));
-    const isExternal = u.icon.startsWith("http") || u.icon.startsWith("data:image");
-    const iconHTML = isExternal ? `<img src="${u.icon}" width="15" height="15">` : u.icon;
+    const isExternal = isImageIcon(u.icon);
+    const iconHTML = isExternal ? `<img src="${escapeHtml(u.icon)}" width="15" height="15">` : escapeHtml(u.icon);
     headers += `<th data-tip="${label}">${iconHTML}</th>`;
   }
 
@@ -549,10 +563,10 @@ function addRegimentToSide(side: Side, regiment: Regiment): void {
   const distance = (Math.hypot(b.y - regiment.by, b.x - regiment.bx) * options.map.units.distance.scale) | 0; // distance between regiment and its base
   const color = state.color?.[0] === "#" ? state.color : "#999";
 
-  const isExternal = regiment.icon!.startsWith("http") || regiment.icon!.startsWith("data:image");
+  const isExternal = isImageIcon(regiment.icon!);
   const iconHtml = isExternal
-    ? `<image href="${regiment.icon}" x="0.1em" y="0.1em" width="1.2em" height="1.2em"></image>`
-    : `<text x="50%" y="1em" style="text-anchor: middle">${regiment.icon}</text>`;
+    ? `<image href="${escapeHtml(regiment.icon!)}" x="0.1em" y="0.1em" width="1.2em" height="1.2em"></image>`
+    : `<text x="50%" y="1em" style="text-anchor: middle">${escapeHtml(regiment.icon!)}</text>`;
   const icon = `<svg width="1.4em" height="1.4em" style="margin-bottom: -.6em; stroke: #333">
       <rect x="0" y="0" width="100%" height="100%" fill="${color}"></rect>${iconHtml}</svg>`;
   const body = `<tbody id="battle${state.i}-${regiment.i}">`;

--- a/src/controllers/icon-selector.ts
+++ b/src/controllers/icon-selector.ts
@@ -2,7 +2,7 @@
 import { destroyDialog } from "@/components/dialog/dialog-helpers";
 import { tip } from "@/components/tooltips";
 import { ICONS, ICONS_PER_ROW } from "@/data/icons-list";
-import { ensureEl } from "@/utils";
+import { ensureEl, escapeHtml, isImageIcon } from "@/utils";
 
 function open(initial: string, callback: (value: string) => void): void {
   const dialog = renderDialog();
@@ -34,7 +34,7 @@ function open(initial: string, callback: (value: string) => void): void {
     const urlInput = addImageButton.previousElementSibling as HTMLInputElement;
     const url = urlInput.value;
     if (!url) return tip("Enter image URL to add", false, "error", 4000);
-    if (!url.match(/^((http|https):\/\/)|data:image\//)) return tip("Enter valid URL", false, "error", 4000);
+    if (!isImageIcon(url)) return tip("Enter valid URL", false, "error", 4000);
 
     addImage(url, callback);
     callback(url);
@@ -101,12 +101,11 @@ function renderIcons(table: HTMLTableElement): void {
 
 /** Collect the external images already used as icons on this map */
 function getUsedImages(): Set<string> {
-  const isExternal = (url: string) => url.startsWith("http") || url.startsWith("data:image");
   const images = new Set<string>();
 
-  for (const unit of options.map.military.units) if (isExternal(unit.icon)) images.add(unit.icon);
+  for (const unit of options.map.military.units) if (isImageIcon(unit.icon)) images.add(unit.icon);
   for (const state of pack.states) {
-    for (const regiment of state?.military || []) if (isExternal(regiment.icon)) images.add(regiment.icon);
+    for (const regiment of state?.military || []) if (isImageIcon(regiment.icon)) images.add(regiment.icon);
   }
 
   return images;
@@ -114,8 +113,11 @@ function getUsedImages(): Set<string> {
 
 function addImage(url: string, callback: (value: string) => void): void {
   const image = document.createElement("div");
-  image.style.cssText = `width: 2.2em; height: 2.2em; background-size: cover; background-image: url(${url})`;
+  image.style.cssText = "width: 2.2em; height: 2.2em; background-size: cover";
+  image.style.backgroundImage = `url("${url.replace(/["\\]/g, "\\$&")}")`;
   image.onclick = () => callback(url);
+  image.onmouseover = () =>
+    tip(`Click to select <img src="${escapeHtml(url)}" style="width: 1em; height: 1em; vertical-align: middle"> icon`);
   ensureEl("addedIcons").appendChild(image);
 }
 

--- a/src/controllers/markers-editor.ts
+++ b/src/controllers/markers-editor.ts
@@ -6,7 +6,7 @@ import { Controllers } from "@/controllers";
 import type { Marker } from "@/generators/markers-generator";
 import { Notes } from "@/generators/notes";
 import { drawMarkers, setEditedMarker } from "@/renderers/draw-markers";
-import { ensureEl, findEl, rn } from "../utils";
+import { ensureEl, escapeHtml, findEl, isImageIcon, rn } from "../utils";
 
 let selectedElement: SVGSVGElement;
 let selectedMarker: Marker;
@@ -155,10 +155,9 @@ function dragMarker(this: SVGElement, event: D3DragEvent<SVGElement, unknown, un
 
 function updateInputs(): void {
   const marker = selectedMarker;
-  ensureEl("markerIcon").innerHTML =
-    marker.icon.startsWith("http") || marker.icon.startsWith("data:image")
-      ? `<img src="${marker.icon}" style="width: 1em; height: 1em;">`
-      : marker.icon;
+  ensureEl("markerIcon").innerHTML = isImageIcon(marker.icon)
+    ? `<img src="${escapeHtml(marker.icon)}" style="width: 1em; height: 1em;">`
+    : escapeHtml(marker.icon);
 
   ensureEl<HTMLInputElement>("markerType").value = marker.type || "";
   ensureEl<HTMLInputElement>("markerIconSize").value = String(marker.px || 12);
@@ -178,8 +177,10 @@ function changeMarkerType(this: HTMLInputElement): void {
 
 function changeMarkerIcon(): void {
   Controllers.IconSelector.open(selectedMarker.icon, value => {
-    const isExternal = value.startsWith("http") || value.startsWith("data:image");
-    ensureEl("markerIcon").innerHTML = isExternal ? `<img src="${value}" style="width: 1em; height: 1em;">` : value;
+    const isExternal = isImageIcon(value);
+    ensureEl("markerIcon").innerHTML = isExternal
+      ? `<img src="${escapeHtml(value)}" style="width: 1em; height: 1em;">`
+      : escapeHtml(value);
 
     getSameTypeMarkers().forEach(marker => {
       marker.icon = value;

--- a/src/controllers/markers-in-radius.ts
+++ b/src/controllers/markers-in-radius.ts
@@ -7,7 +7,7 @@ import type { Marker } from "@/generators/markers-generator";
 import { clearMarkerRadius, drawMarkerRadius } from "@/renderers/draw-marker-radius";
 import { setMarkersFilter } from "@/renderers/draw-markers";
 import { highlightElement } from "@/renderers/overlays/highlight";
-import { downloadFile, ensureEl, getFileName, getLatitude, getLongitude } from "@/utils";
+import { downloadFile, ensureEl, escapeHtml, getFileName, getLatitude, getLongitude, isImageIcon } from "@/utils";
 
 let center: Marker | null = null;
 let lastRadius = 0;
@@ -102,10 +102,9 @@ function renderMarkersList(inRange: Marker[]): void {
   ensureEl("markersRadiusList").innerHTML = inRangeMarkers
     .map(({ i, type, icon, pinned, lock, name: markerName }) => {
       const name = markerName || type;
-      const iconHtml =
-        icon.startsWith("http") || icon.startsWith("data:image")
-          ? `<img src="${icon}" style="width:1.2em; height:1.2em; vertical-align:middle">`
-          : `<span style="width:1.3em">${icon}</span>`;
+      const iconHtml = isImageIcon(icon)
+        ? `<img src="${escapeHtml(icon)}" style="width:1.2em; height:1.2em; vertical-align:middle">`
+        : `<span style="width:1.3em">${escapeHtml(icon)}</span>`;
       return /* html */ `
         <div class="states" data-id="${i}" style="display:flex; align-items:center; gap:.15em">
           ${iconHtml}

--- a/src/controllers/markers-overview.ts
+++ b/src/controllers/markers-overview.ts
@@ -16,7 +16,7 @@ import { Controllers } from "@/controllers";
 import type { Marker } from "@/generators/markers-generator";
 import { setMarkersFilter } from "@/renderers/draw-markers";
 import { highlightElement } from "@/renderers/overlays/highlight";
-import { downloadFile, getFileName, getLatitude, getLongitude } from "@/utils";
+import { downloadFile, escapeHtml, getFileName, getLatitude, getLongitude, isImageIcon } from "@/utils";
 import { ensureEl } from "../utils";
 
 const dialogId = "markersOverview" as const;
@@ -186,16 +186,22 @@ function populateMarkerTypeMenu(): void {
   const types = [{ type: "empty", icon: "❓" }, ...Markers.getConfig()];
   types.forEach(({ icon, type }) => {
     const option = document.createElement("button");
-    option.textContent = `${icon} ${type}`;
+    option.innerHTML = `${iconHtml(icon)} ${type}`;
     menu.appendChild(option);
 
     option.addEventListener("click", () => {
-      ensureEl("markerTypeSelector").textContent = icon;
+      ensureEl("markerTypeSelector").innerHTML = iconHtml(icon);
       ensureEl<HTMLInputElement>("addedMarkerType").value = type;
       changeMarkerType();
       toggleMarkerTypeMenu();
     });
   });
+}
+
+function iconHtml(icon: string): string {
+  return isImageIcon(icon)
+    ? `<img src="${escapeHtml(icon)}" style="width:1.2em; height:1.2em; vertical-align: middle;">`
+    : escapeHtml(icon);
 }
 
 function handleLineClick(ev: MouseEvent): void {
@@ -257,9 +263,9 @@ function renderMarkersPage(view: TableView<Marker>): void {
         <div class="states" data-id=${i} data-type="${type}">
           <div data-col="type">
             ${
-              icon.startsWith("http") || icon.startsWith("data:image")
-                ? `<img src="${icon}" data-tip="Marker icon" style="width:1.2em; height:1.2em; vertical-align: middle;">`
-                : `<span data-tip="Marker icon" style="width:1.2em">${icon}</span>`
+              isImageIcon(icon)
+                ? `<img src="${escapeHtml(icon)}" data-tip="Marker icon" style="width:1.2em; height:1.2em; vertical-align: middle;">`
+                : `<span data-tip="Marker icon" style="width:1.2em">${escapeHtml(icon)}</span>`
             }
             <span data-tip="Marker type">${type}</span>
           </div>

--- a/src/controllers/markers-settings.ts
+++ b/src/controllers/markers-settings.ts
@@ -2,7 +2,7 @@ import { destroyDialog, refreshEditors } from "@/components/dialog/dialog-helper
 import { Layers } from "@/components/layers";
 import { tip } from "@/components/tooltips";
 import { Controllers } from "@/controllers";
-import { ensureEl } from "@/utils";
+import { ensureEl, escapeHtml, isImageIcon } from "@/utils";
 
 const DIALOG_ID = "markersSettings";
 
@@ -66,14 +66,14 @@ function drawConfigTable(): void {
   </tr></thead>`;
 
   const lines = Markers.getConfig().map(({ type, icon, multiplier }) => {
-    const isExternal = icon.startsWith("http") || icon.startsWith("data:image");
+    const isExternal = isImageIcon(icon);
     return /* html */ `<tr>
       <td><input class="type" value="${type}" /></td>
       <td style="position: relative">
-        <img class="image" src="${isExternal ? icon : ""}" ${
+        <img class="image" src="${isExternal ? escapeHtml(icon) : ""}" ${
           isExternal ? "" : "hidden"
         } style="width:1.2em; height:1.2em; vertical-align: middle;">
-        <span class="emoji" style="font-size:1.2em">${isExternal ? "" : icon}</span>
+        <span class="emoji" style="font-size:1.2em">${isExternal ? "" : escapeHtml(icon)}</span>
         <button class="changeIcon icon-pencil"></button>
       </td>
       <td><input class="multiplier" type="number" min="0" max="100" step="0.1" value="${multiplier}" /></td>
@@ -91,7 +91,7 @@ function drawConfigTable(): void {
       if (!image || !emoji) return;
 
       Controllers.IconSelector.open(image.getAttribute("src") || emoji.textContent || "", value => {
-        const isExternal = value.startsWith("http") || value.startsWith("data:image");
+        const isExternal = isImageIcon(value);
         image.setAttribute("src", isExternal ? value : "");
         image.hidden = !isExternal;
         emoji.textContent = isExternal ? "" : value;

--- a/src/controllers/military-overview.ts
+++ b/src/controllers/military-overview.ts
@@ -15,7 +15,7 @@ import { tip } from "@/components/tooltips";
 import { Controllers } from "@/controllers";
 import type { State } from "@/generators/states-generator";
 import type { MilitaryUnit } from "@/types/Military";
-import { downloadFile, getFileName } from "@/utils";
+import { downloadFile, getFileName, isImageIcon } from "@/utils";
 import { capitalize, ensureEl, rn, sanitizeId, si, wiki } from "../utils";
 
 const dialogId = "militaryOverview" as const;
@@ -490,7 +490,7 @@ function militaryCustomize(): void {
     button.dataset.icon = icon;
     button.textContent = "";
 
-    if (icon.startsWith("http") || icon.startsWith("data:image")) {
+    if (isImageIcon(icon)) {
       const image = document.createElement("img");
       image.src = icon;
       image.style.cssText = "width: 1.2em; height: 1.2em; pointer-events: none";

--- a/src/controllers/regiment-editor.ts
+++ b/src/controllers/regiment-editor.ts
@@ -6,7 +6,7 @@ import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
 import { Notes } from "@/generators/notes";
 import { drawRegiment, moveRegiment } from "@/renderers/draw-military";
-import { speak } from "@/utils";
+import { escapeHtml, isImageIcon, speak } from "@/utils";
 import type { Regiment } from "../generators/military-generator";
 import { capitalize, ensureEl, getPointer, last, rn } from "../utils";
 
@@ -113,10 +113,9 @@ function getRegiment(): Regiment | undefined {
 function updateRegimentData(regiment: Regiment): void {
   ensureEl("regimentType").className = regiment.n ? "icon-anchor" : "icon-users";
   ensureEl<HTMLInputElement>("regimentName").value = regiment.name;
-  ensureEl("regimentEmblem").innerHTML =
-    regiment.icon!.startsWith("http") || regiment.icon!.startsWith("data:image")
-      ? `<img src="${regiment.icon}" style="width: 1em; height: 1em;">`
-      : regiment.icon!;
+  ensureEl("regimentEmblem").innerHTML = isImageIcon(regiment.icon!)
+    ? `<img src="${escapeHtml(regiment.icon!)}" style="width: 1em; height: 1em;">`
+    : escapeHtml(regiment.icon!);
 
   const composition = ensureEl("regimentComposition");
   composition.innerHTML = options.map.military.units
@@ -236,7 +235,7 @@ function changeEmblem(): void {
 
   Controllers.IconSelector.open(regiment.icon ?? "", value => {
     regiment.icon = value;
-    const isExternal = value.startsWith("http") || value.startsWith("data:image");
+    const isExternal = isImageIcon(value);
     ensureEl("regimentEmblem").innerHTML = isExternal ? `<img src="${value}" style="width: 1em; height: 1em;">` : value;
     selectedRegiment!.querySelector(".regimentIcon")!.textContent = isExternal ? "" : value;
     selectedRegiment!.querySelector(".regimentImage")!.setAttribute("href", isExternal ? value : "");

--- a/src/controllers/regiments-overview.ts
+++ b/src/controllers/regiments-overview.ts
@@ -16,7 +16,7 @@ import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
 import type { State } from "@/generators/states-generator";
 import { drawRegiment } from "@/renderers/draw-military";
-import { downloadFile, getFileName, getLatitude, getLongitude } from "@/utils";
+import { downloadFile, escapeHtml, getFileName, getLatitude, getLongitude, isImageIcon } from "@/utils";
 import type { Regiment } from "../generators/military-generator";
 import { capitalize, ensureEl, findEl, getPointer, last, si } from "../utils";
 
@@ -184,10 +184,9 @@ function renderRegimentsPage(view: TableView<RegimentRow>): void {
           return `<div data-col="${unitColumnKey(unit.name)}" data-tip="${capitalize(unit.name)} units number">${percentage ? percent(value, unitTotals[unit.name]) : value}</div>`;
         })
         .join("");
-      const emblem =
-        regiment.icon!.startsWith("http") || regiment.icon!.startsWith("data:image")
-          ? `<img data-col="emblem" src="${regiment.icon}" data-tip="Regiment's emblem">`
-          : `<span data-col="emblem" data-tip="Regiment's emblem">${regiment.icon}</span>`;
+      const emblem = isImageIcon(regiment.icon!)
+        ? `<img data-col="emblem" src="${escapeHtml(regiment.icon!)}" data-tip="Regiment's emblem">`
+        : `<span data-col="emblem" data-tip="Regiment's emblem">${escapeHtml(regiment.icon!)}</span>`;
 
       return /* html */ `<div class="states" data-id="${regiment.i}" data-s="${state.i}">
         <fill-box data-col="color" data-tip="${state.fullName}" fill="${state.color}" disabled></fill-box>

--- a/src/renderers/draw-markers.ts
+++ b/src/renderers/draw-markers.ts
@@ -1,7 +1,9 @@
 import { Layers } from "@/components/layers";
 import type { Marker } from "@/generators/markers-generator";
 import { ViewportLayers, type ViewportRenderContext } from "@/renderers/viewport/viewport-renderer";
+import { isImageIcon } from "@/utils/fileUtils";
 import { rn } from "@/utils/numberUtils";
+import { escapeHtml } from "@/utils/stringUtils";
 
 const layer = ViewportLayers.register({ id: "markers", render: reconcileMarkers });
 let editedMarker: Marker | null = null;
@@ -92,9 +94,9 @@ function getMarkerGeometry({ x, y, size = 30 }: Marker, rescale: number, scale: 
 }
 
 function getMarkerContent({ icon, dx = 50, dy = 50, px = 12, pin, fill, stroke }: Marker): string {
-  const isExternal = icon.startsWith("http") || icon.startsWith("data:image");
+  const isExternal = isImageIcon(icon);
   return /* html */ `
       <g>${getPin(pin, fill, stroke)}</g>
-      <text x="${dx}%" y="${dy}%" font-size="${px}px" >${isExternal ? "" : icon}</text>
-      <image x="${dx / 2}%" y="${dy / 2}%" width="${px}px" height="${px}px" href="${isExternal ? icon : ""}" />`;
+      <text x="${dx}%" y="${dy}%" font-size="${px}px" >${isExternal ? "" : escapeHtml(icon)}</text>
+      <image x="${dx / 2}%" y="${dy / 2}%" width="${px}px" height="${px}px" href="${isExternal ? escapeHtml(icon) : ""}" />`;
 }

--- a/src/renderers/draw-military.ts
+++ b/src/renderers/draw-military.ts
@@ -1,6 +1,6 @@
 import { color, easeSinInOut, select, transition } from "d3";
 import type { Regiment } from "../generators/military-generator";
-import { rn } from "../utils";
+import { isImageIcon, rn } from "../utils";
 
 export const drawMilitary = (): void => {
   TIME && console.time("drawMilitary");
@@ -64,14 +64,14 @@ const drawRegimentsRenderer = (regiments: Regiment[], s: number): void => {
     .attr("text-rendering", "optimizeSpeed")
     .attr("x", d => x(d) - size)
     .attr("y", d => d.y)
-    .text(d => (d.icon!.startsWith("http") || d.icon!.startsWith("data:image") ? "" : d.icon!));
+    .text(d => (isImageIcon(d.icon!) ? "" : d.icon!));
   g.append("image")
     .attr("class", "regimentImage")
     .attr("x", d => x(d) - h)
     .attr("y", d => y(d))
     .attr("height", h)
     .attr("width", h)
-    .attr("href", d => (d.icon!.startsWith("http") || d.icon!.startsWith("data:image") ? d.icon! : ""));
+    .attr("href", d => (isImageIcon(d.icon!) ? d.icon! : ""));
 };
 
 export const drawRegiment = (reg: Regiment, stateId: number): void => {
@@ -118,14 +118,14 @@ export const drawRegiment = (reg: Regiment, stateId: number): void => {
     .attr("text-rendering", "optimizeSpeed")
     .attr("x", x1 - size)
     .attr("y", reg.y)
-    .text(reg.icon!.startsWith("http") || reg.icon!.startsWith("data:image") ? "" : reg.icon!);
+    .text(isImageIcon(reg.icon!) ? "" : reg.icon!);
   g.append("image")
     .attr("class", "regimentImage")
     .attr("x", x1 - h)
     .attr("y", y1)
     .attr("height", h)
     .attr("width", h)
-    .attr("href", reg.icon!.startsWith("http") || reg.icon!.startsWith("data:image") ? reg.icon! : "");
+    .attr("href", isImageIcon(reg.icon!) ? reg.icon! : "");
 };
 
 // move one regiment to another

--- a/src/utils/fileUtils.test.ts
+++ b/src/utils/fileUtils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { isImageIcon } from "./fileUtils";
+
+describe("isImageIcon", () => {
+  it("recognises http and data image URLs", () => {
+    expect(isImageIcon("https://example.com/icon.png")).toBe(true);
+    expect(isImageIcon("data:image/svg+xml;base64,PHN2Zy8+")).toBe(true);
+  });
+
+  it("rejects emoji, plain text and other schemes", () => {
+    expect(isImageIcon("⛏️")).toBe(false);
+    expect(isImageIcon("")).toBe(false);
+    expect(isImageIcon("javascript:alert(1)")).toBe(false);
+    expect(isImageIcon("httpx")).toBe(false);
+    expect(isImageIcon('" onerror="alert(1)" data:image/')).toBe(false);
+  });
+});

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -29,6 +29,11 @@ export function downloadFile(data: BlobPart, name: string, type = "text/plain"):
   window.setTimeout(() => window.URL.revokeObjectURL(url), 2000);
 }
 
+/** Whether an icon value is an image URL rather than an emoji or text glyph */
+export function isImageIcon(icon: string): boolean {
+  return /^(https?:\/\/|data:image\/)/.test(icon);
+}
+
 /** Read the selected file as text and pass its content to the callback */
 export function uploadFile(input: HTMLInputElement, callback: (data: string) => void): void {
   const file = input.files?.[0];

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -22,7 +22,7 @@ import {
   wiki
 } from "./commonUtils";
 import { drawCellsValue, drawPath, drawPoint, drawPolygons, drawRouteConnections } from "./debugUtils";
-import { downloadFile, getFileName, uploadFile } from "./fileUtils";
+import { downloadFile, getFileName, isImageIcon, uploadFile } from "./fileUtils";
 import { distanceSquared, rollups } from "./functionUtils";
 import { isLand, isWater, SEA_LEVEL } from "./heightUtils";
 import { applyOption, ensureEl, findEl, getComposedPath, getNextId, getPointer } from "./nodeUtils";
@@ -192,6 +192,7 @@ export {
   getVertexPath,
   initializePrompt,
   isCtrlClick,
+  isImageIcon,
   isLand,
   isValidJSON,
   isVowel,


### PR DESCRIPTION
## Problem

1. The "add marker" type menu in the Markers Overview writes each config icon as plain text. A marker type whose icon is an image URL (set via the generation settings or the Icon Selector) lists the URL instead of a picture, and the selector button shows it too after a pick.
2. Hovering an external-image thumbnail in the Icon Selector leaves the tooltip showing the last emoji's message, because the thumbnails set no tooltip.
3. Marker and regiment icons are read from the map file and spliced into `innerHTML` unescaped at ten sites (marker editor, overview rows, markers-in-radius, generation settings, marker renderer, regiment editor, regiments overview, battle screen). A crafted `.map` with an icon such as `"><img src=x onerror=…>` executes as soon as the marker editor opens.

## Fix

- Menu entries and the selector button render an `<img>` for URL icons, matching the overview rows.
- New `isImageIcon` in `fileUtils.ts`, requiring an `http://`, `https://` or `data:image/` prefix. It replaces the 18 inline `startsWith("http") || startsWith("data:image")` checks and the selector's half-anchored URL regex.
- Every icon interpolation goes through the existing `escapeHtml`, on both the image and the glyph branch.
- Selector thumbnails show their own image in the tooltip, and set their background via the `backgroundImage` property with quotes escaped instead of `cssText`.

## Verification

- `tsc --noEmit` clean, Biome clean, 944 unit tests pass (new `isImageIcon` cases included).
- Headless Chromium on master + this branch: a type with a data-URI icon renders as an image in the menu and on the selector button; no menu entry contains the text `data:image`; a thumbnail hover puts the image in the tooltip.
- Injection test: breakout payloads planted on two markers, a marker type, a regiment and a unit type, then both layers drawn and the overview, editor, settings, regiments overview and Icon Selector opened. Zero injected elements, `onerror` never fired.
