### PR TITLE
fix: fit an opened map to the window it is opened in

### DIFF
--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -105,6 +105,17 @@ The **viewport** is the clearest case of the last rule, and the one most often c
 extent: the extent is the coordinate space the map's geometry lives in, fixed for the life of its
 graph and asked for before the map exists; the viewport is the screen window onto it.
 
+Neither bounds the other; the **zoom floor** is what reconciles them, and it is derived from the
+two rather than configured: `max(viewport.width / extent.width, viewport.height / extent.height)`,
+rounded up. A map opened on a screen bigger than the one it was made on is scaled up until it
+covers the window; a map bigger than the window zooms out below 1 until it fits. Either way there
+is never canvas beside the map, and a map opens at that floor - the fitted view - whatever window
+size it was saved on.
+
+`app.zoomExtent.min` is therefore a derived value the canvas writes and the panel displays, not a
+request the user makes: it is recomputed whenever the viewport or the extent changes. Typing a
+value into the control still applies it, and it stands until the next fit re-derives it.
+
 ### The definition sets
 
 Military unit types, transport types, burg groups, label groups and the coastline settings sit in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fantasy-map-generator",
-  "version": "1.152.0",
+  "version": "1.152.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fantasy-map-generator",
-      "version": "1.152.0",
+      "version": "1.152.1",
       "license": "MIT",
       "dependencies": {
         "alea": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fantasy-map-generator",
   "productName": "Fantasy Map Generator",
-  "version": "1.152.0",
+  "version": "1.152.1",
   "description": "Azgaar's _Fantasy Map Generator_ is a free web application that helps fantasy writers, game masters, and cartographers create and edit fantasy maps.",
   "homepage": "https://github.com/Azgaar/Fantasy-Map-Generator#readme",
   "bugs": {

--- a/src/components/canvas.ts
+++ b/src/components/canvas.ts
@@ -1,10 +1,9 @@
 import { select } from "d3";
 import { Layers } from "@/components/layers";
 import { setViewportSize, viewport } from "@/components/viewport";
-import { setTranslateExtent, setZoomExtent } from "@/components/zoom";
+import { constrainZoom, setTranslateExtent, setZoomExtent } from "@/components/zoom";
 import { fitLegendBox } from "@/renderers/draw-legend";
 import { findEl } from "@/utils/nodeUtils";
-import { rn } from "@/utils/numberUtils";
 
 /** Resize everything that covers the whole map to the graph extent */
 export function applyGraphSize(): void {
@@ -21,19 +20,31 @@ export function applyGraphSize(): void {
   select("#deftemp").select("mask#water > rect").attr("width", width).attr("height", height);
 }
 
+/**
+ * The zoom floor is the scale at which the map covers the viewport, derived from the two of them:
+ * a map larger than the window zooms out until it fits, a smaller one in until it covers. It is
+ * also what the panel shows, so the control never claims a limit the canvas does not enforce.
+ * Rounded up, so the rounding itself cannot leave a hairline of canvas at the edge
+ */
+export function applyZoomExtent(): void {
+  const { width, height } = options.map.graph;
+  const cover = Math.ceil(Math.max(viewport.width / width, viewport.height / height) * 1000) / 1000;
+
+  Options.set(o => (o.app.zoomExtent.min = cover));
+  const input = findEl<HTMLInputElement>("zoomExtentMin");
+  if (input) input.value = String(cover);
+
+  setZoomExtent(cover, options.app.zoomExtent.max);
+  constrainZoom(); // d3 applies a new extent to gestures only; the current view has to be pulled in
+}
+
 /** Set the map window on screen and re-fit everything drawn in screen space */
 export function setViewport(width: number, height: number): void {
   setViewportSize(width, height);
   select("#map").attr("width", viewport.width).attr("height", viewport.height);
 
-  // the map may never zoom out past covering the window, whatever extent the user asked for
-  const { min, max } = options.app.zoomExtent;
-  const coverMin = rn(
-    Math.max(viewport.width / options.map.graph.width, viewport.height / options.map.graph.height),
-    3
-  );
   setTranslateExtent(0, 0, options.map.graph.width, options.map.graph.height);
-  setZoomExtent(Math.max(min, coverMin), max);
+  applyZoomExtent();
 
   const showViewport = (id: string, value: number) => {
     const input = findEl<HTMLInputElement>(id);
@@ -48,12 +59,15 @@ export function setViewport(width: number, height: number): void {
 
 /**
  * The viewport a map opens at, and the one a window resize settles on: the size the user set if
- * they set one, otherwise as much of the map as the browser window can show. Either way it is
- * bounded by the extent - past that there is nothing but empty canvas to show
+ * they set one, otherwise the whole browser window. The extent does not bound it - a map smaller
+ * than the window is scaled up to cover it, never letterboxed
  */
 export function fitMapToScreen(): void {
-  const { width, height } = options.map.graph;
   const kept = options.app.viewport;
   const wanted = kept ?? { width: window.innerWidth, height: window.innerHeight };
-  setViewport(Math.min(width, wanted.width), Math.min(height, wanted.height));
+
+  // a hidden or headless tab reports no size, which would collapse the viewport
+  const width = wanted.width > 0 ? wanted.width : options.map.graph.width;
+  const height = wanted.height > 0 ? wanted.height : options.map.graph.height;
+  setViewport(width, height);
 }

--- a/src/components/options/tabs/options-tab.test.ts
+++ b/src/components/options/tabs/options-tab.test.ts
@@ -8,11 +8,16 @@ import { toggleAssistant } from "@/services/assistant";
 
 vi.mock("@/components/layers", () => ({ Layers: { draw: vi.fn() } }));
 vi.mock("@/components/zoom", () => ({
+  constrainZoom: vi.fn(),
   setMapZoom: vi.fn(),
   setTranslateExtent: vi.fn(),
   setZoomExtent: vi.fn()
 }));
-vi.mock("@/components/canvas", () => ({ fitMapToScreen: vi.fn(), setViewport: vi.fn() }));
+vi.mock("@/components/canvas", () => ({
+  applyZoomExtent: vi.fn(),
+  fitMapToScreen: vi.fn(),
+  setViewport: vi.fn()
+}));
 vi.mock("@/components/options/io-panes", () => ({
   showExportPane: vi.fn(),
   showLoadPane: vi.fn(),

--- a/src/components/options/tabs/options-tab.ts
+++ b/src/components/options/tabs/options-tab.ts
@@ -1,5 +1,5 @@
 import { hsl, select } from "d3";
-import { fitMapToScreen, setViewport } from "@/components/canvas";
+import { applyZoomExtent, fitMapToScreen, setViewport } from "@/components/canvas";
 import { Layers } from "@/components/layers";
 import { DEFAULT_THEME_COLOR } from "@/components/options-model";
 import type { OptionsData } from "@/components/options-schema";
@@ -7,7 +7,7 @@ import { Pins } from "@/components/pins";
 import { generateMapWithSeed, showSeedHistoryDialog } from "@/components/seed";
 import { tip } from "@/components/tooltips";
 import { viewport } from "@/components/viewport";
-import { setMapZoom, setTranslateExtent, setZoomExtent } from "@/components/zoom";
+import { constrainZoom, setMapZoom, setTranslateExtent, setZoomExtent } from "@/components/zoom";
 import { Controllers } from "@/controllers";
 import { getPointsNumber } from "@/data/graph-density";
 import { heightmapTemplates } from "@/data/heightmap-templates";
@@ -554,7 +554,7 @@ const TEMPLATE = /* html */ `
     </tr>
     <tr data-tip="Set minimum and maximum possible zoom level">
       <td>
-        <i data-tip="Restore default zoom extent: [1, 20]" id="zoomExtentDefault" class="icon-ccw"></i>
+        <i data-tip="Restore the default zoom extent" id="zoomExtentDefault" class="icon-ccw"></i>
       </td>
       <td>Zoom extent</td>
       <td>
@@ -957,15 +957,15 @@ function changeZoomExtent(value: string): void {
 }
 
 /**
- * The window onto the map, not the map. It is bounded by the extent the graph was built on: asking
- * for more shows nothing but empty canvas. See docs/architecture/configuration.md
+ * The window onto the map, not the map. It is free of the extent the graph was built on: a viewport
+ * larger than the extent scales the map up to cover it. See docs/architecture/configuration.md
  */
 function changeViewportSize(): void {
   const width = +optionInput("viewportWidth").value;
   const height = +optionInput("viewportHeight").value;
   if (!(width > 0) || !(height > 0)) return;
 
-  setViewport(Math.min(width, options.map.graph.width), Math.min(height, options.map.graph.height));
+  setViewport(width, height);
   Options.set(o => (o.app.viewport = { width: viewport.width, height: viewport.height }));
 }
 
@@ -975,10 +975,12 @@ function fitViewportToWindow(): void {
   fitMapToScreen();
 }
 
+/** The default is the fitted view: the ceiling is the app's, the floor is the map's and the window's */
 function restoreDefaultZoomExtent(): void {
-  const { min, max } = Options.getDefaultOptions().app.zoomExtent;
-  setZoomExtentPreference(min, max);
-  setMapZoom(min);
+  Options.set(o => (o.app.zoomExtent.max = Options.getDefaultOptions().app.zoomExtent.max));
+  optionInput("zoomExtentMax").value = String(options.app.zoomExtent.max);
+  applyZoomExtent();
+  setMapZoom(options.app.zoomExtent.min);
 }
 
 /** The single writer of the zoom extent: one pair, normalised together and shown together */
@@ -986,7 +988,8 @@ function setZoomExtentPreference(min: number, max: number): void {
   Options.set(o => (o.app.zoomExtent = { min, max }));
   optionInput("zoomExtentMin").value = String(min);
   optionInput("zoomExtentMax").value = String(max);
-  setZoomExtent(min, max);
+  setZoomExtent(min, max); // a hand-set floor stands until the next fit re-derives it
+  constrainZoom();
 }
 
 /** Let the user pan beyond the canvas edges, so a map can be inspected off-centre */
@@ -1082,7 +1085,7 @@ export function restoreUi(): void {
 
   // `syncInputs` has already put every preference in its control; these are the ones that also do
   // something the moment they are read back. See docs/architecture/configuration.md
-  const { ui, rendering, emblems, zoomExtent } = options.app;
+  const { ui, rendering, emblems } = options.app;
 
   Emblems.setShape(emblems.shape);
   changeTooltipSize(ui.tooltipSize);
@@ -1093,7 +1096,7 @@ export function restoreUi(): void {
 
   changeDialogsTheme(ui.themeColor, ui.transparency);
   setRendering(rendering);
-  setZoomExtent(zoomExtent.min, zoomExtent.max);
+  applyZoomExtent();
 }
 
 // Legacy seam: the classic style.js reads the culture set cap, the submap and transform tools

--- a/src/components/zoom.ts
+++ b/src/components/zoom.ts
@@ -1,4 +1,4 @@
-import { type D3ZoomEvent, select, zoom, zoomIdentity } from "d3";
+import { type D3ZoomEvent, select, zoom, zoomIdentity, zoomTransform } from "d3";
 import { Layers } from "@/components/layers";
 import { setViewportTransform, viewport } from "@/components/viewport";
 import { ViewportLayers } from "@/renderers/viewport/viewport-renderer";
@@ -116,9 +116,14 @@ export function zoomTo(x: number, y: number, z = 8, duration = 2000): void {
   select<SVGSVGElement, unknown>("#map").transition().duration(duration).call(zoomBehavior.transform, transform);
 }
 
-/** Reset zoom to initial */
+/** Reset zoom to the initial view: the map origin at the smallest scale the extents allow */
 export function resetZoom(duration = 1000): void {
-  select<SVGSVGElement, unknown>("#map").transition().duration(duration).call(zoomBehavior.transform, zoomIdentity);
+  const [min] = zoomBehavior.scaleExtent();
+  const transform = zoomIdentity.scale(min);
+  const selection = select<SVGSVGElement, unknown>("#map");
+
+  if (duration) selection.transition().duration(duration).call(zoomBehavior.transform, transform);
+  else zoomBehavior.transform(selection, transform); // no transition: the caller redraws right after
 }
 
 export function panMap(x: number, y: number): void {
@@ -135,6 +140,16 @@ export function changeMapZoom(factor: number): void {
 
 export function setZoomExtent(min: number, max: number): void {
   zoomBehavior.scaleExtent([min, max]);
+}
+
+/**
+ * Pull the current view back inside the extents. d3 applies them to gestures only, so a scale or a
+ * translate that a new viewport or a new map has put out of bounds stays there until asked
+ */
+export function constrainZoom(): void {
+  const node = findEl<SVGSVGElement>("map");
+  if (!node || !("__zoom" in node)) return; // no zoom behavior on the element yet
+  zoomBehavior.scaleTo(select<SVGSVGElement, unknown>(node), zoomTransform(node).k);
 }
 
 export function setTranslateExtent(x0: number, y0: number, x1: number, y1: number): void {

--- a/src/services/io/load.ts
+++ b/src/services/io/load.ts
@@ -6,6 +6,7 @@ import { registerMap } from "@/components/lifecycle";
 import { syncOptionInputs } from "@/components/options/tabs/options-tab";
 import { clearMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
+import { resetZoom } from "@/components/zoom";
 import { GraphOverride } from "@/generators/graph-override";
 import { invalidateEmblems } from "@/renderers/draw-emblems";
 import { clearLegend } from "@/renderers/draw-legend";
@@ -667,9 +668,10 @@ async function parseLoadedData(data: string[], mapVersion: string | null): Promi
     Layers.drawAll();
     applyStoredStyles();
     applyDefaultViewboxEvents();
+    fitMapToScreen();
+    resetZoom(0); // an opened map is shown fitted, whatever window size it was made on
     focusOn();
     invokeActiveZooming();
-    fitMapToScreen();
 
     WARN && console.warn(`TOTAL: ${rn((performance.now() - uploadTimeStart) / 1000, 2)}s`);
 

--- a/src/services/versioning.ts
+++ b/src/services/versioning.ts
@@ -20,7 +20,7 @@ import { Pins } from "@/components/pins";
 import { tip } from "@/components/tooltips";
 import { isElectron } from "./platform";
 
-export const VERSION = "1.152.0";
+export const VERSION = "1.152.1";
 
 // new changes on top
 const latestPublicChanges = [

--- a/tests/e2e/canvas-size.spec.ts
+++ b/tests/e2e/canvas-size.spec.ts
@@ -1,8 +1,34 @@
-import { expect, test } from "@playwright/test";
+import path from "node:path";
+import { expect, type Page, test } from "@playwright/test";
 import { countMaps, waitForMap, waitForNextMap } from "./wait-for-map";
 
 // The canvas size is the extent the Voronoi graph was built on, so it is fixed for the life of a map.
-// A window resize re-fits the viewport onto it; only the next map adopts the new window size.
+// The viewport always fills the window, and the zoom floor is derived from the two: a map larger than
+// the window zooms out below 1 until it fits, a smaller one is scaled up until it covers the window.
+// Only the next map adopts the new window size as its extent.
+
+/** What the map looks like on screen right now: the extent, the svg window and the applied zoom */
+function readView(page: Page) {
+  return page.evaluate(() => {
+    const transform = document.getElementById("viewbox")!.getAttribute("transform") ?? "";
+    return {
+      extent: { ...(window as any).options.map.graph },
+      svgWidth: Number(document.getElementById("map")!.getAttribute("width")),
+      svgHeight: Number(document.getElementById("map")!.getAttribute("height")),
+      zoomMin: (window as any).options.app.zoomExtent.min as number,
+      scale: Number(/scale\(([\d.]+)\)/.exec(transform)?.[1] ?? 1)
+    };
+  });
+}
+
+/** Open a fixture the way the user does, and wait for the map it produces */
+async function openFixture(page: Page, fixture: string) {
+  const previous = await countMaps(page);
+  await page.locator("#mapToLoad").setInputFiles(path.join(__dirname, "../fixtures", fixture));
+  await waitForNextMap(page, previous);
+  await page.waitForTimeout(500);
+}
+
 test.describe("canvas size", () => {
   test("a generated map keeps its extent when the window resizes", async ({ page }) => {
     await page.setViewportSize({ width: 1000, height: 700 });
@@ -15,15 +41,13 @@ test.describe("canvas size", () => {
     await page.setViewportSize({ width: 1400, height: 800 });
     await page.waitForTimeout(500);
 
-    const afterResize = await page.evaluate(() => ({
-      width: (window as any).options.map.graph.width,
-      height: (window as any).options.map.graph.height,
-      svgWidth: Number(document.getElementById("map")!.getAttribute("width"))
-    }));
+    const afterResize = await readView(page);
 
-    expect(afterResize.width).toBe(generated.width);
-    expect(afterResize.height).toBe(generated.height);
-    expect(afterResize.svgWidth).toBe(1000); // the viewport is re-fitted: min(extent, window)
+    expect(afterResize.extent.width).toBe(generated.width);
+    expect(afterResize.extent.height).toBe(generated.height);
+    expect(afterResize.svgWidth).toBe(1400); // the viewport follows the window
+    expect(afterResize.svgHeight).toBe(800);
+    expect(afterResize.scale).toBeGreaterThanOrEqual(1400 / generated.width); // and the map covers it
   });
 
   test("the next map is generated at the new window size", async ({ page }) => {
@@ -41,6 +65,38 @@ test.describe("canvas size", () => {
     const regenerated = await page.evaluate(() => ({ ...(window as any).options.map.graph }));
     expect(regenerated.width).toBe(1400);
     expect(regenerated.height).toBe(800);
+  });
+
+  // 1.139.4.map was saved on a 1512x828 canvas, so this window is wider than the map it opens
+  test("a map opened on a bigger screen is scaled up to fill it", async ({ page }) => {
+    await page.setViewportSize({ width: 1700, height: 1000 });
+    await page.goto("/?seed=canvas-size-loaded");
+    await waitForMap(page);
+
+    await openFixture(page, "1.139.4.map");
+    const loaded = await readView(page);
+
+    expect(loaded.extent.width).toBe(1512); // the opened map keeps the extent it was built on
+    expect(loaded.svgWidth).toBe(1700); // but the window it is shown in is the whole screen
+    expect(loaded.svgHeight).toBe(1000);
+    expect(loaded.zoomMin).toBeGreaterThanOrEqual(1700 / loaded.extent.width); // scaled up to cover it
+    expect(loaded.scale).toBe(loaded.zoomMin); // and it opens at that floor: the fitted view
+  });
+
+  // the other direction: a window smaller than the map, where the floor has to fall below 1
+  test("a map opened on a smaller screen is fitted into it", async ({ page }) => {
+    await page.setViewportSize({ width: 1000, height: 600 });
+    await page.goto("/?seed=canvas-size-fitted");
+    await waitForMap(page);
+
+    await openFixture(page, "1.139.4.map");
+    const loaded = await readView(page);
+
+    expect(loaded.extent.width).toBe(1512);
+    expect(loaded.svgWidth).toBe(1000);
+    expect(loaded.zoomMin).toBeLessThan(1); // the floor follows the map down, as it did before 1.152
+    expect(loaded.zoomMin).toBeGreaterThanOrEqual(600 / loaded.extent.height); // never past covering
+    expect(loaded.scale).toBe(loaded.zoomMin);
   });
 
   test("a pinned canvas size survives both the resize and the next map", async ({ page }) => {

--- a/tests/e2e/style-parity.spec.ts
+++ b/tests/e2e/style-parity.spec.ts
@@ -68,10 +68,15 @@ function collectStyleSnapshot(page: Page) {
 // derives #scaleBar's transform from that width. Both are content-derived layout rather than
 // preset style, and neither is stable enough to baseline: the width tracks text metrics, which
 // differ between platforms, and on a generated map it also tracks the "nice" round distance the
-// bar picks for that map's scale. Excluded from both comparisons below.
+// bar picks for that map's scale.
+//
+// #labels font-size is the same kind of value: applyLabelsZoomSize derives it from the current
+// zoom, and a map opens at the scale that fits it to the window, so it tracks the window size
+// against the map's extent rather than any style. Excluded from both comparisons below.
 function stripContentDerivedLayout(snapshot: Record<string, Record<string, string>>) {
   delete snapshot["#scaleBar"]?.transform;
   delete snapshot["#scaleBarBack"]?.width;
+  delete snapshot["#labels"]?.["font-size"];
 }
 
 test("styled attributes match the pre-migration baseline", async ({page}) => {

--- a/tests/fixtures/style-baseline-generated.json
+++ b/tests/fixtures/style-baseline-generated.json
@@ -109,9 +109,7 @@
     "stroke-width": "0.5",
     "filter": "url(#dropShadow01)"
   },
-  "#labels": {
-    "font-size": "100px"
-  },
+  "#labels": {},
   "#lakes": {},
   "#freshwater": {
     "opacity": "0.5",

--- a/tests/fixtures/style-baseline.json
+++ b/tests/fixtures/style-baseline.json
@@ -111,9 +111,7 @@
     "stroke-width": "0",
     "filter": "url(#dropShadow05)"
   },
-  "#labels": {
-    "font-size": "100px"
-  },
+  "#labels": {},
   "#lakes": {},
   "#freshwater": {
     "opacity": "0.9",


### PR DESCRIPTION
## The bug

A map opened on a screen that is not the one it was made on no longer fills the window. 1.152.0 changed two things at once in `fitMapToScreen()`:

```js
setViewport(Math.min(graph.width, wanted.width), Math.min(graph.height, wanted.height));
setZoomExtent(Math.max(options.app.zoomExtent.min, coverMin), max);
```

Each half breaks one direction:

- **Map smaller than the window** — the `#map` svg is sized to the map's extent, so the map sits in the top-left with dead canvas right and bottom.
- **Map larger than the window** — the cover scale is below 1, but the default `zoomExtent.min` of `1` wins, so the map can never be zoomed out to fit.

Reproduced with `1.108.12.map` (extent 1440×778) at 1600×900 and at 1000×600, and confirmed against a build of `d00e3311^`.

## What it used to do

`public/modules/ui/options.js` sized the svg from the user's canvas request (which follows the window), and the floor was the derived cover value, which also overwrote the control:

```js
svgWidth = Math.min(+mapWidthInput.value, window.innerWidth);
const zoomMin = rn(Math.max(svgWidth / graphWidth, svgHeight / graphHeight), 3);
zoomExtentMin.value = zoomMin;
setZoomExtent(zoomMin, +zoomExtentMax.value);
```

## The fix

- **`canvas.ts`** — the viewport follows the window (or the viewport the user pinned); the extent no longer bounds it. The zoom floor is `max(viewport / extent)`, **rounded up** — rounding to nearest can leave a sub-pixel strip of canvas, which makes d3's `constrain` centre the map instead of pinning it. It is written to `app.zoomExtent.min` and into the panel, so the control shows the limit the canvas enforces.
- **`zoom.ts`** — new `constrainZoom()` re-applies the current transform through the behavior, because d3 enforces `scaleExtent`/`translateExtent` on gestures only; a raised floor otherwise did nothing until the user touched the map. `resetZoom()` targets the floor rather than a bare identity, and skips the transition at duration 0 (Submap and Transform call `resetZoom(0)` right after a fit).
- **`load.ts`** — `fitMapToScreen()` runs before `focusOn()` (matching the generation path, so a `?scale=`/`?burg=` deep link still wins), followed by `resetZoom(0)` so an opened map opens at the fitted view.
- **`options-tab.ts`** — a hand-set floor applies as typed and stands until the next fit re-derives it, as before. "Restore default zoom extent" re-derives the floor instead of forcing `1`, which would have re-broken the invariant.

## Verified

`1.108.12.map`, extent 1440×778:

| Window | `#map` svg | Zoom floor | Opens at |
| --- | --- | --- | --- |
| 1000×600 (smaller) | 1000×600 | 0.772 | 0.772 — whole map fitted |
| 1600×900 (bigger) | 1600×900 | 1.157 | 1.157 — scaled up, no bands |

`setMapZoom(0.1)` clamps to the floor; zooming to 4 and then resizing keeps `k=4` and only re-derives the floor, so a resize never yanks the user's view; regenerating resets the extent to the window with floor `1`.

942 unit tests, `tsc` and `biome check src/` pass. `tests/e2e/canvas-size.spec.ts` covers both directions; per the repo rule Playwright was not run locally, so CI is the first run.

## Notes

- `app.zoomExtent.min` is now a **derived** value the canvas writes rather than a stored preference — that is what 1.151 did, and `docs/architecture/configuration.md` is updated to say so, but it sits slightly against that file's "preferences are what the user asked for" framing. Worth a second opinion.
- The version bump to 1.152.1 was already in the working tree; the `sync-version` pre-commit hook pulls `package.json` and the lockfile along with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
