### PR TITLE
Anchor the marker type menu to its button

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -2409,6 +2409,10 @@ svg.button {
   opacity: 0.8;
 }
 
+#markerTypeSelectorWrapper {
+  position: relative;
+}
+
 #markerTypeSelectMenu {
   display: none;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -133,7 +133,7 @@
     </style>
     <link
       rel="preload"
-      href="index.css?v=42fbdabf"
+      href="index.css?v=57642bbf"
       as="style"
       onload="
         this.onload = null;


### PR DESCRIPTION
## Problem

In the Markers Overview, the "add marker" type button (❓) appears to do nothing. The menu does open, but it renders above the top of the screen.

The v1.152.0 stylesheet rewrite (#1821) dropped the `#markerTypeSelectorWrapper { position: relative }` rule. The menu is `position: absolute; bottom: 100%`, so without it the menu positions against the dialog rather than the button. Reproduced on e16db498, the commit before #1827, with the menu's bounding box at y = -212.

## Fix

Restore the wrapper rule. Asset stamp bumped for `index.css`.

## Verification

Headless Chromium: after a real click on the button the menu is visible with its box inside the dialog, directly above the button.
