### PR TITLE
Upload local SVG or raster icons in the Icon Selector

### DIFF
--- a/src/controllers/good-editor.ts
+++ b/src/controllers/good-editor.ts
@@ -6,7 +6,7 @@ import { capitalize, rn } from "@/utils";
 import { CULTURE_TYPES } from "../generators/cultures-generator";
 import type { DemandCategory, Good } from "../generators/goods-generator";
 import { DEMAND_CATEGORY_ICONS, DEMAND_PRIORITY } from "../generators/goods-generator";
-import { ensureEl, getRandomColor, unique } from "../utils";
+import { ensureEl, getRandomColor, sanitizeSvgIcon, unique } from "../utils";
 
 function open(editedGood?: Good, onUpdate?: () => void) {
   const icons = Array.from(ensureEl("good-icons").querySelectorAll("symbol")).map(el => el.id);
@@ -527,19 +527,7 @@ function uploadImage(type: "image" | "svg", callback: (type: string, id: string)
       const svg = /*html*/ `<svg id="${id}" xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200"><image x="0" y="0" width="200" height="200" href="${result}"/></svg>`;
       goodIcons.insertAdjacentHTML("beforeend", svg);
     } else {
-      const el = document.createElement("html");
-      el.innerHTML = result;
-
-      el.querySelectorAll("*").forEach(el => {
-        const attributes = el.getAttributeNames();
-        attributes.forEach(attr => {
-          if (attr.includes("inkscape") || attr.includes("sodipodi")) el.removeAttribute(attr);
-        });
-      });
-
-      if (result.includes("from the Noun Project")) el.querySelectorAll("text").forEach(textEl => void textEl.remove());
-
-      const svg = el.querySelector("svg");
+      const svg = sanitizeSvgIcon(result);
       if (!svg)
         return void tip(
           "The file should be prepared for load to FMG. If you don't know why it's happening, try to upload raster image",

--- a/src/controllers/icon-selector.ts
+++ b/src/controllers/icon-selector.ts
@@ -2,7 +2,7 @@
 import { destroyDialog } from "@/components/dialog/dialog-helpers";
 import { tip } from "@/components/tooltips";
 import { ICONS, ICONS_PER_ROW } from "@/data/icons-list";
-import { ensureEl, escapeHtml, isImageIcon } from "@/utils";
+import { ensureEl, escapeHtml, isImageIcon, sanitizeSvgIcon, svgToDataUri } from "@/utils";
 
 function open(initial: string, callback: (value: string) => void): void {
   const dialog = renderDialog();
@@ -40,6 +40,14 @@ function open(initial: string, callback: (value: string) => void): void {
     callback(url);
     urlInput.value = "";
   };
+
+  const fileInput = ensureEl<HTMLInputElement>("iconFileToLoad");
+  ensureEl("uploadIconImage").onclick = () => fileInput.click();
+  fileInput.onchange = () =>
+    uploadIcon(fileInput, url => {
+      addImage(url, callback);
+      callback(url);
+    });
 
   for (const image of Array.from(ensureEl("addedIcons").querySelectorAll<HTMLElement>("div"))) {
     image.onclick = () => callback(image.style.backgroundImage.slice(5, -2));
@@ -83,6 +91,9 @@ function renderDialog(): HTMLElement {
         <span>Paste link to the image here: </span>
         <input id="imageInput" style="width: 20em" />
         <button id="addImage" type="button">Add</button>
+        <span> or </span>
+        <button id="uploadIconImage" type="button" data-tip="Upload a local SVG or raster image, up to 200kB. It is stored inside the map file">Upload file</button>
+        <input id="iconFileToLoad" type="file" accept="image/*,.svg" style="display: none" />
       </div>
       <div id="addedIcons" class="pointer" style="display: flex; flex-wrap: wrap; max-width: 420px"></div>
     </div>`;
@@ -107,8 +118,41 @@ function getUsedImages(): Set<string> {
   for (const state of pack.states) {
     for (const regiment of state?.military || []) if (isImageIcon(regiment.icon)) images.add(regiment.icon);
   }
+  for (const marker of pack.markers || []) if (isImageIcon(marker.icon)) images.add(marker.icon);
 
   return images;
+}
+
+function uploadIcon(input: HTMLInputElement, onLoaded: (dataUri: string) => void): void {
+  const file = input.files?.[0];
+  input.value = "";
+  if (!file) return;
+
+  if (file.size > 200000) {
+    return void tip(
+      "File is too big, please optimize it to below 200kB. Recommended size is up to 10kB",
+      true,
+      "error",
+      5000
+    );
+  }
+
+  const isSvg = file.type === "image/svg+xml" || file.name.toLowerCase().endsWith(".svg");
+  const reader = new FileReader();
+  reader.onload = () => {
+    const result = reader.result as string;
+    if (!isSvg) {
+      if (!isImageIcon(result)) return void tip("The file is not a supported image", false, "error", 4000);
+      return onLoaded(result);
+    }
+
+    const svg = sanitizeSvgIcon(result);
+    if (!svg) return void tip("The file is not a valid SVG image", false, "error", 4000);
+    onLoaded(svgToDataUri(svg.outerHTML));
+  };
+
+  if (isSvg) reader.readAsText(file);
+  else reader.readAsDataURL(file);
 }
 
 function addImage(url: string, callback: (value: string) => void): void {

--- a/src/utils/fileUtils.test.ts
+++ b/src/utils/fileUtils.test.ts
@@ -1,5 +1,56 @@
+// @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
-import { isImageIcon } from "./fileUtils";
+import { isImageIcon, sanitizeSvgIcon, svgToDataUri } from "./fileUtils";
+
+describe("sanitizeSvgIcon", () => {
+  it("returns the svg element from the file markup", () => {
+    const svg = sanitizeSvgIcon(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><path d="M0 0h10"/></svg>'
+    );
+    expect(svg?.tagName.toLowerCase()).toBe("svg");
+    expect(svg?.querySelector("path")).not.toBeNull();
+  });
+
+  it("strips inkscape and sodipodi attributes", () => {
+    const svg = sanitizeSvgIcon(
+      '<svg xmlns="http://www.w3.org/2000/svg" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" inkscape:version="1.1" sodipodi:docname="icon.svg"><path inkscape:label="p" d="M0 0"/></svg>'
+    );
+    expect(svg?.getAttributeNames().some(attr => attr.includes("inkscape") || attr.includes("sodipodi"))).toBe(false);
+    expect(svg?.querySelector("path")?.getAttributeNames()).toEqual(["d"]);
+  });
+
+  it("removes attribution text from Noun Project files", () => {
+    const svg = sanitizeSvgIcon(
+      '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/><text>Created by Artist from the Noun Project</text></svg>'
+    );
+    expect(svg?.querySelector("text")).toBeNull();
+  });
+
+  it("keeps text elements in files without attribution", () => {
+    const svg = sanitizeSvgIcon('<svg xmlns="http://www.w3.org/2000/svg"><text>label</text></svg>');
+    expect(svg?.querySelector("text")).not.toBeNull();
+  });
+
+  it("returns null when the markup has no svg", () => {
+    expect(sanitizeSvgIcon("<div>not an svg</div>")).toBeNull();
+  });
+});
+
+describe("svgToDataUri", () => {
+  it("encodes markup as a base64 svg data uri", () => {
+    const markup = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h10"/></svg>';
+    const uri = svgToDataUri(markup);
+    expect(uri.startsWith("data:image/svg+xml;base64,")).toBe(true);
+    const decoded = Buffer.from(uri.split(",")[1], "base64").toString("utf8");
+    expect(decoded).toBe(markup);
+  });
+
+  it("round-trips non-latin characters", () => {
+    const markup = '<svg xmlns="http://www.w3.org/2000/svg"><text>Привет 城市</text></svg>';
+    const decoded = Buffer.from(svgToDataUri(markup).split(",")[1], "base64").toString("utf8");
+    expect(decoded).toBe(markup);
+  });
+});
 
 describe("isImageIcon", () => {
   it("recognises http and data image URLs", () => {

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -29,6 +29,32 @@ export function downloadFile(data: BlobPart, name: string, type = "text/plain"):
   window.setTimeout(() => window.URL.revokeObjectURL(url), 2000);
 }
 
+/** Strip Inkscape/Sodipodi attributes and Noun Project credits; null if the markup has no svg */
+export function sanitizeSvgIcon(svgText: string): SVGElement | null {
+  const container = document.createElement("html");
+  container.innerHTML = svgText;
+
+  for (const element of Array.from(container.querySelectorAll("*"))) {
+    for (const attr of element.getAttributeNames()) {
+      if (attr.includes("inkscape") || attr.includes("sodipodi")) element.removeAttribute(attr);
+    }
+  }
+
+  if (svgText.includes("from the Noun Project")) {
+    container.querySelectorAll("text").forEach(text => void text.remove());
+  }
+
+  return container.querySelector("svg");
+}
+
+/** UTF-8 safe base64 data URI */
+export function svgToDataUri(svgText: string): string {
+  const bytes = new TextEncoder().encode(svgText);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return `data:image/svg+xml;base64,${btoa(binary)}`;
+}
+
 /** Whether an icon value is an image URL rather than an emoji or text glyph */
 export function isImageIcon(icon: string): boolean {
   return /^(https?:\/\/|data:image\/)/.test(icon);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -22,7 +22,7 @@ import {
   wiki
 } from "./commonUtils";
 import { drawCellsValue, drawPath, drawPoint, drawPolygons, drawRouteConnections } from "./debugUtils";
-import { downloadFile, getFileName, isImageIcon, uploadFile } from "./fileUtils";
+import { downloadFile, getFileName, isImageIcon, sanitizeSvgIcon, svgToDataUri, uploadFile } from "./fileUtils";
 import { distanceSquared, rollups } from "./functionUtils";
 import { isLand, isWater, SEA_LEVEL } from "./heightUtils";
 import { applyOption, ensureEl, findEl, getComposedPath, getNextId, getPointer } from "./nodeUtils";
@@ -220,10 +220,12 @@ export {
   SEA_LEVEL,
   safeParseJSON,
   sanitizeId,
+  sanitizeSvgIcon,
   setInlineStyleProperty,
   si,
   speak,
   splitInTwo,
+  svgToDataUri,
   TYPED_ARRAY_MAX,
   throttle,
   toCsvField,


### PR DESCRIPTION
## What

Markers and regiments already render `http`/`data:image` icons, but the Icon Selector only offered a URL box. This adds an "Upload file" button next to it:

- Raster files are stored as a data URI as is.
- SVG files are parsed, stripped of Inkscape/Sodipodi attributes and Noun Project attribution text, then encoded as a base64 data URI (UTF-8 safe). That logic already lived inline in the good editor; it is now `sanitizeSvgIcon` / `svgToDataUri` in `fileUtils.ts`, and the good editor calls the shared helper.
- Files over 200kB are rejected with a tip, since the data URI is stored in the map file.
- Marker icons already in use on the map now reappear in the selector's image list, alongside the regiment ones.

Note: `sanitizeSvgIcon` is cosmetic, not a security sanitizer. Icons are only ever loaded through `<img>` and SVG `<image>`, where scripts do not run, so that is fine for this use.

## Verification

- `tsc --noEmit` clean, Biome clean, 960 unit tests pass (new tests for both helpers).
- Headless Chromium: an Inkscape-exported SVG with Noun Project attribution uploads as a data URI with those bits stripped and the shape kept; a PNG passes through unchanged; both appear as thumbnails; the marker renders the new icon on the map; reopening the selector lists the marker's icon.
