### PR TITLE
Precache the whole build so the PWA works offline

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "dist-electron/main.js",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && node scripts/pwa-precache.mjs",
     "preview": "vite preview",
     "electron": "node scripts/electron.mjs",
     "test": "vitest",

--- a/public/sw.js
+++ b/public/sw.js
@@ -32,11 +32,13 @@ precacheAndRoute(self.__WB_MANIFEST || [], {ignoreURLParametersMatching: [/.*/]}
 
 setCatchHandler(({request}) => (request.mode === "navigate" ? matchPrecache("index.html") : Response.error()));
 
+// Google-hosted scripts (analytics) are left to the browser: with a blocker installed the
+// request never gets a response, and a worker strategy would surface that as an uncaught error
 registerRoute(
   ({request, url}) =>
     request.destination === "script" &&
     !url.pathname.endsWith("min.js") &&
-    !url.pathname.includes("google"),
+    !url.hostname.includes("google"),
   new StaleWhileRevalidate({
     cacheName: "fmg-scripts",
     plugins: [

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,12 +1,20 @@
 importScripts("https://storage.googleapis.com/workbox-cdn/releases/6.2.0/workbox-sw.js");
 
-const {Route, registerRoute} = workbox.routing;
+const {registerRoute, setCatchHandler} = workbox.routing;
 const {CacheFirst, NetworkFirst, StaleWhileRevalidate} = workbox.strategies;
 const {CacheableResponsePlugin} = workbox.cacheableResponse;
 const {ExpirationPlugin} = workbox.expiration;
+const {precacheAndRoute, cleanupOutdatedCaches, matchPrecache} = workbox.precaching;
+
+// A new build ships a new precache list, so take over open pages at once rather than
+// waiting for every tab to close: otherwise the old worker keeps serving the old build
+self.skipWaiting();
+workbox.core.clientsClaim();
 
 const DAY = 24 * 60 * 60; // in seconds
 
+// The html is always fetched fresh, so a reload picks up a release the moment it is deployed.
+// It has to come before the precache route, which would otherwise answer navigations itself
 registerRoute(
   ({request}) => request.mode === "navigate",
   new NetworkFirst({
@@ -15,6 +23,14 @@ registerRoute(
     plugins: [new CacheableResponsePlugin({statuses: [0, 200]})]
   })
 );
+
+// Every file the build produced, listed by scripts/pwa-precache.mjs after `vite build`, so the
+// app works offline in full and not only for the parts a user happened to open while online.
+// The ?v= stamps on index.html's assets are not part of the precached urls, hence ignored here
+cleanupOutdatedCaches();
+precacheAndRoute(self.__WB_MANIFEST || [], {ignoreURLParametersMatching: [/.*/]});
+
+setCatchHandler(({request}) => (request.mode === "navigate" ? matchPrecache("index.html") : Response.error()));
 
 registerRoute(
   ({request, url}) =>

--- a/scripts/pwa-precache.mjs
+++ b/scripts/pwa-precache.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+/**
+ * Give the service worker a precache list of everything the build produced.
+ *
+ * Without it the worker only caches what the browser has already requested, so a PWA opened
+ * offline is missing every editor the user never opened online (each is a lazy-loaded chunk).
+ * Runs after `vite build` and rewrites dist/sw.js in place, filling `self.__WB_MANIFEST`.
+ *
+ * Usage:
+ *   node scripts/pwa-precache.mjs [dist]   # default dist: ./dist
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const PLACEHOLDER = "self.__WB_MANIFEST";
+const WORKER = "sw.js";
+
+function hashFile(filePath) {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex").slice(0, 8);
+}
+
+/** One `{url, revision}` per file in `dist`, minus the worker; urls are relative to the worker */
+export function collectPrecacheEntries(dist) {
+  return fs
+    .readdirSync(dist, { recursive: true, withFileTypes: true })
+    .filter(entry => entry.isFile())
+    .map(entry => path.relative(dist, path.join(entry.parentPath, entry.name)).split(path.sep).join("/"))
+    .filter(url => url !== WORKER)
+    .sort()
+    .map(url => ({ url, revision: hashFile(path.join(dist, url)) }));
+}
+
+export function injectManifest(source, entries) {
+  if (!source.includes(PLACEHOLDER)) throw new Error(`${WORKER} has no ${PLACEHOLDER} placeholder to fill`);
+  return source.replace(PLACEHOLDER, JSON.stringify(entries));
+}
+
+function main() {
+  const dist = path.resolve(process.argv[2] ?? "dist");
+  const workerPath = path.join(dist, WORKER);
+  const entries = collectPrecacheEntries(dist);
+  fs.writeFileSync(workerPath, injectManifest(fs.readFileSync(workerPath, "utf8"), entries));
+  console.log(`[pwa-precache] ${entries.length} files listed in ${path.relative(process.cwd(), workerPath)}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/scripts/pwa-precache.test.mjs
+++ b/scripts/pwa-precache.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { collectPrecacheEntries, injectManifest } from "./pwa-precache.mjs";
+
+function makeDist(files) {
+  const dist = fs.mkdtempSync(path.join(os.tmpdir(), "pwa-precache-"));
+  for (const [file, content] of Object.entries(files)) {
+    fs.mkdirSync(path.dirname(path.join(dist, file)), { recursive: true });
+    fs.writeFileSync(path.join(dist, file), content);
+  }
+  return dist;
+}
+
+test("lists every file under dist with a posix url and a content revision", () => {
+  const dist = makeDist({ "index.html": "<html>", "index-Ab12Cd34.js": "js", "charges/lion.svg": "<svg>" });
+  const entries = collectPrecacheEntries(dist);
+  assert.deepEqual(
+    entries.map(({ url }) => url),
+    ["charges/lion.svg", "index-Ab12Cd34.js", "index.html"]
+  );
+  for (const { revision } of entries) assert.match(revision, /^[0-9a-f]{8}$/);
+});
+
+test("leaves the service worker itself out of its own manifest", () => {
+  const dist = makeDist({ "index.html": "<html>", "sw.js": "worker" });
+  assert.deepEqual(
+    collectPrecacheEntries(dist).map(({ url }) => url),
+    ["index.html"]
+  );
+});
+
+test("revision follows the file content", () => {
+  const before = collectPrecacheEntries(makeDist({ "main.js": "one" }))[0].revision;
+  const after = collectPrecacheEntries(makeDist({ "main.js": "two" }))[0].revision;
+  const same = collectPrecacheEntries(makeDist({ "main.js": "one" }))[0].revision;
+  assert.notEqual(before, after);
+  assert.equal(before, same);
+});
+
+test("injects the manifest where the worker source expects it", () => {
+  const source = 'precacheAndRoute(self.__WB_MANIFEST || []);\nregisterRoute();';
+  const entries = [{ url: "index.html", revision: "0123abcd" }];
+  assert.equal(
+    injectManifest(source, entries),
+    'precacheAndRoute([{"url":"index.html","revision":"0123abcd"}] || []);\nregisterRoute();'
+  );
+});
+
+test("refuses a worker source without the placeholder", () => {
+  assert.throws(() => injectManifest("registerRoute();", []), /__WB_MANIFEST/);
+});

--- a/src/components/shell.ts
+++ b/src/components/shell.ts
@@ -54,9 +54,18 @@ function onTitlebarButtonTouch(event: TouchEvent): void {
 /**
  * Each release replaces the content-hashed chunk files on the server, so a page opened before
  * the release 404s when it lazy-loads a chunk it has not requested yet ("Failed to fetch
- * dynamically imported module"). Offer a reload to pick up the new build
+ * dynamically imported module"). Offer a reload to pick up the new build. Offline the same error
+ * means the chunk was never precached (it was not in the build the worker installed), so say that
  */
 function onChunkLoadError(): void {
+  if (!navigator.onLine) {
+    alertDialog({
+      title: "You are offline",
+      message: "This part of the app was not downloaded before the connection was lost. Reconnect and try again"
+    });
+    return;
+  }
+
   confirmationDialog({
     title: "New version released",
     message:

--- a/tests/e2e/pwa-offline.spec.ts
+++ b/tests/e2e/pwa-offline.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+import { waitForMap } from "./wait-for-map";
+
+// The worker only registers itself off localhost, and only the production build carries the
+// precache list, so these tests register it by hand and skip against the dev server
+test.describe("PWA offline", () => {
+  test.beforeEach(async ({ page, context }) => {
+    const worker = await (await context.request.get("/Fantasy-Map-Generator/sw.js")).text();
+    test.skip(worker.includes("self.__WB_MANIFEST"), "needs the built service worker (npm run build && npm run preview)");
+
+    await page.goto("/");
+    await waitForMap(page);
+    await page.evaluate(async () => {
+      await navigator.serviceWorker.register("./sw.js");
+      await navigator.serviceWorker.ready;
+    });
+    await context.setOffline(true);
+  });
+
+  test.afterEach(async ({ context }) => {
+    await context.setOffline(false);
+  });
+
+  test("opens an editor that was never opened online", async ({ page }) => {
+    await page.reload();
+    await waitForMap(page);
+
+    await page.click("#optionsTrigger");
+    await page.click("#toolsTab");
+    await page.click("#editBiomesButton");
+
+    await expect(page.locator("#biomesEditor")).toBeVisible();
+    await expect(page.getByText("New version released")).toHaveCount(0);
+  });
+
+  test("names the real cause when a chunk fails to load offline", async ({ page }) => {
+    await page.evaluate(() => window.dispatchEvent(new Event("vite:preloadError")));
+
+    await expect(page.locator(".ui-dialog-title", { hasText: "offline" })).toBeVisible();
+    await expect(page.getByText("New version released")).toHaveCount(0);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,7 @@ export default ({ mode }: { mode: string }) => ({
   build: {
     outDir: mode === "electron" ? "../dist-electron/renderer" : "../dist",
     assetsDir: "./",
-    emptyOutDir: mode === "electron"
+    emptyOutDir: true // outDir sits outside root, so Vite would otherwise keep every past build's chunks
   },
   publicDir: "../public",
   resolve: {


### PR DESCRIPTION
Fixes #1681.

## What

The service worker now precaches every file the build produces, so the installed PWA works offline in full instead of only for the parts the user happened to open while online.

- `scripts/pwa-precache.mjs` runs at the end of `npm run build`. It lists every file in `dist` (the worker excepted) with a content-hash revision and writes the list into the built `sw.js` in place of `self.__WB_MANIFEST`. No new dependency; same shape as `stamp-assets` and `sync-version`.
- `public/sw.js` precaches that list, cleans out entries from previous builds, and activates immediately (`skipWaiting` + `clientsClaim`) so a new build is not held back by an old worker. Navigation stays network-first, so a reload picks up a release the moment it is deployed; the precached `index.html` is the offline fallback. The `?v=` stamps on index.html's assets are ignored when matching, otherwise those requests would miss the precache.
- `vite.config.ts` empties `dist` on every web build. `outDir` is outside `root`, so Vite kept every past build's chunks, and the precache list would have included them.
- `shell.ts`: when a lazy chunk fails to load and the browser is offline, the dialog says "You are offline" instead of "New version released".

The full build precaches 568 files, about 22 MB, on the first visit.

## Why

Since the Vite migration every editor is a lazy-loaded chunk. With runtime caching alone, opening a never-used editor offline failed and showed the misleading "New version released" prompt.

## Tests

- `scripts/pwa-precache.test.mjs` (node --test): listing, worker exclusion, revision follows content, manifest injection, missing placeholder.
- `tests/e2e/pwa-offline.spec.ts`: registers the worker by hand (the app skips registration on localhost), goes offline, reloads, opens the Biomes editor that was never opened online, and checks the offline dialog text. Skips itself on the dev server; runs against the built preview in CI as the rest of the suite does.
- Full Playwright suite against the built preview: 232 passed, 1 pre-existing skip. Vitest: 953 passed.