### PR TITLE
Keep global filters in Firefox raster exports

### DIFF
--- a/src/services/io/export.test.ts
+++ b/src/services/io/export.test.ts
@@ -45,9 +45,11 @@ function makeSvg(rootFilter: string | null, withViewbox = true): SVGSVGElement {
   }
   svg.appendChild(defs);
   if (withViewbox) {
-    const viewbox = document.createElementNS(SVG_NS, "g");
-    viewbox.id = "viewbox";
-    svg.appendChild(viewbox);
+    for (const id of ["viewbox", "scaleBar"]) {
+      const group = document.createElementNS(SVG_NS, "g");
+      group.id = id;
+      svg.appendChild(group);
+    }
   }
   return svg;
 }
@@ -58,6 +60,12 @@ describe("relocateRootFilter", () => {
     relocateRootFilter(svg);
     expect(svg.getAttribute("filter")).toBeNull();
     expect(svg.querySelector("#viewbox")?.getAttribute("filter")).toBe("url(#filter-tint)");
+  });
+
+  it("applies the same filter to the scale bar, which sits outside #viewbox", () => {
+    const svg = makeSvg("url(#filter-tint)");
+    relocateRootFilter(svg);
+    expect(svg.querySelector("#scaleBar")?.getAttribute("filter")).toBe("url(#filter-tint)");
   });
 
   it("gives every filter an explicit region covering the viewport", () => {

--- a/src/services/io/export.ts
+++ b/src/services/io/export.ts
@@ -288,10 +288,8 @@ async function getMapURL(type: string, config: GetMapURLOptions = {}): Promise<s
   if (noVignette) clone.select("#vignette").remove();
   if (noScaleBar) clone.select("#scaleBar").remove();
 
-  if (type === "svg") {
-    removeUnusedElements(clone);
-    relocateRootFilter(cloneEl);
-  }
+  if (type === "svg") removeUnusedElements(clone);
+  relocateRootFilter(cloneEl); // Firefox drops a root-svg filter when the svg is rasterized via an image
   if (customization && type === "mesh") updateMeshCells(clone);
   inlineStyle(clone);
 
@@ -590,13 +588,14 @@ export function flattenSymbolReferences(svg: SVGSVGElement): void {
 }
 
 // Inkscape can't render filters on the root svg element and miscomposites default filter regions on large groups,
-// so move the global filter to #viewbox and give all filters an explicit full-viewport region
+// so move the global filter to the drawn groups and give all filters an explicit full-viewport region
 export function relocateRootFilter(svg: SVGSVGElement): void {
   const filter = svg.getAttribute("filter");
   const viewbox = svg.querySelector("#viewbox");
   if (!filter || !viewbox) return;
   svg.removeAttribute("filter");
   viewbox.setAttribute("filter", filter);
+  svg.querySelector("#scaleBar")?.setAttribute("filter", filter);
 
   svg.querySelectorAll("filter").forEach(filterEl => {
     filterEl.setAttribute("filterUnits", "userSpaceOnUse");

--- a/tests/e2e/export-global-filter.spec.ts
+++ b/tests/e2e/export-global-filter.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "@playwright/test";
+import { waitForMap } from "./wait-for-map";
+
+// Firefox ignores a filter set on the root svg element when the svg is rasterized through an image,
+// so the raster export has to carry the global filter on #viewbox like the svg export does
+test("raster export carries the global filter on #viewbox", async ({ page }) => {
+  await page.goto("/?seed=test-export-filter&width=1280&height=720");
+  await waitForMap(page);
+
+  const result = await page.evaluate(async () => {
+    document.getElementById("map")!.setAttribute("filter", "url(#filter-grayscale)");
+    const url = await (window as any).Services.ExportMap.getMapURL("png");
+    const text = await (await fetch(url)).text();
+    const doc = new DOMParser().parseFromString(text, "image/svg+xml");
+    const root = doc.documentElement;
+
+    const img = new Image();
+    await new Promise((resolve, reject) => {
+      img.onload = resolve;
+      img.onerror = reject;
+      img.src = url;
+    });
+    const canvas = document.createElement("canvas");
+    canvas.width = img.width;
+    canvas.height = img.height;
+    const ctx = canvas.getContext("2d")!;
+    ctx.drawImage(img, 0, 0);
+    const pixels: number[][] = [];
+    for (const [x, y] of [[0.25, 0.25], [0.5, 0.5], [0.75, 0.75]]) {
+      const [r, g, b] = ctx.getImageData(Math.round(img.width * x), Math.round(img.height * y), 1, 1).data;
+      pixels.push([r, g, b]);
+    }
+
+    return {
+      rootFilter: root.getAttribute("filter"),
+      viewboxFilter: doc.getElementById("viewbox")?.getAttribute("filter"),
+      scaleBarFilter: doc.getElementById("scaleBar")?.getAttribute("filter"),
+      hasFilterDef: Boolean(doc.getElementById("filter-grayscale")),
+      pixels
+    };
+  });
+
+  expect(result.rootFilter).toBeNull();
+  expect(result.viewboxFilter).toBe("url(#filter-grayscale)");
+  expect(result.scaleBarFilter).toBe("url(#filter-grayscale)");
+  expect(result.hasFilterDef).toBe(true);
+  for (const [r, g, b] of result.pixels) {
+    expect(Math.abs(r - g)).toBeLessThanOrEqual(1);
+    expect(Math.abs(g - b)).toBeLessThanOrEqual(1);
+  }
+});


### PR DESCRIPTION
Fixes #1547.

Firefox ignores a `filter` attribute on the root `<svg>` element when the svg is rendered through an image, which is how the png and jpeg exports rasterize the map. Chromium applies it, so the bug only shows on Firefox. #1646 already moves the root filter onto `#viewbox` for the svg download; this runs the same relocation for every export type, so png, jpeg, tiles and the 3D mesh texture carry the filter on a group Firefox honours.

The scale bar sits outside `#viewbox`, so the relocation now applies the filter there as well. Exports match what the screen shows, and the svg download picks up the filtered scale bar too.

Verified with a minimal page (root-filtered svg drawn to a canvas: Firefox 155 returns the unfiltered colour, Chromium the filtered one), then with a real exported map rendered in headless Firefox before and after the change. Adds an e2e test that fails on master and passes here, plus a unit test for the scale bar.
