### PR TITLE
fix: distinguish completed work from unmerged or declined board items

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
 # Description
 
-<!-- Please include a summary of the change, motivation and context. It it's a but fix, add a reference in format #issue_number -->
+<!-- Describe the problem, resulting behavior, and validation. Use "Fixes #123" only if this PR completes that issue; use "Refs #123" for partial work. Link the originating idea discussion when applicable. -->
+
+<!-- Before closing a request: check its acceptance criteria, split remaining work into linked issues, and record implementation/release evidence. Merged does not mean released. See docs/board-completion.md. -->

--- a/.github/workflows/board-reconcile.yml
+++ b/.github/workflows/board-reconcile.yml
@@ -10,7 +10,9 @@ on:
         type: boolean
         default: true
   issues:
-    types: [opened, edited, labeled, unlabeled, reopened]
+    types: [opened, edited, labeled, unlabeled, closed, reopened]
+  pull_request_target:
+    types: [closed, reopened]
 
 permissions:
   issues: write
@@ -29,6 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Metadata only: never execute a pull request's code with the project token.
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
       - uses: actions/setup-node@v5
         with:
           node-version: "24"

--- a/docs/board-completion.md
+++ b/docs/board-completion.md
@@ -1,0 +1,35 @@
+# Board completion tracking
+
+The [FMG dev board](https://github.com/users/Azgaar/projects/3) derives completion from the issue or pull request. Status changes on the board do not replace resolving the underlying request.
+
+| GitHub state | Board status |
+|---|---|
+| Issue closed as completed | Done |
+| Issue closed as not planned or duplicate | Archive |
+| Pull request merged | Done |
+| Pull request closed without merging | Archive |
+| Open issue or PR incorrectly marked Done, including reopened work | Backlog, ready for re-triage |
+| Open work with any other status | Preserve the maintainer's choice |
+
+Done means the issue was accepted as complete or the PR was merged. It does **not** assert that a release has been deployed. Check the PR's target branch and record a release/version when confirming availability to users. A superseded PR belongs in Archive even when its replacement has shipped; link the replacement in its resolution record.
+
+Archive is a Status value, distinct from Projects' archive mechanism. Open proposals may also be deliberately parked there. Actually archived project items keep their status unchanged. A closed issue with an unknown closure reason is reported for review instead of being guessed complete.
+
+## Completing a request
+
+1. Link the implementation to its issue. Use `Fixes #123` when the issue is fully addressed, or `Refs #123` for partial work. Include the source discussion if the issue came from an idea.
+2. Check the request's acceptance criteria against the implementation. Update old checklists; create linked follow-up issues for any remaining asks. Do not close a broad request just because a similarly titled PR merged.
+3. Record the implementing PR/commit and the release/version if verified. When resolving a source discussion, link the canonical issue or implementation too. The resolution must be understandable without private chat history.
+4. Close the issue as completed, or as not planned with an explanation for a declined/superseded request. The reconciler updates the board. Reopening a completed issue returns a stale Done card to Backlog; assign its next working status after re-triage.
+
+When merging through a release branch, confirm that the original issue was resolved after integration; do not assume closing keywords ran when the feature PR merged. Review shipped requests and originating discussions as part of each release.
+
+## Automation
+
+`scripts/board-reconcile.mjs` reads all project pages and repairs status from GitHub state, including populated Status fields. Theme, Priority and Size retain their separate fill-only policy. The reconciler never closes issues or discussions itself, and it does not infer completion from titles, checkboxes or source-code similarity.
+
+Issue closure/reopening and PR closure/reopening trigger reconciliation. PR events use `pull_request_target` strictly for metadata: checkout always selects the default branch and no PR code is executed. The scheduled sweep repairs missed events and any later changes from native project workflows; GitHub schedules may be delayed.
+
+In the project's Workflows UI, prefer **issue completed → Done**, **issue not planned → Archive**, **PR merged → Done**, and **PR closed unmerged → Archive**, where the available filters support those distinctions. Disable any generic closed → Done rule that conflicts. Keep any reverse **Status Done → close issue** workflow disabled: a board move is not acceptance evidence. These UI settings are separate from the repository workflow and must be verified in GitHub; the API audit cannot confirm them.
+
+Manual workflow dispatch defaults to a dry run. It reads current metadata and reports the plan without changing fields, labels, or filing token-failure issues. Execution failures make the run fail; unknown closure reasons appear in the summary and require a maintainer decision.

--- a/scripts/board-fields.mjs
+++ b/scripts/board-fields.mjs
@@ -7,6 +7,15 @@ export const FIELD_IDS = {
   theme: "PVTSSF_lAHOAZPlEs4Bh_N6zhhNn90"
 };
 
+export const STATUS_OPTIONS = {
+  Backlog: "f75ad846",
+  Approved: "61e4505c",
+  "In progress": "47fc9ee4",
+  "In review": "df73e18b",
+  Done: "98236657",
+  Archive: "6e3c9f61"
+};
+
 export const PRIORITY_OPTIONS = {
   "P0 – Urgent": "79628723",
   "P1 – High": "0a877460",

--- a/scripts/board-plan.mjs
+++ b/scripts/board-plan.mjs
@@ -1,4 +1,4 @@
-import { PRIORITY_OPTIONS, SIZE_OPTIONS, THEME_LABEL_TO_OPTION, THEME_OPTIONS } from "./board-fields.mjs";
+import { PRIORITY_OPTIONS, SIZE_OPTIONS, STATUS_OPTIONS, THEME_LABEL_TO_OPTION, THEME_OPTIONS } from "./board-fields.mjs";
 import { classifyTheme } from "./theme-classify.mjs";
 
 const THEME_OPTION_TO_LABEL = Object.fromEntries(
@@ -108,14 +108,37 @@ export function planFieldWrites(item, trustedLogins = new Set()) {
   return { writes, drift };
 }
 
-const FIELD_BY_NAME = { Theme: "theme", Priority: "priority", Size: "size" };
+export function planStatusWrites(item) {
+  const writes = [];
+  const drift = [];
+  if (item.isArchived) return { writes, drift };
+
+  let status = null;
+  if (item.state === "OPEN") {
+    if (item.fields.status === "Done") status = "Backlog";
+  } else if (item.type === "PullRequest") {
+    if (item.state === "MERGED") status = "Done";
+    else if (item.state === "CLOSED") status = "Archive";
+  } else if (item.type === "Issue" && item.state === "CLOSED") {
+    if (item.stateReason === "COMPLETED") status = "Done";
+    else if (["NOT_PLANNED", "DUPLICATE"].includes(item.stateReason)) status = "Archive";
+    else drift.push(`#${item.number}: closed issue has no recognized completion reason; review its resolution`);
+  }
+
+  if (status && item.fields.status !== status) {
+    writes.push({ number: item.number, field: "status", optionName: status, optionId: STATUS_OPTIONS[status] });
+  }
+  return { writes, drift };
+}
+
+const FIELD_BY_NAME = { Theme: "theme", Priority: "priority", Size: "size", Status: "status" };
 
 export function itemsFromGraphql(nodes) {
   const items = [];
   for (const node of nodes) {
     const content = node.content || {};
     if (!content.number) continue;
-    const fields = { theme: null, priority: null, size: null };
+    const fields = { theme: null, priority: null, size: null, status: null };
     for (const value of node.fieldValues.nodes) {
       const key = FIELD_BY_NAME[value?.field?.name];
       if (key) fields[key] = value.name;
@@ -124,6 +147,9 @@ export function itemsFromGraphql(nodes) {
       id: node.id,
       number: content.number,
       type: content.__typename,
+      state: content.state ?? null,
+      stateReason: content.stateReason ?? null,
+      isArchived: node.isArchived === true,
       title: content.title || "",
       body: content.body || "",
       labels: (content.labels?.nodes || []).map(l => l.name),

--- a/scripts/board-plan.test.mjs
+++ b/scripts/board-plan.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { test } from "node:test";
-import { itemsFromGraphql, parseTriage, planFieldWrites, planLabelWrites } from "./board-plan.mjs";
+import { itemsFromGraphql, parseTriage, planFieldWrites, planLabelWrites, planStatusWrites } from "./board-plan.mjs";
 
 test("parses an exact block", () => {
   const body = "### Triage\nPriority: P2 – Medium\nSize: M\n";
@@ -304,4 +305,135 @@ test("derives the label from a human-set Theme field instead of guessing", () =>
     })
   );
   assert.deepEqual(got, { writes: [{ number: 1780, label: "theme: ui-editors" }], drift: [] });
+});
+
+test("repairs completed, declined, merged and unmerged cards and converges after one pass", () => {
+  for (const [type, state, stateReason, before, after] of [
+    ["Issue", "CLOSED", "COMPLETED", "Backlog", "Done"],
+    ["Issue", "CLOSED", "NOT_PLANNED", "Done", "Archive"],
+    ["Issue", "CLOSED", "DUPLICATE", "Done", "Archive"],
+    ["PullRequest", "MERGED", null, "In review", "Done"],
+    ["PullRequest", "CLOSED", null, "Done", "Archive"],
+    ["Issue", "OPEN", "REOPENED", "Done", "Backlog"],
+    ["PullRequest", "OPEN", null, "Done", "Backlog"]
+  ]) {
+    const input = item({ type, state, stateReason, fields: { status: before } });
+    const { writes, drift } = planStatusWrites(input);
+    assert.deepEqual(drift, []);
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0].optionName, after);
+    assert.equal(writes[0].field, "status");
+    assert.ok(writes[0].optionId);
+    assert.deepEqual(planStatusWrites({ ...input, fields: { status: after } }), { writes: [], drift: [] });
+  }
+});
+
+test("preserves active triage, intentionally parked proposals and actually archived history", () => {
+  for (const status of [null, "Backlog", "Approved", "In progress", "In review", "Archive"]) {
+    assert.deepEqual(planStatusWrites(item({ state: "OPEN", fields: { status } })), { writes: [], drift: [] });
+  }
+  assert.deepEqual(
+    planStatusWrites(item({ type: "PullRequest", state: "CLOSED", isArchived: true, fields: { status: "Done" } })),
+    { writes: [], drift: [] }
+  );
+});
+
+test("unknown issue closure reasons require review instead of being marked complete", () => {
+  for (const stateReason of [null, undefined, "UNRECOGNIZED"]) {
+    const result = planStatusWrites(item({ state: "CLOSED", stateReason }));
+    assert.deepEqual(result.writes, []);
+    assert.match(result.drift[0], /review its resolution/);
+  }
+});
+
+test("carries completion metadata and archived state from GraphQL into the planner", () => {
+  const [got] = itemsFromGraphql([{
+    ...node,
+    isArchived: true,
+    content: { ...node.content, state: "CLOSED", stateReason: "NOT_PLANNED" }
+  }]);
+  assert.equal(got.state, "CLOSED");
+  assert.equal(got.stateReason, "NOT_PLANNED");
+  assert.equal(got.isArchived, true);
+  assert.equal(got.fields.status, "Backlog");
+});
+
+const completionNode = (number, type, state, stateReason, status) => ({
+  id: `item-${number}`,
+  fieldValues: { nodes: [
+    { name: status, field: { name: "Status" } },
+    { name: "Military", field: { name: "Theme" } }
+  ] },
+  content: {
+    __typename: type, number, state, stateReason, title: "Regiment issue", body: "",
+    labels: { nodes: [{ name: "theme: military" }] },
+    repository: { nameWithOwner: "Azgaar/Fantasy-Map-Generator" }
+  }
+});
+
+function runCompletionFixture({ dryRun = false, authFailure = false, writeFailure = false } = {}) {
+  const env = { ...process.env };
+  delete env.NODE_TEST_CONTEXT;
+  const pages = [
+    [completionNode(1, "PullRequest", "CLOSED", null, "Done")],
+    [completionNode(2, "Issue", "CLOSED", "COMPLETED", "Backlog")]
+  ];
+  const script = `
+    const pages = ${JSON.stringify(pages)};
+    let page = 0;
+    let writes = 0;
+    globalThis.fetch = async (url, options) => {
+      if (url !== "https://api.github.com/graphql") throw new Error("Unexpected external write: " + url);
+      const {query, variables} = JSON.parse(options.body);
+      if (query.includes("updateProjectV2ItemFieldValue")) {
+        console.log("WRITE", variables.item, variables.option);
+        if (${writeFailure} && ++writes === 1) return {ok:false,status:502,json:async()=>({message:"fixture write failure"})};
+        return {ok:true,status:200,json:async()=>({data:{updateProjectV2ItemFieldValue:{}}})};
+      }
+      if (${authFailure}) return {ok:false,status:401,json:async()=>({message:"Bad credentials"})};
+      if (variables.cursor !== (page === 0 ? null : "next-page")) throw new Error("Wrong pagination cursor");
+      const nodes = pages[page++];
+      return {ok:true,status:200,json:async()=>({data:{user:{projectV2:{items:{nodes,pageInfo:{hasNextPage:page < 2,endCursor:"next-page"}}}}}})};
+    };
+    await import(${JSON.stringify(new URL("./board-reconcile.mjs", import.meta.url).href)});
+  `;
+  return spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+    encoding: "utf8",
+    env: {
+      ...env, PROJECT_TOKEN: "fixture-token", GITHUB_TOKEN: "fixture-token",
+      GITHUB_REPOSITORY: "Azgaar/Fantasy-Map-Generator", GITHUB_STEP_SUMMARY: "",
+      DRY_RUN: dryRun ? "1" : "", TRUSTED_TRIAGE_LOGINS: ""
+    }
+  });
+}
+
+test("runner repairs completion across all board pages", () => {
+  const result = runCompletionFixture();
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /2 items · 2 field writes/);
+  assert.match(result.stdout, /WRITE item-1 6e3c9f61/);
+  assert.match(result.stdout, /WRITE item-2 98236657/);
+});
+
+test("runner preview prints completion repairs without writing", () => {
+  const result = runCompletionFixture({ dryRun: true });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /set #1 status = Archive/);
+  assert.match(result.stdout, /set #2 status = Done/);
+  assert.doesNotMatch(result.stdout, /WRITE/);
+});
+
+test("runner dry run cannot file an issue when project authentication fails", () => {
+  const result = runCompletionFixture({ dryRun: true, authFailure: true });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Dry run: would report PROJECT_TOKEN authentication failure/);
+  assert.doesNotMatch(result.stderr, /Unexpected external write/);
+});
+
+test("runner continues completion repairs after one write fails and reports failure", () => {
+  const result = runCompletionFixture({ writeFailure: true });
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /WRITE item-2 98236657/);
+  assert.match(result.stdout, /Write failures/);
+  assert.match(result.stdout, /#1 status: graphql 502/);
 });

--- a/scripts/board-reconcile.mjs
+++ b/scripts/board-reconcile.mjs
@@ -1,6 +1,6 @@
 import { appendFileSync } from "node:fs";
 import { FIELD_IDS, PROJECT_ID } from "./board-fields.mjs";
-import { itemsFromGraphql, planFieldWrites, planLabelWrites } from "./board-plan.mjs";
+import { itemsFromGraphql, planFieldWrites, planLabelWrites, planStatusWrites } from "./board-plan.mjs";
 
 const DRY_RUN = Boolean(process.env.DRY_RUN);
 const REPO = process.env.GITHUB_REPOSITORY || "Azgaar/Fantasy-Map-Generator";
@@ -37,6 +37,7 @@ query($owner: String!, $number: Int!, $cursor: String) {
         pageInfo { hasNextPage endCursor }
         nodes {
           id
+          isArchived
           fieldValues(first: 50) {
             nodes {
               ... on ProjectV2ItemFieldSingleSelectValue {
@@ -49,6 +50,8 @@ query($owner: String!, $number: Int!, $cursor: String) {
             __typename
             ... on Issue {
               number
+              state
+              stateReason
               title
               body
               labels(first: 100) { nodes { name } }
@@ -58,6 +61,7 @@ query($owner: String!, $number: Int!, $cursor: String) {
             }
             ... on PullRequest {
               number
+              state
               title
               body
               labels(first: 100) { nodes { name } }
@@ -131,6 +135,10 @@ async function addLabel(number, label) {
 }
 
 async function reportTokenFailure(message) {
+  if (DRY_RUN) {
+    console.error(`Dry run: would report PROJECT_TOKEN authentication failure: ${message}`);
+    return;
+  }
   const title = "Dev board automation: PROJECT_TOKEN needs renewing";
   const search = await fetch(
     `https://api.github.com/search/issues?q=${encodeURIComponent(`repo:${REPO} is:issue is:open in:title "${title}"`)}`,
@@ -183,6 +191,9 @@ async function main() {
   const fieldWrites = [];
   const labelWrites = [];
   for (const item of items) {
+    const completion = planStatusWrites(item);
+    fieldWrites.push(...completion.writes.map(write => ({ ...write, itemId: item.id })));
+    drift.push(...completion.drift);
     const planned = planFieldWrites(item, TRUSTED_LOGINS);
     fieldWrites.push(...planned.writes.map(write => ({ ...write, itemId: item.id })));
     drift.push(...planned.drift);


### PR DESCRIPTION
Closed, unmerged PRs were displayed as Done, alongside completed work. The reconciler now derives terminal Status from GitHub outcomes: completed issues and merged PRs become Done; not-planned/duplicate issues and closed, unmerged PRs become Archive. Open cards left in Done return to Backlog. Other active statuses and actually archived history are preserved; unknown issue closure reasons require review.

Adds issue-closure and PR-closure/reopening triggers. PR events check out only the default branch and execute metadata automation, never PR code. The scheduled sweep repairs missed events and conflicting native project updates. Dry runs now suppress token-failure issue creation as well as field/label writes.

Documents the completion policy and release-time closure review, and updates the PR template to distinguish Fixes from partial references. Done means completed/merged, not necessarily released. Theme/Priority/Size behavior remains fill-only.

Validation: all 47 script tests pass, including runner fixtures for pagination, preview, authentication failure and partial-write failure. Previewing current board data identified exactly three status corrections (#1799, #1819, #1820). Those live cards have been moved to Archive separately; #1690 was closed with implementation evidence, #1721 narrowed to its remaining work, and discussion #1784 resolved. The notes and journey tests used for those acceptance checks also pass (77 tests).

The existing native project workflow settings are UI-only and still need checking for generic closed-to-Done rules; the reconciler provides recovery after such a rule runs. No changes to issue/discussion state are performed by this script.

The shared local commit hook was skipped because its Biome 2.4.15 cannot parse upstream’s 2.5 configuration; none of the changed files is in the Biome source include set. Dedicated script tests and whitespace checks passed.

Hosted CI note: the documentation PR’s lint and unit checks passed. Its Playwright run failed the unchanged legacy added-label note migration check (230 passed, one skipped, one failed). The failure and investigation criteria are tracked in #1841; it is not being treated as a clean browser-suite result. See https://github.com/Azgaar/Fantasy-Map-Generator/actions/runs/34492975245.