### PR TITLE
Keep the update announcement out of the map loading e2e suite

### DIFF
--- a/tests/e2e/load-map.spec.ts
+++ b/tests/e2e/load-map.spec.ts
@@ -77,6 +77,11 @@ function getReliefState(page: Page) {
 test.describe("Map loading", () => {
   test.beforeEach(async ({ context, page }) => {
     await context.clearCookies();
+    // With no stored version the app raises its "updated to version ..." dialog 6 seconds after the
+    // page loads (services/versioning.ts), which on a slow runner lands inside a test and trips the
+    // "no #alert is open" guards below. "99.99.99" rather than the real VERSION so this cannot drift:
+    // the announcement fires only for a stored version older than the build's.
+    await context.addInitScript(() => localStorage.setItem("version", "99.99.99"));
 
     await page.goto("/");
     await page.evaluate(() => {


### PR DESCRIPTION
The Playwright job on #1839 (a docs-only change) failed on `load-map.spec.ts › a legacy note on an added label follows it onto pack.addedLabels`. The test guards against any open `#alert` to catch the "notes without an element" prompt. The report's page snapshot shows the alert that was actually open: the "Fantasy Map Generator update" announcement, which `services/versioning.ts` raises six seconds after a page loads with no stored version. On a slow runner it lands inside the test.

The suite's setup now seeds a stored version before each page load, so the announcement never arms during the suite. That covers both tests with the same guard. "99.99.99" rather than the real VERSION so the seed cannot drift: the announcement fires only for a stored version older than the build's.

All 16 map loading tests pass locally.
