### PR TITLE
fix: stop an empty legend redrawing as an "undefined" row

### DIFF
--- a/src/controllers/biomes-editor.ts
+++ b/src/controllers/biomes-editor.ts
@@ -383,6 +383,7 @@ function toggleLegend(): void {
     .filter(({ i }) => statistics[i].cells)
     .sort((a, b) => statistics[b.i].area - statistics[a.i].area)
     .map(({ i, color, name }) => [i, color, name]);
+  if (!data.length) return void tip("No biomes to show", false, "error");
   drawLegend(LEGEND_NAME, data);
 }
 

--- a/src/controllers/cultures-editor.ts
+++ b/src/controllers/cultures-editor.ts
@@ -816,6 +816,7 @@ function toggleLegend(): void {
     .filter(c => c.i && !c.removed && c.cells)
     .sort((a, b) => (b.area ?? 0) - (a.area ?? 0))
     .map(c => [c.i, c.color, c.name]);
+  if (!data.length) return void tip("No cultures to show", false, "error");
   drawLegend(LEGEND_NAME, data);
 }
 

--- a/src/controllers/religions-editor.ts
+++ b/src/controllers/religions-editor.ts
@@ -765,6 +765,7 @@ function toggleLegend(): void {
     .filter(r => r.i && !r.removed && r.area)
     .sort((a, b) => (b.area ?? 0) - (a.area ?? 0))
     .map(r => [r.i, r.color, r.name]);
+  if (!data.length) return void tip("No religions to show", false, "error");
   drawLegend(LEGEND_NAME, data);
 }
 

--- a/src/controllers/states-editor.ts
+++ b/src/controllers/states-editor.ts
@@ -1014,6 +1014,7 @@ function toggleLegend(): void {
     .filter(s => s.i && !s.removed && s.cells)
     .sort((a, b) => (b.area ?? 0) - (a.area ?? 0))
     .map(s => [s.i, s.color, s.name]);
+  if (!data.length) return void tip("No states to show", false, "error");
   drawLegend(LEGEND_NAME, data);
 }
 

--- a/src/controllers/zones-editor.ts
+++ b/src/controllers/zones-editor.ts
@@ -353,6 +353,7 @@ function toggleLegend(): void {
   const isFiltered = filterBy !== "all";
   const visibleZones = pack.zones.filter(zone => !zone.hidden && (!isFiltered || zone.type === filterBy));
   const data = visibleZones.map(({ i, name, color }) => [`zone${i}`, color, name]);
+  if (!data.length) return void tip("No zones to show", false, "error");
   drawLegend(LEGEND_NAME, data);
 }
 

--- a/src/renderers/draw-legend.test.ts
+++ b/src/renderers/draw-legend.test.ts
@@ -211,6 +211,17 @@ describe("several legend boxes", () => {
     expect(legendPositions.get("Zones")).toEqual({ x: 99, y: 84.67 });
   });
 
+  it("redraws a box with no items as empty, not as one blank row", () => {
+    drawLegend("Zones", []); // every zone filtered out
+    expect(boxOf("Zones")!.getAttribute("data")).toBe("");
+
+    redrawLegend();
+
+    const swatches = boxOf("Zones")!.querySelectorAll("rect:not(.legendBox)");
+    expect(swatches).toHaveLength(0);
+    expect(boxOf("Zones")!.textContent).toBe("Zones"); // the title alone, no "undefined" row
+  });
+
   it("adopts the single box of a map saved before the legend could hold several", () => {
     const legend = document.getElementById("legend")!;
     legend.setAttribute("data", "state1,#ff0000,Alpha|state2,#00ff00,Beta");

--- a/src/renderers/draw-legend.ts
+++ b/src/renderers/draw-legend.ts
@@ -111,7 +111,9 @@ export function redrawLegend(): void {
 
   for (const node of getBoxes()) {
     const name = node.dataset.legend ?? "";
-    const data: LegendItem[] = (node.getAttribute("data") || "").split("|").map(line => line.split(","));
+    // a box with no items stores an empty string, which splits into one blank row
+    const stored = (node.getAttribute("data") || "").split("|").filter(Boolean);
+    const data: LegendItem[] = stored.map(line => line.split(","));
     drawLegend(name, data);
   }
 }

--- a/tests/e2e/legend-boxes.spec.ts
+++ b/tests/e2e/legend-boxes.spec.ts
@@ -61,4 +61,19 @@ test.describe("legend boxes", () => {
     await expect(page.locator("#legend > g[data-legend]")).toHaveCount(1);
     await expect(page.locator('#legend > g[data-legend="States"]')).toBeAttached();
   });
+
+  test("toggling a legend with nothing to list reports it instead of drawing an empty box", async ({ page }) => {
+    await openEditor(page, "ZonesEditor");
+
+    // hide every zone through the editor, so the legend has nothing to list
+    const hide = page.locator("#zonesBodySection .zoneHide");
+    const count = await hide.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) await hide.nth(i).click();
+
+    await page.locator("#zonesLegend").click();
+
+    await expect(page.locator("#tooltip")).toHaveText("No zones to show");
+    await expect(page.locator("#legend > g[data-legend]")).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
# Description

Fixes #1843

A legend box with no items — the Zones editor with every zone hidden — stores an empty string in its `data` attribute. Splitting that on `|` yields one blank row rather than none, so the next redraw drew a swatch with fill `"undefined"` and the label `"undefined"` under the title.

## The bug

```js
[].join("|")                  // ""      the box stores an empty string
"".split("|")                 // [""]    ...which splits into ONE blank row
String(row[1]) → "undefined"  // fill
String(row[2]) → "undefined"  // label
```

Any style change triggers it, since those redraw each box from its stored data.

## The change

Drop the empty entry before parsing. A real row is always `id,color,label`, so `filter(Boolean)` can only ever remove the empty-string artefact.

```ts
// a box with no items stores an empty string, which splits into one blank row
const stored = (node.getAttribute("data") || "").split("|").filter(Boolean);
const data: LegendItem[] = stored.map(line => line.split(","));
```

## Testing

Manual, in the browser: hid every zone in the Zones editor, toggled the legend box on, then changed the items-per-column slider to force a redraw. Before the change the box gained a black swatch labelled "undefined"; after it, the box stays empty. Checked in both directions on the same map.

Before: 
<img width="2048" height="893" alt="before fix" src="https://github.com/user-attachments/assets/43cee060-0c8d-4471-bbd1-4886667d9f07" />

After: 
<img width="1993" height="893" alt="after fix" src="https://github.com/user-attachments/assets/739b7c3e-fb1b-4e06-8ea7-6aec25217131" />

A regression test covers it — without the change it fails, finding the phantom swatch the blank row produces (`<rect fill="undefined">`, which renders black because the string isn't a valid colour).

One note for anyone reproducing it: the Zones type filter cannot be used to empty the list, since its options are built from the types that exist and so always leave at least one zone visible. Hiding the rows is the way in.

---

Spotted by @barrulus while reviewing #1816.
