### PR TITLE
Fix diplomacy bulk edits, invalid relations, and map target selection

### DIFF
--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -13,6 +13,7 @@ Check out [Dev board](https://github.com/users/Azgaar/projects/3/views/1?sumFiel
 Current version of the Fantasy Map Generator is the latest `master` branch. You can download it here: https://github.com/Azgaar/Fantasy-Map-Generator/archive/refs/heads/master.zip. Also see [the wiki](https://github.com/Azgaar/Fantasy-Map-Generator/wiki/Q&A#can-i-use-the-generator-offline).
 
 - Legend boxes for States, Cultures, Religions, Biomes and Zones can be shown at the same time by _[esullivan9](https://github.com/esullivan9)_
+- Diplomacy: click states on the map to select relation targets, repair invalid pairs in the editor or matrix, and record only actual changes in bulk edits
 
 # Releases
 

--- a/src/controllers/diplomacy-editor.test.ts
+++ b/src/controllers/diplomacy-editor.test.ts
@@ -1,0 +1,261 @@
+// @vitest-environment jsdom
+import { select } from "d3";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { tip } from "@/components/tooltips";
+import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
+import type { State } from "@/generators/states-generator";
+import { DiplomacyEditor } from "./diplomacy-editor";
+
+vi.mock("@/components/layers", () => ({ Layers: { show: vi.fn(), hide: vi.fn(), isOn: () => false } }));
+vi.mock("@/renderers/emblems/renderer", () => ({ EmblemRenderer: { trigger: vi.fn() } }));
+vi.mock("@/components/tooltips", () => ({ tip: vi.fn(), clearMainTip: vi.fn() }));
+vi.mock("@/components/viewbox-events", () => ({
+  applyDefaultViewboxEvents: vi.fn(() => select("#viewbox").on("click", null))
+}));
+vi.mock("@/components/dialog/highlighting", () => ({ applyLineHighlighting: vi.fn() }));
+vi.mock("@/components/dialog/sorting", () => ({
+  bindColumnSorting: vi.fn(),
+  sortDataByColumns: (_id: string, rows: State[]) => rows
+}));
+vi.mock("@/components/dialog/dialog-helpers", async importOriginal => ({
+  ...(await importOriginal<typeof import("@/components/dialog/dialog-helpers")>()),
+  closeDialogs: vi.fn()
+}));
+vi.mock("@/components/dialog/table", () => ({
+  initColumnVisibility: vi.fn(),
+  renderEditorHeader: () => "",
+  renderEditorPagination: vi.fn(),
+  initEditorTable: ({ getData, onUpdate }: { getData: () => State[]; onUpdate: (view: unknown) => void }) => ({
+    reset: () => {
+      const rows = getData();
+      onUpdate({ rows, all: rows });
+    }
+  })
+}));
+
+interface DialogOptions {
+  close?: () => void;
+  buttons?: Record<string, (this: HTMLElement) => void>;
+}
+
+let dialogs: Map<HTMLElement, DialogOptions>;
+let states: State[];
+
+function element<T extends Element = HTMLElement>(selector: string): T {
+  const el = document.querySelector<T>(selector);
+  if (!el) throw new Error(`Missing ${selector}`);
+  return el;
+}
+
+function close(selector: string): void {
+  dialogs.get(element<HTMLElement>(selector))?.close?.();
+}
+
+function action(label: string): void {
+  const dialog = element<HTMLElement>("#diplomacyRelations");
+  dialogs.get(dialog)!.buttons![label].call(dialog);
+}
+
+function choose(relation: string): void {
+  element<HTMLInputElement>(`#relationsForm input[value="${relation}"]`).click();
+}
+
+function mapClick(cell: number): void {
+  element("#viewbox").dispatchEvent(new MouseEvent("click", { clientX: cell, bubbles: true }));
+}
+
+function editRow(state = 2): void {
+  element<HTMLElement>(`#diplomacyBodySection [data-id="${state}"] .changeRelations`).click();
+}
+
+const chronicle = () => states[0].diplomacy as unknown as string[][];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dialogs = new Map();
+  document.body.innerHTML = `<div id="dialogs"><div id="alert"><div id="alertMessage"></div></div></div>
+    <svg><g id="viewbox"><g id="statesBody"></g><g id="statesHalo"></g><g id="debug"></g></g></svg>`;
+  vi.stubGlobal("$", (target: string | HTMLElement) => {
+    const el = typeof target === "string" ? element<HTMLElement>(target) : target;
+    return {
+      dialog: (options: string | DialogOptions) => {
+        if (options === "close") dialogs.get(el)?.close?.();
+        else if (options === "destroy") {
+          dialogs.delete(el);
+          el.classList.remove("ui-dialog-content");
+        } else if (typeof options === "object") {
+          dialogs.set(el, { ...dialogs.get(el), ...options });
+          el.classList.add("ui-dialog-content");
+        }
+      }
+    };
+  });
+  states = [
+    { i: 0, name: "Neutrals", diplomacy: [] },
+    { i: 1, name: "One", fullName: "State One", diplomacy: ["x", "x", "Rival", "Neutral", "x"] },
+    { i: 2, name: "Two", fullName: "State Two", diplomacy: ["x", "Rival", "x", "Ally", "x"] },
+    { i: 3, name: "Three", fullName: "State Three", diplomacy: ["x", "Neutral", "Ally", "x", "x"] },
+    { i: 4, name: "Removed", removed: true, diplomacy: ["x", "x", "x", "x", "x"] }
+  ] as State[];
+  vi.stubGlobal("pack", { states, cells: { state: Uint16Array.from([0, 1, 2, 3, 4, 99]) } });
+  vi.stubGlobal("Pack", { findCell: (x: number) => (x < 6 ? x : undefined) });
+  vi.stubGlobal("customization", 0);
+  DiplomacyEditor.open();
+  mapClick(1);
+});
+
+afterEach(() => {
+  if (document.getElementById("diplomacyEditor")) close("#diplomacyEditor");
+  vi.unstubAllGlobals();
+});
+
+describe("diplomacy bulk edits", () => {
+  test("skips an existing ally while recording the actual changed pair", () => {
+    editRow();
+    choose("Ally");
+    mapClick(3);
+    action("Apply");
+    expect(states[2].diplomacy).toEqual(["x", "Ally", "x", "Ally", "x"]);
+    expect(states[1].diplomacy![2]).toBe("Ally");
+    expect(chronicle()).toEqual([["Defence pact", "Two entered into defensive pact with One"]]);
+  });
+
+  test("applies to other targets even when the clicked row already has the chosen relation", () => {
+    editRow();
+    mapClick(3);
+    action("Apply");
+    expect(states[2].diplomacy![3]).toBe("Rival");
+    expect(states[3].diplomacy![2]).toBe("Rival");
+    expect(chronicle()).toEqual([["Rivalization", "Two and Three became rivals"]]);
+  });
+
+  test("uses each target's former relation for war termination history", () => {
+    states[2].diplomacy![3] = states[3].diplomacy![2] = "Enemy";
+    editRow();
+    choose("Friendly");
+    mapClick(3);
+    action("Apply");
+    expect(chronicle().map(entry => entry[0])).toEqual(["Relations change", "War termination"]);
+  });
+});
+
+describe("invalid diplomacy", () => {
+  function showInvalidPair(): void {
+    states[1].diplomacy![2] = states[2].diplomacy![1] = "x";
+    element<HTMLElement>("#diplomacyEditorRefresh").click();
+    element<HTMLElement>("#diplomacyShowMatrix").click();
+  }
+
+  test("renders invalid pairs without mutating them and keeps only the diagonal uneditable", () => {
+    showInvalidPair();
+    expect(element('[data-id="2"] .changeRelations').textContent).toContain("Invalid");
+    expect(document.querySelectorAll("#diplomacyMatrixBody td.x")).toHaveLength(3);
+    element<HTMLElement>('#diplomacyMatrixBody tr[data-id="1"] td.x').click();
+    expect(document.getElementById("diplomacyRelations")).toBeNull();
+    expect(states[1].diplomacy![2]).toBe("x");
+    expect(chronicle()).toEqual([]);
+  });
+
+  test("requires an explicit replacement and repairs reciprocal vassal relations", () => {
+    showInvalidPair();
+    element<HTMLElement>('#diplomacyMatrixBody tr[data-id="1"] td[data-id="2"]').click();
+    action("Apply");
+    expect(tip).toHaveBeenCalledWith("Please choose a relation", false, "warn");
+    expect(states[1].diplomacy![2]).toBe("x");
+    choose("Vassal");
+    action("Apply");
+    const reloaded = JSON.parse(JSON.stringify(states)) as State[];
+    expect(reloaded[1].diplomacy![2]).toBe("Vassal");
+    expect(reloaded[2].diplomacy![1]).toBe("Suzerain");
+    expect(element('#diplomacyMatrixBody tr[data-id="2"] td[data-id="1"]').textContent).toBe("Suzerain");
+  });
+
+  test("repairs a broken inverse even if the selected direction already matches", () => {
+    states[1].diplomacy![2] = "x";
+    editRow();
+    action("Apply");
+    expect(states[1].diplomacy![2]).toBe("Rival");
+    expect(chronicle()).toHaveLength(1);
+  });
+
+  test("keeps matrix columns aligned with sparse arrays and removed states", () => {
+    delete states[1].diplomacy![2];
+    states[2].diplomacy = undefined;
+    element<HTMLElement>("#diplomacyEditorRefresh").click();
+    element<HTMLElement>("#diplomacyShowMatrix").click();
+    const row = element('#diplomacyMatrixBody tr[data-id="1"]');
+    expect(row.querySelectorAll("td")).toHaveLength(3);
+    expect(row.querySelector('td[data-id="3"]')!.textContent).toBe("Neutral");
+    element<HTMLElement>('#diplomacyMatrixBody tr[data-id="2"] td[data-id="1"]').click();
+    choose("Suzerain");
+    action("Apply");
+    expect(states[2].diplomacy![1]).toBe("Suzerain");
+    expect(states[1].diplomacy![2]).toBe("Vassal");
+  });
+
+  test("explicit reset repairs invalid pairs and preserves self, neutral and removed entries", () => {
+    showInvalidPair();
+    element<HTMLElement>("#diplomacyReset").click();
+    expect(states[1].diplomacy).toEqual(["x", "x", "Neutral", "Neutral", "x"]);
+    expect(states[2].diplomacy![1]).toBe("Neutral");
+    expect(states[4].diplomacy![1]).toBe("x");
+    expect(chronicle()).toEqual([]);
+  });
+});
+
+describe("map target selection lifecycle", () => {
+  test("keeps the subject fixed, toggles valid targets and synchronizes select-all", () => {
+    editRow();
+    const before = JSON.stringify(states);
+    const self = element("#diplomacyBodySection .Self");
+    mapClick(3);
+    expect(element<HTMLInputElement>("#selectState3").checked).toBe(true);
+    expect(element("#selectAllNoneBtn").classList.contains("pressed")).toBe(true);
+    expect(element("#diplomacyBodySection .Self")).toBe(self);
+    for (const cell of [0, 2, 4, 5, 8]) mapClick(cell);
+    expect(JSON.stringify(states)).toBe(before);
+    element<HTMLInputElement>("#selectState3").click();
+    expect(element("#selectAllNoneBtn").classList.contains("pressed")).toBe(false);
+    element<HTMLElement>("#selectAllNoneBtn").click();
+    expect(element<HTMLInputElement>("#selectState3").checked).toBe(true);
+    mapClick(3);
+    expect(element<HTMLInputElement>("#selectState3").checked).toBe(false);
+  });
+
+  test.each(["Apply", "Cancel", "close"])("restores map selection after %s", exit => {
+    const previous = select("#viewbox").on("click");
+    editRow();
+    mapClick(3);
+    const before = JSON.stringify(states);
+    if (exit === "close") close("#diplomacyRelations");
+    else action(exit);
+    if (exit !== "Apply") expect(JSON.stringify(states)).toBe(before);
+    expect(document.getElementById("diplomacyRelations")).toBeNull();
+    expect(select("#viewbox").on("click")).toBe(previous);
+    mapClick(3);
+    expect(element<HTMLElement>("#diplomacyBodySection .Self").dataset.id).toBe("3");
+  });
+
+  test("closing the editor discards the pending selection and restores default map events", () => {
+    editRow();
+    choose("Enemy");
+    mapClick(3);
+    const before = JSON.stringify(states);
+    close("#diplomacyEditor");
+    expect(document.getElementById("diplomacyRelations")).toBeNull();
+    expect(JSON.stringify(states)).toBe(before);
+    expect(applyDefaultViewboxEvents).toHaveBeenCalledOnce();
+    expect(select("#viewbox").on("click")).toBeUndefined();
+  });
+
+  test("reopening the relation dialog replaces the pending selection without stacking handlers", () => {
+    const previous = select("#viewbox").on("click");
+    editRow();
+    mapClick(3);
+    editRow(3);
+    expect(document.querySelectorAll("#diplomacyRelations")).toHaveLength(1);
+    expect(document.querySelectorAll("#stateSelectionContainer input:checked")).toHaveLength(1);
+    action("Cancel");
+    expect(select("#viewbox").on("click")).toBe(previous);
+  });
+});

--- a/src/controllers/diplomacy-editor.ts
+++ b/src/controllers/diplomacy-editor.ts
@@ -65,6 +65,7 @@ const relations: Record<string, Relation> = {
 };
 
 const dialogId = "diplomacyEditor" as const;
+const relationsDialogId = "diplomacyRelations";
 const position = { my: "right top", at: "right-10 top+10", of: "svg", collision: "fit" };
 let selectedDiplomacyId = 0;
 const columns: EditorColumn<State>[] = [
@@ -212,8 +213,9 @@ function renderDiplomacyPage(view: TableView<State>): void {
   </div>`;
 
   for (const state of view.rows) {
-    const relation = state.diplomacy![selectedId];
-    const { color, inText } = relations[relation];
+    const storedRelation = state.diplomacy?.[selectedId] ?? "x";
+    const relation = Object.hasOwn(relations, storedRelation) ? storedRelation : "Invalid";
+    const { color, inText } = relations[relation] ?? { color: "#a9a9a9", inText: "has an invalid relation to" };
 
     const tipText = `${state.name} ${inText} ${selectedName}`;
     const tipSelect = `${tipText}. Click to see relations to ${state.name}`;
@@ -290,7 +292,7 @@ function showStateRelations(): void {
       if (this.id.slice(0, 9) === "state-gap") return; // exclude state gap element
       const id = +this.id.slice(5); // state id
 
-      const relation = pack.states[id].diplomacy![sel];
+      const relation = pack.states[id].diplomacy?.[sel] ?? "x";
       const color = relations[relation]?.color || "#4682b4";
 
       this.setAttribute("fill", color);
@@ -301,7 +303,7 @@ function showStateRelations(): void {
     });
 }
 
-function selectStateOnMapClick(this: SVGElement, event: any): void {
+function selectStateOnMapClick(this: SVGElement, event: MouseEvent): void {
   const point = getPointer(event, this);
   const i = Pack.findCell(point[0], point[1])!;
   const state = pack.cells.state[i];
@@ -312,6 +314,7 @@ function selectStateOnMapClick(this: SVGElement, event: any): void {
 }
 
 function selectRelation(subjectId: number, objectId: number, currentRelation: string): void {
+  closeRelationsDialog();
   const states = pack.states;
   const subject = states[subjectId];
 
@@ -348,7 +351,10 @@ function selectRelation(subjectId: number, objectId: number, currentRelation: st
     )
     .join("");
 
-  alertMessage.innerHTML = /* html */ `
+  const dialog = document.createElement("div");
+  dialog.id = relationsDialogId;
+  dialog.className = "dialog";
+  dialog.innerHTML = /* html */ `
     <form id='relationsForm' style="overflow: hidden; display: flex; flex-direction: column; gap: .3em; padding: 0.1em 0;">
       <header>
         <svg class="coaIcon" viewBox="0 0 200 200">
@@ -357,12 +363,13 @@ function selectRelation(subjectId: number, objectId: number, currentRelation: st
         <b>${subject.fullName}</b>
       </header>
 
+      <div class="info-line">Choose a relation, then select target states in the list or click them on the map. Apply to save.</div>
       <main style='display: flex; gap: 1em;'>
         <section style="display: flex; flex-direction: column; gap: .3em;">${relationsSelector}</section>
         <section style="display: flex; flex-direction: column; gap: .3em;">
           <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.3em;">
             <label style="font-weight: 500; font-size: 0.95em;">States:</label>
-            <button id="selectAllNoneBtn" type="button" style="padding: 0.3em 0.8em; cursor: pointer; font-size: 0.9em;" data-tip="Toggle selection of all states. Also supports Ctrl+A.">Select All / None</button>
+            <button id="selectAllNoneBtn" type="button" style="padding: 0.3em 0.8em; cursor: pointer; font-size: 0.9em;" data-tip="Toggle selection of all states.">Select All / None</button>
           </div>
           <div id="stateSelectionContainer" style="display: flex; flex-direction: column; gap: .3em;">${objectsSelector}</div>
         </section>
@@ -370,18 +377,44 @@ function selectRelation(subjectId: number, objectId: number, currentRelation: st
     </form>
   `;
 
-  $("#alert").dialog({
+  ensureEl("dialogs").appendChild(dialog);
+  const viewbox = select<SVGElement, unknown>("#viewbox");
+  const previousClick = viewbox.on("click");
+  viewbox.on("click", function (event: MouseEvent) {
+    const [x, y] = getPointer(event, this);
+    const cell = Pack.findCell(x, y);
+    if (cell === undefined) return;
+    const stateId = pack.cells.state[cell];
+    if (!stateId || stateId === subjectId || !pack.states[stateId] || pack.states[stateId].removed) return;
+    const checkbox = dialog.querySelector<HTMLInputElement>(`#selectState${stateId}`);
+    if (!checkbox) return;
+    checkbox.checked = !checkbox.checked;
+    updateButtonState();
+  });
+
+  $(dialog).dialog({
     width: "fit-content",
     title: `Change relations`,
+    close: () => {
+      if (previousClick) viewbox.on("click", previousClick);
+      else viewbox.on("click", null);
+      destroyDialog(relationsDialogId);
+    },
     buttons: {
       Apply: function (this: HTMLElement) {
         const formData = new FormData(ensureEl<HTMLFormElement>("relationsForm"));
-        const newRelation = formData.get("relationSelect") as string;
+        const newRelation = formData.get("relationSelect");
+        if (typeof newRelation !== "string" || !Object.hasOwn(relations, newRelation)) {
+          tip("Please choose a relation", false, "warn");
+          return;
+        }
         const objectIds = [...formData.getAll("objectSelect")].map(Number);
 
         for (const oid of objectIds) {
-          changeRelation(subjectId, oid, currentRelation, newRelation);
+          changeRelation(subjectId, oid, newRelation);
         }
+        refreshDiplomacyEditor();
+        if (findEl("diplomacyMatrix")) showRelationsMatrix();
         $(this).dialog("close");
       },
       Cancel: function (this: HTMLElement) {
@@ -417,20 +450,29 @@ function selectRelation(subjectId: number, objectId: number, currentRelation: st
     toggleSelectAll();
   });
 
+  dialog.addEventListener("change", updateButtonState);
   updateButtonState();
 }
 
-function changeRelation(subjectId: number, objectId: number, oldRelation: string, newRelation: string): void {
-  if (newRelation === oldRelation) return;
+function closeRelationsDialog(): void {
+  if (findEl(relationsDialogId)) $(`#${relationsDialogId}`).dialog("close");
+}
+
+function changeRelation(subjectId: number, objectId: number, newRelation: string): void {
   const states = pack.states;
+  if (!objectId || subjectId === objectId || !states[objectId] || states[objectId].removed) return;
+  const oldRelation = states[subjectId].diplomacy?.[objectId];
+  const inverse = newRelation === "Vassal" ? "Suzerain" : newRelation === "Suzerain" ? "Vassal" : newRelation;
+  if (newRelation === oldRelation && states[objectId].diplomacy?.[subjectId] === inverse) return;
   const chronicle = getChronicle();
 
   const subjectName = states[subjectId].name;
   const objectName = states[objectId].name;
 
-  states[subjectId].diplomacy![objectId] = newRelation;
-  states[objectId].diplomacy![subjectId] =
-    newRelation === "Vassal" ? "Suzerain" : newRelation === "Suzerain" ? "Vassal" : newRelation;
+  states[subjectId].diplomacy ??= [];
+  states[objectId].diplomacy ??= [];
+  states[subjectId].diplomacy[objectId] = newRelation;
+  states[objectId].diplomacy[subjectId] = inverse;
 
   // update relation history
   const change = (): string[] => [
@@ -469,9 +511,6 @@ function changeRelation(subjectId: number, objectId: number, oldRelation: string
   else if (newRelation === "Unknown") chronicle.push(unknown());
   else if (newRelation === "Rival") chronicle.push(rival());
   else chronicle.push(change());
-
-  refreshDiplomacyEditor();
-  if (findEl("diplomacyMatrix")) showRelationsMatrix();
 }
 
 function regenerateRelations(): void {
@@ -484,14 +523,16 @@ function resetRelations(): void {
   if (!selectedId) return;
   const states = pack.states;
 
-  states[selectedId].diplomacy!.forEach((relation, index) => {
-    if (relation !== "x") {
-      states[selectedId].diplomacy![index] = "Neutral";
-      states[index].diplomacy![selectedId] = "Neutral";
-    }
-  });
+  for (const state of states) {
+    if (!state.i || state.i === selectedId || state.removed) continue;
+    states[selectedId].diplomacy ??= [];
+    state.diplomacy ??= [];
+    states[selectedId].diplomacy[state.i] = "Neutral";
+    state.diplomacy[selectedId] = "Neutral";
+  }
 
   refreshDiplomacyEditor();
+  if (findEl("diplomacyMatrix")) showRelationsMatrix();
 }
 
 function showRelationsHistory(): void {
@@ -549,7 +590,6 @@ function changeReliationsHistory(this: HTMLElement): void {
 function showRelationsMatrix(): void {
   renderMatrix();
   const states = pack.states.filter(s => s.i && !s.removed);
-  const valid = states.map(state => state.i);
   const diplomacyMatrixBody = ensureEl("diplomacyMatrixBody");
 
   let table = `<table><thead><tr><th data-tip='&#8205;'></th>`;
@@ -557,14 +597,14 @@ function showRelationsMatrix(): void {
   table += `<tbody>`;
 
   states.forEach(state => {
-    table += `<tr data-id=${state.i}><th data-tip='Relations of ${state.fullName}'>${state.name}</th>${state
-      .diplomacy!.filter((_v, i) => valid.includes(i))
-      .map((relation, index) => {
-        const relationObj = relations[relation];
-        if (!relationObj) return `<td class='${relation}'>${relation}</td>`;
-
-        const objectState = pack.states[valid[index]];
-        const t = `${state.fullName} ${relationObj.inText} ${objectState.fullName}`;
+    table += `<tr data-id=${state.i}><th data-tip='Relations of ${state.fullName}'>${state.name}</th>${states
+      .map(objectState => {
+        if (state.i === objectState.i) return `<td class="x">x</td>`;
+        const relation = state.diplomacy?.[objectState.i] ?? "x";
+        if (!Object.hasOwn(relations, relation)) {
+          return `<td data-id=${objectState.i} data-tip="Invalid relation. Click to choose a replacement" class="Unknown">Invalid</td>`;
+        }
+        const t = `${state.fullName} ${relations[relation].inText} ${objectState.fullName}`;
         return `<td data-id=${objectState.i} data-tip='${t}' class='${relation}'>${relation}</td>`;
       })
       .join("")}</tr>`;
@@ -578,8 +618,8 @@ function showRelationsMatrix(): void {
     const el = event.target as HTMLElement;
     if (el.tagName !== "TD") return;
 
-    const currentRelation = el.innerText;
-    if (!relations[currentRelation]) return;
+    if (!el.dataset.id) return;
+    const currentRelation = el.textContent ?? "";
 
     const subjectId = +el.closest<HTMLElement>("tr")!.dataset.id!;
     const objectId = +el.dataset.id!;
@@ -623,6 +663,7 @@ function downloadDiplomacyData(): void {
 }
 
 function closeDiplomacyEditor(): void {
+  closeRelationsDialog();
   applyDefaultViewboxEvents();
   clearMainTip();
   const selected = ensureEl("diplomacyBodySection").querySelector("div.Self");

--- a/src/services/versioning.ts
+++ b/src/services/versioning.ts
@@ -24,6 +24,7 @@ export const VERSION = "1.152.1";
 
 // new changes on top
 const latestPublicChanges = [
+  "Diplomacy: select relation targets on the map and repair invalid relations",
   "Heightmap: option to render contour lines",
   "Ability to override a burg's treasury",
   "Dialogs: preserve position between sessions",

--- a/tests/e2e/states.spec.ts
+++ b/tests/e2e/states.spec.ts
@@ -1,5 +1,5 @@
-import {test, expect} from "@playwright/test";
-import { waitForMap } from "./wait-for-map";
+import {test, expect, type Page} from "@playwright/test";
+import { countMaps, waitForMap, waitForNextMap } from "./wait-for-map";
 
 test.describe("States", () => {
   test.beforeEach(async ({context, page}) => {
@@ -129,5 +129,135 @@ test.describe("States", () => {
     expect(pageErrors).toEqual([]);
     await expect.poll(() => page.evaluate(cell => (window as any).pack.cells.state[cell], target.cell)).toBe(0);
     expect(await page.evaluate(state => (window as any).pack.states[state].label, target.state)).toBeUndefined();
+  });
+});
+
+declare const Controllers: { DiplomacyEditor: { open: () => Promise<void> } };
+declare const Services: {
+  Save: { prepareMapData: () => string };
+  Load: { uploadMap: (file: File) => void };
+};
+declare const pack: {
+  states: import("@/generators/states-generator").State[];
+  cells: { state: Uint16Array; p: [number, number][] };
+};
+
+test.describe("Diplomacy", () => {
+  let ids: number[];
+  let errors: string[];
+  const formDialog = (page: Page) => page.locator(".ui-dialog:has(#relationsForm)");
+
+  async function openRelation(page: Page): Promise<void> {
+    await page.locator(`#diplomacyBodySection [data-id="${ids[1]}"] .changeRelations`).click();
+    await expect(page.locator("#relationsForm")).toBeVisible();
+  }
+
+  async function mapClick(page: Page, stateId: number): Promise<void> {
+    const point = await page.evaluate(id => {
+      const viewbox = document.getElementById("viewbox") as unknown as SVGGraphicsElement;
+      for (let cell = 0; cell < pack.cells.state.length; cell++) {
+        if (pack.cells.state[cell] !== id) continue;
+        const [x, y] = pack.cells.p[cell];
+        const screen = new DOMPoint(x, y).matrixTransform(viewbox.getScreenCTM()!);
+        if (screen.x < 10 || screen.y < 10 || screen.x > innerWidth - 10 || screen.y > innerHeight - 10) continue;
+        if (document.elementFromPoint(screen.x, screen.y)?.closest("#map")) return { x: screen.x, y: screen.y };
+      }
+      return null;
+    }, stateId);
+    expect(point, `Visible map point for state ${stateId}`).not.toBeNull();
+    await page.mouse.click(point!.x, point!.y);
+  }
+
+  test.beforeEach(async ({ page }) => {
+    errors = [];
+    page.on("pageerror", error => errors.push(error.message));
+    await page.goto("/?seed=diplomacy-parcel&width=1600&height=1000");
+    await waitForMap(page);
+    ids = await page.evaluate(() => {
+      const states = pack.states.filter(state => state.i && !state.removed);
+      for (const a of states) for (const b of states) a.diplomacy![b.i] = a.i === b.i ? "x" : "Neutral";
+      const [a, b, c] = states;
+      a.diplomacy![b.i] = b.diplomacy![a.i] = "Rival";
+      b.diplomacy![c.i] = c.diplomacy![b.i] = "Ally";
+      pack.states[0].diplomacy = [];
+      return [a.i, b.i, c.i];
+    });
+    await page.evaluate(() => Controllers.DiplomacyEditor.open());
+    await expect(page.locator("#diplomacyEditor")).toBeVisible();
+  });
+
+  test.afterEach(() => expect(errors).toEqual([]));
+
+  test("bulk changes skip existing allies and preserve genuine history", async ({ page }) => {
+    await openRelation(page);
+    await page.locator('input[name="relationSelect"][value="Ally"]').check();
+    await page.locator(`label[for="selectState${ids[2]}"]`).click();
+    await formDialog(page).getByRole("button", { name: "Apply", exact: true }).click();
+    expect(await page.evaluate(() => pack.states[0].diplomacy.length)).toBe(1);
+    expect(await page.evaluate(([a, b]) => pack.states[a].diplomacy![b], ids)).toBe("Ally");
+  });
+
+  test("unchanged row relation does not suppress changes to other targets", async ({ page }) => {
+    await openRelation(page);
+    await page.locator(`label[for="selectState${ids[2]}"]`).click();
+    await formDialog(page).getByRole("button", { name: "Apply", exact: true }).click();
+    expect(await page.evaluate(([, b, c]) => pack.states[b].diplomacy![c], ids)).toBe("Rival");
+    expect(await page.evaluate(() => pack.states[0].diplomacy.length)).toBe(1);
+  });
+
+  for (const exit of ["Cancel", "Escape", "titlebar", "parent"]) {
+    test(`map selection leaves data unchanged and cleans up after ${exit}`, async ({ page }) => {
+      const before = await page.evaluate(() => JSON.stringify(pack.states.map(state => state.diplomacy)));
+      await openRelation(page);
+      await page.evaluate(() => {
+        const dialogs = document.querySelectorAll<HTMLElement>(".ui-dialog");
+        for (const dialog of dialogs) {
+          dialog.style.left = "0px";
+          dialog.style.top = "0px";
+        }
+      });
+      await mapClick(page, ids[2]);
+      await expect(page.locator(`#selectState${ids[2]}`)).toBeChecked();
+      await expect(page.locator("#diplomacyBodySection .Self")).toHaveAttribute("data-id", String(ids[0]));
+      if (exit === "Cancel") await formDialog(page).getByRole("button", { name: "Cancel", exact: true }).click();
+      else if (exit === "Escape") await page.keyboard.press("Escape");
+      else if (exit === "titlebar") await formDialog(page).locator(".ui-dialog-titlebar-close").click();
+      else {
+        await page
+          .locator(".ui-dialog:has(#diplomacyEditor) .ui-dialog-titlebar-close")
+          .evaluate((button: HTMLButtonElement) => button.click());
+      }
+      await expect(page.locator("#relationsForm")).toBeHidden();
+      expect(await page.evaluate(() => JSON.stringify(pack.states.map(state => state.diplomacy)))).toBe(before);
+      if (exit === "parent" || exit === "Escape") await page.evaluate(() => Controllers.DiplomacyEditor.open());
+      await mapClick(page, ids[2]);
+      await expect(page.locator("#diplomacyBodySection .Self")).toHaveAttribute("data-id", String(ids[2]));
+    });
+  }
+
+  test("invalid relations can be repaired and survive the real save/load service", async ({ page }) => {
+    await page.evaluate(([a, b]) => {
+      pack.states[a].diplomacy![b] = pack.states[b].diplomacy![a] = "x";
+    }, ids);
+    await page.locator("#diplomacyEditorRefresh").click();
+    await page.locator("#diplomacyShowMatrix").click();
+    const pair = page.locator(`#diplomacyMatrixBody tr[data-id="${ids[0]}"] td[data-id="${ids[1]}"]`);
+    await expect(pair).toHaveText("Invalid");
+    await pair.click();
+    await formDialog(page).getByRole("button", { name: "Apply", exact: true }).click();
+    await expect(page.locator("#relationsForm")).toBeVisible();
+    await page.locator('input[name="relationSelect"][value="Vassal"]').check();
+    await formDialog(page).getByRole("button", { name: "Apply", exact: true }).click();
+    const saved = await page.evaluate(() => Services.Save.prepareMapData());
+    await page.goto("/?seed=diplomacy-reload&width=1600&height=1000");
+    await waitForMap(page);
+    const previous = await countMaps(page);
+    await page.evaluate(data => Services.Load.uploadMap(new File([data], "diplomacy.map")), saved);
+    await waitForNextMap(page, previous);
+    expect(await page.evaluate(([a, b]) => [pack.states[a].diplomacy![b], pack.states[b].diplomacy![a]], ids)).toEqual([
+      "Vassal",
+      "Suzerain"
+    ]);
+    expect(await page.evaluate(() => pack.states[0].diplomacy.length)).toBe(1);
   });
 });


### PR DESCRIPTION
# Description

Bulk diplomacy edits now compare each selected pair against its own current relation, skipping unchanged pairs and recording history only for genuine changes. Invalid matrix entries remain editable and require an explicit replacement; reciprocal Vassal/Suzerain relations are preserved.

While the Change relations dialog is open, map clicks toggle the existing target checkboxes. Applying, cancelling, or closing the dialog restores the previous map handler. The implementation stays in the existing controller and reuses the shared DOM, map, and dialog utilities.

Fixes #1663. Fixes #1662. Refs #1643.

Validation:

- 975 unit tests passed across 88 files, including 14 diplomacy regression tests.
- Biome lint and the production build passed.
- Seven focused Playwright checks passed against both development and production builds using system Chromium. The same seven checks failed against the unchanged base, reproducing the original defects.
- Browser coverage includes mixed bulk edits, map selection, Cancel/Escape/titlebar/parent-close cleanup, and invalid-pair repair followed by a real save/reload.

The original attached map in #1643 still needs its specific acceptance check before issue closure; the browser regression reproduces invalid entries on a generated map. The full E2E suite and map corpus were not run.
