### PR TITLE
Fix state creation and province recolouring refresh

### DIFF
--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -14,6 +14,7 @@ Current version of the Fantasy Map Generator is the latest `master` branch. You 
 
 - Legend boxes for States, Cultures, Religions, Biomes and Zones can be shown at the same time by _[esullivan9](https://github.com/esullivan9)_
 - Diplomacy: click states on the map to select relation targets, repair invalid pairs in the editor or matrix, and record only actual changes in bulk edits
+- States and Provinces: newly created states and their borders appear immediately; province recolouring updates both the map and editor list
 
 # Releases
 

--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -14,7 +14,7 @@ Current version of the Fantasy Map Generator is the latest `master` branch. You 
 
 - Legend boxes for States, Cultures, Religions, Biomes and Zones can be shown at the same time by _[esullivan9](https://github.com/esullivan9)_
 - Diplomacy: click states on the map to select relation targets, repair invalid pairs in the editor or matrix, and record only actual changes in bulk edits
-- States and Provinces: newly created states and their borders appear immediately; province recolouring updates both the map and editor list
+- States and Provinces: state creation and province recolouring refresh visible map layers immediately; province recolouring also updates the editor list
 
 # Releases
 

--- a/src/controllers/provinces-editor.ts
+++ b/src/controllers/provinces-editor.ts
@@ -1222,7 +1222,6 @@ function recolorProvinces(): void {
   });
 
   Layers.draw("provinces");
-  Layers.show("provinces");
   provincesTable.refresh();
 }
 

--- a/src/controllers/provinces-editor.ts
+++ b/src/controllers/provinces-editor.ts
@@ -1221,7 +1221,9 @@ function recolorProvinces(): void {
     p.color = stateColor[0] === "#" ? d3Color(interpolate(stateColor, rndColor)(0.2))!.hex() : rndColor;
   });
 
+  Layers.draw("provinces");
   Layers.show("provinces");
+  provincesTable.refresh();
 }
 
 function downloadProvincesData(): void {

--- a/src/controllers/states-editor.ts
+++ b/src/controllers/states-editor.ts
@@ -1552,6 +1552,7 @@ function addState(this: SVGElement, event: MouseEvent): void {
   redrawEmblem("state", newState);
 
   Layers.hide("provinces");
+  Layers.draw("states", "borders");
   Layers.show("states", "borders");
 
   statesTable.refresh();

--- a/src/controllers/states-editor.ts
+++ b/src/controllers/states-editor.ts
@@ -1553,7 +1553,6 @@ function addState(this: SVGElement, event: MouseEvent): void {
 
   Layers.hide("provinces");
   Layers.draw("states", "borders");
-  Layers.show("states", "borders");
 
   statesTable.refresh();
 }

--- a/src/services/versioning.ts
+++ b/src/services/versioning.ts
@@ -24,6 +24,7 @@ export const VERSION = "1.152.1";
 
 // new changes on top
 const latestPublicChanges = [
+  "States and Provinces: refresh the map and editor after state creation and province recolouring",
   "Diplomacy: select relation targets on the map and repair invalid relations",
   "Heightmap: option to render contour lines",
   "Ability to override a burg's treasury",

--- a/src/services/versioning.ts
+++ b/src/services/versioning.ts
@@ -24,7 +24,6 @@ export const VERSION = "1.152.1";
 
 // new changes on top
 const latestPublicChanges = [
-  "States and Provinces: refresh the map and editor after state creation and province recolouring",
   "Diplomacy: select relation targets on the map and repair invalid relations",
   "Heightmap: option to render contour lines",
   "Ability to override a burg's treasury",

--- a/tests/e2e/annex-mode.spec.ts
+++ b/tests/e2e/annex-mode.spec.ts
@@ -244,7 +244,12 @@ test.describe("State and province refresh", () => {
           expect(changed.every(p => p.state === state)).toBe(true);
           expect(provinces.some(p => p.state !== state)).toBe(true);
         }
-        expect(await page.evaluate(() => Layers.isOn("provinces"))).toBe(true);
+        expect(await page.evaluate(() => Layers.isOn("provinces"))).toBe(visible);
+        if (!visible) {
+          await expect(page.locator("#provs")).toBeHidden();
+          await expect(page.locator("#provs path")).toHaveCount(0);
+          await page.evaluate(() => Layers.show("provinces"));
+        }
         const mismatches = await page.evaluate(() => {
           const map = pack.provinces
             .filter(
@@ -296,6 +301,13 @@ test.describe("State and province refresh", () => {
       await clickMapAt(page, target!.point);
 
       expect(await page.evaluate(i => pack.cells.state[i], target!.i)).toBe(newState);
+      expect(await page.evaluate(() => [Layers.isOn("states"), Layers.isOn("borders")])).toEqual([visible, visible]);
+      if (!visible) {
+        await expect(page.locator("#regions")).toBeHidden();
+        await expect(page.locator("#borders")).toBeHidden();
+        await expect(page.locator("#statesBody path, #borders path")).toHaveCount(0);
+        await page.evaluate(() => Layers.show("states", "borders"));
+      }
       await expect(page.locator(`#statesBody #state${newState}`)).toHaveAttribute("d", /\S/);
       expect(await page.locator("#borders").innerHTML()).not.toBe(oldBorders);
       const rendered = await page.evaluate(() =>

--- a/tests/e2e/annex-mode.spec.ts
+++ b/tests/e2e/annex-mode.spec.ts
@@ -77,6 +77,9 @@ test.describe("Annex by clicking on the map", () => {
     // the states layer is redrawn: the annexing state's fill now covers the annexed cells
     expect(await page.locator(`#statesBody #state${parent.i}`).getAttribute("d")).not.toBe(parentFill);
     expect(await page.locator(`#statesBody #state${child.i}`).count()).toBe(0);
+    const borders = await page.locator("#borders").innerHTML();
+    await page.evaluate(() => Layers.draw("borders"));
+    expect(await page.locator("#borders").innerHTML()).toBe(borders);
 
     const result = await page.evaluate(
       ([p, c]) => {
@@ -204,5 +207,133 @@ test.describe("Annex by clicking on the map", () => {
     expect(await page.locator("#debug .annex-preview .annex-child").count()).toBe(0);
     const removed = await page.evaluate(c => Boolean((window as any).pack.provinces[c].removed), foreign.i);
     expect(removed).toBe(false);
+  });
+});
+
+declare const pack: import("@/types/PackedGraph").PackedGraph;
+
+test.describe("State and province refresh", () => {
+  let errors: string[];
+
+  test.beforeEach(async ({ page }) => {
+    errors = [];
+    page.on("pageerror", error => errors.push(error.message));
+    await page.addInitScript(() => localStorage.setItem("preset", "landmass"));
+    await page.goto("/?seed=state-refresh&width=1600&height=1000");
+    await waitForMap(page);
+  });
+
+  test.afterEach(() => expect(errors).toEqual([]));
+
+  for (const visible of [true, false]) {
+    for (const filtered of [true, false]) {
+      test(`recolour updates the map and list with layer ${visible ? "on" : "off"} and ${filtered ? "one state" : "all states"}`, async ({
+        page
+      }) => {
+        await openEditor(page, "editProvincesButton", "provincesEditor");
+        const provinces = await page.evaluate(() => pack.provinces.filter(p => p.i && !p.removed));
+        const state = filtered ? provinces[0].state : -1;
+        await page.selectOption("#provincesFilterState", String(state));
+        if (!visible) await page.evaluate(() => Layers.hide("provinces"));
+        await page.click("#provincesRecolor");
+
+        const after = await page.evaluate(() => pack.provinces.filter(p => p.i && !p.removed));
+        const changed = after.filter(p => provinces.find(old => old.i === p.i)!.color !== p.color);
+        expect(changed.length).toBeGreaterThan(0);
+        if (filtered) {
+          expect(changed.every(p => p.state === state)).toBe(true);
+          expect(provinces.some(p => p.state !== state)).toBe(true);
+        }
+        expect(await page.evaluate(() => Layers.isOn("provinces"))).toBe(true);
+        const mismatches = await page.evaluate(() => {
+          const map = pack.provinces
+            .filter(
+              p => p.i && !p.removed && document.getElementById(`province${p.i}`)?.getAttribute("fill") !== p.color
+            )
+            .map(p => p.i);
+          const rows = Array.from(document.querySelectorAll<HTMLElement>("#provincesBodySection [data-id]"));
+          const table = rows
+            .filter(
+              row =>
+                row.querySelector("fill-box")?.getAttribute("fill") !== pack.provinces[Number(row.dataset.id)].color
+            )
+            .map(row => row.dataset.id);
+          return { map, table, rows: rows.length };
+        });
+        expect(mismatches.rows).toBeGreaterThan(0);
+        expect(mismatches.map).toEqual([]);
+        expect(mismatches.table).toEqual([]);
+        await expect(page.locator("#provincesFilterState")).toHaveValue(String(state));
+      });
+    }
+
+    test(`creating a state refreshes fills and borders with layers ${visible ? "on" : "off"}`, async ({ page }) => {
+      await openEditor(page, "editStatesButton", "statesEditor");
+      if (!visible) await page.evaluate(() => Layers.hide("states", "borders"));
+      const candidates = await page.evaluate(() => {
+        const { cells, burgs } = pack;
+        return Array.from(cells.i)
+          .filter(
+            i =>
+              cells.h[i] >= 20 &&
+              cells.state[i] &&
+              !burgs[cells.burg[i]]?.capital &&
+              cells.c[i].every(c => cells.state[c] === cells.state[i])
+          )
+          .map(i => ({ i, point: cells.p[i] }));
+      });
+      let target: (typeof candidates)[number] | undefined;
+      for (const candidate of candidates) {
+        if (await isMapVisibleAt(page, candidate.point)) {
+          target = candidate;
+          break;
+        }
+      }
+      expect(target).toBeDefined();
+      const newState = await page.evaluate(() => pack.states.length);
+      const oldBorders = await page.locator("#borders").innerHTML();
+      await page.click("#statesAdd");
+      await clickMapAt(page, target!.point);
+
+      expect(await page.evaluate(i => pack.cells.state[i], target!.i)).toBe(newState);
+      await expect(page.locator(`#statesBody #state${newState}`)).toHaveAttribute("d", /\S/);
+      expect(await page.locator("#borders").innerHTML()).not.toBe(oldBorders);
+      const rendered = await page.evaluate(() =>
+        ["statesBody", "borders"].map(id => document.getElementById(id)!.innerHTML)
+      );
+      await page.evaluate(() => Layers.draw("states", "borders"));
+      expect(
+        await page.evaluate(() => ["statesBody", "borders"].map(id => document.getElementById(id)!.innerHTML))
+      ).toEqual(rendered);
+      expect(await page.evaluate(() => [Layers.isOn("states"), Layers.isOn("borders")])).toEqual([true, true]);
+    });
+  }
+
+  test("locating a province capital works before labels have been enabled", async ({ page }) => {
+    expect(await page.evaluate(() => Layers.isOn("labels"))).toBe(false);
+    await expect(page.locator("#labels text")).toHaveCount(0);
+    await openEditor(page, "editProvincesButton", "provincesEditor");
+    await page.selectOption("#provincesFilterState", "-1");
+    const capital = page.locator("#provincesBodySection .icon-star-empty:not(.placeholder)").first();
+    const burg = await capital.evaluate(element => {
+      const id = Number(element.closest<HTMLElement>("[data-id]")!.dataset.id);
+      return pack.burgs[pack.provinces[id].burg];
+    });
+    await capital.click();
+    await expect
+      .poll(() =>
+        page.evaluate(({ x, y }) => {
+          const matrix = (document.getElementById("viewbox") as unknown as SVGGraphicsElement).getScreenCTM()!;
+          const point = new DOMPoint(x, y).matrixTransform(matrix);
+          return (
+            Math.abs(matrix.a - 8) < 0.01 &&
+            Math.abs(point.x - innerWidth / 2) < 1 &&
+            Math.abs(point.y - innerHeight / 2) < 1
+          );
+        }, burg)
+      )
+      .toBe(true);
+    expect(await page.evaluate(() => Layers.isOn("labels"))).toBe(false);
+    await expect(page.locator("#labels text")).toHaveCount(0);
   });
 });


### PR DESCRIPTION
# Description

Province recolouring now immediately updates visible map layers and the editor list, including when a state filter is active. Creating a state now redraws its fill and borders when those layers are visible. Hidden layers stay hidden and render the updated data when enabled.

Both controllers use the existing `Layers.draw` method; province recolouring also refreshes the existing table. `Layers.show` alone skipped redraws for layers that were already visible. The bug fix is documented in the changelog without adding a What's new entry.

Fixes #1782. Fixes #1781. Refs #1435.

Validation:

- All 975 unit tests across 88 files, Biome lint, and the production build passed.
- Eight focused Chromium browser checks passed against development and production builds. The original refresh defects were reproduced against unchanged upstream `3da6d84a` before the fix.
- Province coverage checks the map and table with layers initially on/off and with one state/all states selected. Hidden layers remain hidden and show the updated colours when enabled.
- State creation coverage checks immediate redraws for visible fills and borders, preserves hidden layers, and checks their contents after enabling them. Existing annexation coverage verifies its fill and border redraws already work upstream.
- #1435's capital-location check passes on unchanged upstream before labels have ever been enabled, using a fresh landmass-preset session. No production change was needed for that issue; the acceptance test is included for closure review.

Browser tests extend the existing annex-mode spec and reuse its map helpers and shared readiness helper. The full E2E suite and map corpus were not run. Release availability has not been verified.
