### PR TITLE
Fix Goods bulk visibility ignoring tag filters

### DIFF
--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -14,6 +14,7 @@ Current version of the Fantasy Map Generator is the latest `master` branch. You 
 
 - Legend boxes for States, Cultures, Religions, Biomes and Zones can be shown at the same time by _[esullivan9](https://github.com/esullivan9)_
 - Diplomacy: click states on the map to select relation targets, repair invalid pairs in the editor or matrix, and record only actual changes in bulk edits
+- Goods editor: Show all respects the tag filter across pages, with consistent checkbox state and displayed counts
 
 # Releases
 

--- a/src/controllers/goods-editor.ts
+++ b/src/controllers/goods-editor.ts
@@ -99,8 +99,8 @@ function open() {
   });
 }
 
-function getVisibleCount(): number {
-  return pack.goods.reduce((count, good) => count + (good.visible ? 1 : 0), 0);
+function getVisibleCount(goods = pack.goods): number {
+  return goods.reduce((count, good) => count + (good.visible ? 1 : 0), 0);
 }
 
 function refreshEditor() {
@@ -142,7 +142,7 @@ function renderDialog(): void {
   ensureEl("dialogs").insertAdjacentHTML("beforeend", editorHtml);
   ensureEl("goodsTagsFilter").classList.toggle("active", filterState.visibleTags.length > 0);
   ensureEl(`${dialogId}Header`).querySelector<HTMLElement>('[data-col="display"]')!.innerHTML = /* html */ `<input
-    type="checkbox" data-tip="Show or hide all goods on the Goods map" class="native" id="goodsDisplayAll"
+    type="checkbox" data-tip="Show or hide all goods matching the current filter" class="native" id="goodsDisplayAll"
     style="margin: 0; width: 1.2em;" />`;
   bindColumnSorting(dialogId, goodsTable.reset);
   initColumnVisibility({
@@ -235,7 +235,6 @@ function renderGoodsPage(view: TableView<Good>) {
     .join("");
   body.innerHTML = lines || "No goods available";
 
-  ensureEl("goodsDisplayed").innerHTML = String(getVisibleCount());
   ensureEl("goodsNumber").innerHTML = String(pack.goods.length);
   ensureEl("goodsProduced").innerHTML = String(rn(totalProduced));
   ensureEl("goodsStock").innerHTML = String(rn(totalStock));
@@ -629,7 +628,7 @@ function toggleDisplayedGood(good: Good, el: HTMLInputElement) {
 
 function toggleAllDisplayed(this: HTMLInputElement) {
   const checked = this.checked;
-  for (const good of pack.goods) good.visible = checked;
+  for (const good of goodsTable.view().all) good.visible = checked;
 
   ensureEl("goodsBody")
     .querySelectorAll<HTMLInputElement>(".goodDisplayed")
@@ -637,16 +636,19 @@ function toggleAllDisplayed(this: HTMLInputElement) {
       checkbox.checked = checked;
     });
 
+  updateDisplayAllCheckbox();
   Layers.draw("goods");
 }
 
 function updateDisplayAllCheckbox() {
   const master = ensureEl<HTMLInputElement>("goodsDisplayAll");
-  const total = pack.goods.length;
-  const visibleCount = getVisibleCount();
+  const goods = goodsTable.view().all;
+  const total = goods.length;
+  const visibleCount = getVisibleCount(goods);
+  master.disabled = total === 0;
   master.checked = total > 0 && visibleCount === total;
   master.indeterminate = visibleCount > 0 && visibleCount < total;
-  ensureEl("goodsDisplayed").innerHTML = String(visibleCount);
+  ensureEl("goodsDisplayed").innerHTML = String(getVisibleCount());
 }
 
 function requestGoodsRegeneration() {

--- a/tests/e2e/table-actions.spec.ts
+++ b/tests/e2e/table-actions.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import { waitForMap } from "./wait-for-map";
 
 // Each row action has a column of its own, so the icons line up down the table. That makes the cells
@@ -173,4 +173,130 @@ test("the note icon opens the Notes Editor on the row's entity", async ({ page }
     expect(opened.glyph, dialogId).toBeTruthy();
     expect(opened.selected, dialogId).toContain(`${noteType}:`);
   }
+});
+
+declare const pack: import("@/types/PackedGraph").PackedGraph;
+declare const Controllers: { GoodsEditor: { open: () => Promise<void> } };
+
+test.describe("Goods display filter", () => {
+  let initial: { i: number; visible: boolean; matches: boolean }[];
+  let errors: string[];
+
+  async function filterGoods(page: Page) {
+    await page.click("#goodsTagsFilter");
+    await page.locator('#alert input[value="batch-a"]').check();
+    await page.locator('#alert input[value="batch-b"]').check();
+    await page.locator(".ui-dialog:has(#alert)").getByRole("button", { name: "Apply", exact: true }).click();
+  }
+
+  async function expectFilteredVisibility(page: Page, visible: boolean) {
+    const expected = initial.map(good => ({ i: good.i, visible: good.matches ? visible : good.visible }));
+    expect(await page.evaluate(() => pack.goods.map(({ i, visible }) => ({ i, visible })))).toEqual(expected);
+    await expect(page.locator("#goodsDisplayed")).toHaveText(String(expected.filter(good => good.visible).length));
+    await expect(page.locator("#goodsNumber")).toHaveText(String(initial.length));
+    await expect(page.locator("#goodsDisplayAll")).toHaveJSProperty("checked", visible);
+    await expect(page.locator("#goodsDisplayAll")).toHaveJSProperty("indeterminate", false);
+    const rows = page.locator("#goodsBody .goodDisplayed");
+    expect(
+      await rows.evaluateAll(
+        (inputs, value) => inputs.every(input => (input as HTMLInputElement).checked === value),
+        visible
+      )
+    ).toBe(true);
+  }
+
+  test.beforeEach(async ({ page }) => {
+    errors = [];
+    page.on("pageerror", error => errors.push(error.message));
+    await page.addInitScript(() => localStorage.setItem("version", "99.0.0"));
+    await page.goto("/?seed=goods-filter&width=1600&height=1000");
+    await waitForMap(page);
+    initial = await page.evaluate(() => {
+      pack.goods.forEach((good, index) => {
+        good.tags = index === 0 ? ["batch-a"] : ["unrelated"];
+        good.visible = index > 0 && index % 2 === 0;
+      });
+      const firstId = Math.max(...pack.goods.map(good => good.i)) + 1;
+      for (let index = 0; index < 104; index++) {
+        pack.goods.push({
+          ...structuredClone(pack.goods[0]),
+          i: firstId + index,
+          name: `Filter test ${index}`,
+          tags: [index % 2 ? "batch-a" : "batch-b"],
+          visible: false
+        });
+      }
+      const cell = pack.cells.i.find(i => pack.cells.h[i] >= 20)!;
+      pack.cells.good[cell] = pack.goods[0].i;
+      return pack.goods.map(good => ({
+        i: good.i,
+        visible: Boolean(good.visible),
+        matches: good.tags[0] !== "unrelated"
+      }));
+    });
+    await page.evaluate(() => Controllers.GoodsEditor.open());
+    await expect(page.locator("#goodsEditor")).toBeVisible();
+  });
+
+  test.afterEach(() => expect(errors).toEqual([]));
+
+  test("bulk show and hide affect every matching page and preserve unrelated goods", async ({ page }) => {
+    await filterGoods(page);
+    await page.locator("#goodsFooter .editorPageNext").click();
+    await expect(page.locator("#goodsBody .goodDisplayed")).toHaveCount(5);
+    await page.locator("#goodsDisplayAll").check();
+    await expectFilteredVisibility(page, true);
+    await expect(page.locator("#goodsFooter .editorPageInput")).toHaveValue("2");
+    expect(await page.locator(`#goodsIcons [data-i="${initial[0].i}"]`).count()).toBeGreaterThan(0);
+
+    await page.locator("#goodsDisplayAll").uncheck();
+    await expectFilteredVisibility(page, false);
+    await expect(page.locator(`#goodsIcons [data-i="${initial[0].i}"]`)).toHaveCount(0);
+    await expect(page.locator("#goodsFooter .editorPageInput")).toHaveValue("2");
+  });
+
+  test("master checkbox follows filtered goods and individual row changes", async ({ page }) => {
+    await page.evaluate(() => {
+      for (const good of pack.goods) if (good.tags[0] !== "unrelated") good.visible = true;
+    });
+    await filterGoods(page);
+    await expectFilteredVisibility(page, true);
+    await page.locator("#goodsBody .goodDisplayed").first().uncheck();
+    await expect(page.locator("#goodsDisplayAll")).not.toBeChecked();
+    await expect(page.locator("#goodsDisplayAll")).toHaveJSProperty("indeterminate", true);
+    const count = initial.filter(good => good.matches || good.visible).length - 1;
+    await expect(page.locator("#goodsDisplayed")).toHaveText(String(count));
+    await page.locator("#goodsDisplayAll").check();
+    await expectFilteredVisibility(page, true);
+  });
+
+  test("clearing the filter restores bulk actions and counts for the whole catalogue", async ({ page }) => {
+    await filterGoods(page);
+    await page.click("#goodsTagsFilter");
+    await page.locator(".ui-dialog:has(#alert)").getByRole("button", { name: "Clear filter", exact: true }).click();
+    await page.locator("#goodsDisplayAll").check();
+    expect(await page.evaluate(() => pack.goods.every(good => good.visible))).toBe(true);
+    await expect(page.locator("#goodsDisplayed")).toHaveText(String(initial.length));
+    await expect(page.locator("#goodsDisplayAll")).toHaveJSProperty("indeterminate", false);
+    await page.locator("#goodsDisplayAll").uncheck();
+    expect(await page.evaluate(() => pack.goods.every(good => !good.visible))).toBe(true);
+    await expect(page.locator("#goodsDisplayed")).toHaveText("0");
+    await expect(page.locator("#goodsIcons > *")).toHaveCount(0);
+  });
+
+  test("a filter with no matching goods disables the bulk checkbox", async ({ page }) => {
+    await filterGoods(page);
+    await page.evaluate(() => {
+      for (const good of pack.goods) good.tags = ["unrelated"];
+    });
+    await page.click("#goodsEditorRefresh");
+    await expect(page.locator("#goodsBody .goodDisplayed")).toHaveCount(0);
+    await expect(page.locator("#goodsDisplayAll")).toBeDisabled();
+    await expect(page.locator("#goodsDisplayAll")).not.toBeChecked();
+    await expect(page.locator("#goodsDisplayAll")).toHaveJSProperty("indeterminate", false);
+    expect(await page.evaluate(() => pack.goods.map(({ i, visible }) => ({ i, visible })))).toEqual(
+      initial.map(({ i, visible }) => ({ i, visible }))
+    );
+    await expect(page.locator("#goodsDisplayed")).toHaveText(String(initial.filter(good => good.visible).length));
+  });
 });


### PR DESCRIPTION
# Description

The Goods editor's bulk visibility checkbox now affects all goods matching the active tag filter across pages, preserving unrelated goods. The checkbox reflects the filtered selection and is disabled for an empty result set; the footer's map-wide displayed count updates after bulk changes. Clearing the filter restores the action to the whole catalogue.

Reuses the existing table's filtered data and visible-count helper. The fix is documented in the changelog only.

Fixes #1783.

Validation:

- All 975 unit tests across 88 files, Biome lint, and the production build passed.
- Four focused Chromium browser checks passed on development and production; all four fail on unchanged upstream `3da6d84a`.
- Coverage includes 105 matching goods across two pages, multiple selected tags, Show/Hide with unrelated goods preserved, map icons and displayed counts, individual row changes, clearing filters, and an empty result set.

Tests extend the existing table-actions spec and use the shared map-readiness helper. The full E2E suite and map corpus were not run.
