### PR TITLE
Fix diplomacy regeneration failing after a state is removed

### DIFF
--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -16,6 +16,7 @@ Current version of the Fantasy Map Generator is the latest `master` branch. You 
 - Diplomacy: click states on the map to select relation targets, repair invalid pairs in the editor or matrix, and record only actual changes in bulk edits
 - States and Provinces: state creation and province recolouring refresh visible map layers immediately; province recolouring also updates the editor list
 - Goods editor: Show all respects the tag filter across pages, with consistent checkbox state and displayed counts
+- Diplomacy: regenerating relations no longer fails midway (leaving "Invalid" relations) when a state has been removed and another is a vassal
 
 # Releases
 

--- a/src/generators/states-generator.test.ts
+++ b/src/generators/states-generator.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("StatesModule.collectTaxes", () => {
   let StatesModule: any;
@@ -152,5 +152,51 @@ describe("StatesModule.collectTaxes", () => {
     expect(globalThis.pack.states[0].treasury).toBe(0);
     // State 1 has no deal credit and only poll tax (0 here), so treasury stays 0
     expect(globalThis.pack.states[1].treasury).toBe(0);
+  });
+});
+
+describe("StatesModule.generateDiplomacy", () => {
+  let StatesModule: any;
+
+  beforeEach(async () => {
+    globalThis.TIME = false;
+    globalThis.options = { year: 100 } as any;
+    // 0.5 makes P(0.8) true and rw() pick no Rival, so the vassal branch runs and no war is declared
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    await import("./states-generator");
+    StatesModule = (globalThis as any).States;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("skips removed states when vassals copy their suzerain's relations", () => {
+    // state 2 is a large state bordering the small state 3, which becomes its vassal; state 4 is far away
+    const cellState = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 4];
+    globalThis.pack = {
+      cells: {
+        i: cellState.map((_, i) => i),
+        h: cellState.map(() => 30),
+        state: cellState,
+        area: cellState.map(() => 10),
+        f: cellState.map(() => 1)
+      },
+      states: [
+        { i: 0, name: "Neutrals" },
+        { i: 1, removed: true },
+        { i: 2, name: "A", neighbors: [3], center: 0, expansionism: 1, campaigns: [] },
+        { i: 3, name: "B", neighbors: [2], center: 10, expansionism: 1, campaigns: [] },
+        { i: 4, name: "C", neighbors: [], center: 11, expansionism: 1, campaigns: [] }
+      ]
+    } as any;
+
+    expect(() => StatesModule.generateDiplomacy()).not.toThrow();
+
+    const { states } = globalThis.pack;
+    expect(states[1].diplomacy).toBeUndefined();
+    expect(states[2].diplomacy).toEqual(["x", "x", "x", "Suzerain", "Neutral"]);
+    expect(states[3].diplomacy).toEqual(["x", "x", "Vassal", "x", "Neutral"]);
+    expect(states[4].diplomacy).toEqual(["x", "x", "Neutral", "Neutral", "x"]);
   });
 });

--- a/src/generators/states-generator.ts
+++ b/src/generators/states-generator.ts
@@ -517,11 +517,11 @@ class StatesModule {
         const suzerain = states[f].diplomacy!.indexOf("Vassal");
 
         for (let i = 1; i < states.length; i++) {
-          if (i === f || i === suzerain) continue;
+          if (i === f || i === suzerain || states[i].removed) continue;
           states[f].diplomacy![i] = states[suzerain].diplomacy![i];
           if (states[suzerain].diplomacy![i] === "Suzerain") states[f].diplomacy![i] = "Ally";
           for (let e = 1; e < states.length; e++) {
-            if (e === f || e === suzerain) continue;
+            if (e === f || e === suzerain || states[e].removed) continue;
             if (states[e].diplomacy![suzerain] === "Suzerain" || states[e].diplomacy![suzerain] === "Vassal") continue;
             states[e].diplomacy![f] = states[e].diplomacy![suzerain];
           }


### PR DESCRIPTION
## Problem

Reported on Discord today: after removing a state and pressing "Regenerate diplomatical relations", the Diplomacy editor shows `Invalid` for most states and relations can no longer be changed or regenerated.

A removed state is stored as `{i, removed: true}` with no `diplomacy` array. `States.generateDiplomacy()` skips removed states in its outer `f`/`t` loops, but the "vassals copy relations from their suzerains" block iterates every state index (`i` and `e`) with no `removed` guard. The first vassal processed throws:

```
TypeError: Cannot read properties of undefined (reading '<suzerain>')
```

Generation aborts partway, so every row from the first vassal onward is left at the `x` placeholder. Since #1846 the editor renders those as `Invalid`; before it the editor render itself crashed. The reporter's map matched this to the index: state 1 removed, first vassal is state 24, states 2–23 complete, everything from 24 up is `x`.

It needs a removed state plus at least one vassal rolled in that run, which is near-certain on maps with many states. That is why the first Regenerate press can succeed and the next one fail.

## Fix

Skip removed states in both inner copy loops. One more Regenerate press then repairs an affected map.

## Test

Unit test in `states-generator.test.ts` builds a 3-state pack with one removed slot, forces the vassal branch (`Math.random` pinned), and asserts generation completes with the expected symmetric relations and the removed slot untouched. It throws the reporter's TypeError before the fix.
