### PR TITLE
Fix anchor sizes lost on save and reload

### DIFF
--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -16,6 +16,7 @@ Current version of the Fantasy Map Generator is the latest `master` branch. You 
 - Diplomacy: click states on the map to select relation targets, repair invalid pairs in the editor or matrix, and record only actual changes in bulk edits
 - States and Provinces: state creation and province recolouring refresh visible map layers immediately; province recolouring also updates the editor list
 - Goods editor: Show all respects the tag filter across pages, with consistent checkbox state and displayed counts
+- Burg icons and anchors: a map whose style record lost its icon or anchor groups gets them back from the saved map on load, so their sizes can be edited and saved again
 
 # Releases
 

--- a/src/generators/burgs-generator.test.ts
+++ b/src/generators/burgs-generator.test.ts
@@ -445,6 +445,27 @@ describe("ensureBurgGroupStyles", () => {
     expect(burgIcons.groups.fortresses).not.toBe(burgIcons.groups.town);
     expect(anchors.groups.fortresses).toEqual(townAnchor);
   });
+
+  it("seeds from the shipped defaults when a record has no group to copy", async () => {
+    globalThis.window = globalThis.window || ({} as any);
+    await import("./burgs-generator");
+    const Burgs = (globalThis as any).Burgs;
+
+    options.map.burgs.groups = [{ name: "cities" }] as never;
+    const town = { attrs: { fill: "#aaa" }, options: { size: 1, icon: "#icon-burg" } };
+    const townAnchor = { attrs: { fill: "#bbb" }, options: { size: 2 } };
+    (globalThis as any).Styles = {
+      defaults: { burgIcons: { burgIcons: { groups: { town } }, anchors: { groups: { town: townAnchor } } } }
+    };
+    (globalThis as any).styles = { burgIcons: { burgIcons: { groups: {} }, anchors: { groups: {} } } };
+
+    Burgs.ensureBurgGroupStyles();
+
+    const { burgIcons, anchors } = (globalThis as any).styles.burgIcons;
+    expect(burgIcons.groups.cities).toEqual(town);
+    expect(burgIcons.groups.cities).not.toBe(town);
+    expect(anchors.groups.cities).toEqual(townAnchor);
+  });
 });
 
 describe("BurgsModule.parseStoredGroups", () => {

--- a/src/generators/burgs-generator.ts
+++ b/src/generators/burgs-generator.ts
@@ -493,12 +493,12 @@ class BurgModule {
   /** burg groups can exist without a style entry (the Burg Groups editor, presets that don't
    * list them) - without one the renderer falls back to the default group and edits never persist */
   ensureBurgGroupStyles(): void {
-    const { burgIcons, anchors } = styles.burgIcons;
-    const iconTemplate = burgIcons.groups.town || Object.values(burgIcons.groups)[0];
-    const anchorTemplate = anchors.groups.town || Object.values(anchors.groups)[0];
-    for (const { name } of options.map.burgs.groups) {
-      if (!burgIcons.groups[name] && iconTemplate) burgIcons.groups[name] = structuredClone(iconTemplate);
-      if (!anchors.groups[name] && anchorTemplate) anchors.groups[name] = structuredClone(anchorTemplate);
+    for (const type of ["burgIcons", "anchors"] as const) {
+      const { groups } = styles.burgIcons[type];
+      const template = groups.town || Object.values(groups)[0] || Styles.defaults.burgIcons[type].groups.town;
+      for (const { name } of options.map.burgs.groups) {
+        if (!groups[name]) groups[name] = structuredClone(template);
+      }
     }
   }
 

--- a/src/generators/styles-legacy.dom.test.ts
+++ b/src/generators/styles-legacy.dom.test.ts
@@ -1,5 +1,11 @@
 import { expect, test, vi } from "vitest";
-import { harvestAttributes, harvestStylesFromSvg, stripMigratedAttributes, stylesFromMap } from "./styles-legacy";
+import {
+  harvestAttributes,
+  harvestStylesFromSvg,
+  restoreEmptyBurgGroupStyles,
+  stripMigratedAttributes,
+  stylesFromMap
+} from "./styles-legacy";
 
 test("harvestAttributes derives from routes and schema", () => {
   const table = harvestAttributes();
@@ -81,6 +87,44 @@ test("a legacy style record keeps its burg/anchor groups against the DOM harvest
   expect(styles.burgIcons.burgIcons.groups.capital.attrs.fill).toBe("#000000");
   expect(styles.burgIcons.burgIcons.groups.town).toBeDefined();
   styles.burgIcons.burgIcons.groups.capital.attrs.fill = "#ffffff";
+});
+
+test("a legacy style record with an empty burg/anchor record harvests that record from the DOM", () => {
+  document.body.innerHTML = `<svg id="map">
+    <g id="burgIcons"><g id="cities" fill="#e57676" font-size="18"></g></g>
+    <g id="anchors"><g id="cities" fill="#ffffff" font-size="18"></g><g id="towns" font-size="12"></g></g>
+  </svg>`;
+  // pre-v1.150 main.js initialised the legacy record as anchors: {}, and {} counted as present
+  styles.burgIcons.anchors.groups = {};
+  harvestStylesFromSvg({ hasStyleRecord: true });
+  expect(styles.burgIcons.anchors.groups.cities.options.size).toBe(18);
+  expect(styles.burgIcons.anchors.groups.towns.options.size).toBe(12);
+  expect(styles.burgIcons.burgIcons.groups.cities).toBeUndefined(); // the filled record still wins
+  Styles.set(structuredClone(Styles.defaults));
+});
+
+test("restoreEmptyBurgGroupStyles refills an empty record from the svg and leaves a filled one alone", () => {
+  document.body.innerHTML = `<svg id="map">
+    <g id="burgIcons"><g id="cities" font-size="18"></g></g>
+    <g id="anchors"><g id="cities" font-size="18"></g><g id="towns" font-size="12"></g></g>
+  </svg>`;
+  styles.burgIcons.anchors.groups = {};
+  styles.burgIcons.burgIcons.groups.capital.options.size = 5;
+  restoreEmptyBurgGroupStyles();
+  expect(styles.burgIcons.anchors.groups.cities.options.size).toBe(18);
+  expect(styles.burgIcons.anchors.groups.towns.options.size).toBe(12);
+  expect(styles.burgIcons.anchors.groups.town).toBeDefined(); // defaults stay as fallbacks
+  expect(styles.burgIcons.burgIcons.groups.cities).toBeUndefined();
+  expect(styles.burgIcons.burgIcons.groups.capital.options.size).toBe(5);
+  Styles.set(structuredClone(Styles.defaults));
+});
+
+test("restoreEmptyBurgGroupStyles falls back to the defaults when the svg has no groups either", () => {
+  document.body.innerHTML = `<svg id="map"><g id="anchors"></g></svg>`;
+  styles.burgIcons.anchors.groups = {};
+  restoreEmptyBurgGroupStyles();
+  expect(styles.burgIcons.anchors.groups).toEqual(Styles.defaults.burgIcons.anchors.groups);
+  Styles.set(structuredClone(Styles.defaults));
 });
 
 test("save sync keeps store-authoritative zoom options when the DOM lacks the attrs", () => {

--- a/src/generators/styles-legacy.ts
+++ b/src/generators/styles-legacy.ts
@@ -246,11 +246,27 @@ export function stylesFromMap(root: ParentNode = document): Styles {
   return presetFromLegacy(bags, { onUnknown: "skip" });
 }
 
+// a map migrated before the empty-record check above kept an empty burg icon / anchor record that
+// nothing could refill (the editor drops edits to a missing group); the restored svg still has the groups
+export function restoreEmptyBurgGroupStyles(): void {
+  const empty = (["burgIcons", "anchors"] as const).filter(type => !Object.keys(styles.burgIcons[type].groups).length);
+  if (!empty.length) return;
+  const harvested = stylesFromMap();
+  for (const type of empty) styles.burgIcons[type].groups = harvested.burgIcons[type].groups;
+}
+
 // migration for pre v1.150 maps: harvest the DOM
 export function harvestStylesFromSvg({ hasStyleRecord = false } = {}): void {
   const harvested = stylesFromMap();
   harvested.labels = structuredClone(styles.labels);
-  if (hasStyleRecord) harvested.burgIcons = structuredClone(styles.burgIcons);
+  // pre-v1.150 main.js initialised the legacy record as burgIcons: {}, anchors: {}, so an empty
+  // record means "never filled", and the svg groups are the only source of their styling
+  if (hasStyleRecord) {
+    for (const type of ["burgIcons", "anchors"] as const) {
+      if (Object.keys(styles.burgIcons[type].groups).length)
+        harvested.burgIcons[type] = structuredClone(styles.burgIcons[type]);
+    }
+  }
   harvested.relief.options = structuredClone(styles.relief.options);
   // post-migration maps carry no rescale/data-width attrs, so the store owns these
   // options; a loaded old map's attrs win here until the load-time strip removes them
@@ -721,6 +737,7 @@ const stylesLegacyBridge = {
   harvestAttributes,
   stylesFromMap,
   harvestStylesFromSvg,
+  restoreEmptyBurgGroupStyles,
   stripDisplay,
   migrateStyles,
   restoreStrippedLayerStyles,

--- a/src/services/io/load.ts
+++ b/src/services/io/load.ts
@@ -8,6 +8,7 @@ import { clearMainTip, tip } from "@/components/tooltips";
 import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { resetZoom } from "@/components/zoom";
 import { GraphOverride } from "@/generators/graph-override";
+import { restoreEmptyBurgGroupStyles } from "@/generators/styles-legacy";
 import { invalidateEmblems } from "@/renderers/draw-emblems";
 import { onLegendClick } from "@/renderers/draw-legend";
 import { zonesFilter } from "@/renderers/draw-zones";
@@ -380,6 +381,8 @@ async function parseLoadedData(data: string[], mapVersion: string | null): Promi
 
     const styleRecord = data[48] ? safeParseJSON(data[48]) : undefined; // data[48] should be already migrated by auto-update
     Styles.set(Styles.parse(styleRecord));
+    restoreEmptyBurgGroupStyles();
+    Burgs.ensureBurgGroupStyles();
 
     if (data[50]) Layers.restore(JSON.parse(data[50]));
     if (data[51]) GraphOverride.restore(JSON.parse(data[51]));


### PR DESCRIPTION
Fixes #1853.

Some migrated maps have empty anchor style groups even though their saved SVG contains the correct sizes. Edits to those missing groups are silently lost.

Recover empty burg-icon and anchor groups in the existing migrations using `stylesFromMap`. Require nonempty groups in the schema so the existing parser supplies defaults when needed. The change is confined to migration and style validation.

Aligned with `v1.153.0` at `38bdd723`; conflicts resolved.

Validation: 1,143 unit tests and 32 SVG tests (jsdom) pass; lint and production build pass. The reporter's map recovers anchor sizes 18/12/8, and an edited size survives serialization and parsing. Browser/E2E tests were not run.