### PR TITLE
fix: size fogging cover to the graph extent, not the viewport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fantasy-map-generator",
-  "version": "1.152.1",
+  "version": "1.152.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fantasy-map-generator",
-      "version": "1.152.1",
+      "version": "1.152.2",
       "license": "MIT",
       "dependencies": {
         "alea": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fantasy-map-generator",
   "productName": "Fantasy Map Generator",
-  "version": "1.152.1",
+  "version": "1.152.2",
   "description": "Azgaar's _Fantasy Map Generator_ is a free web application that helps fantasy writers, game masters, and cartographers create and edit fantasy maps.",
   "homepage": "https://github.com/Azgaar/Fantasy-Map-Generator#readme",
   "bugs": {

--- a/src/renderers/overlays/fogging.ts
+++ b/src/renderers/overlays/fogging.ts
@@ -12,8 +12,9 @@ export function drawFogging(layer: Layer): void {
   if (!isRevealed) return void element.replaceChildren();
   if (element.hasChildNodes()) return; // already showing: the mask alone changed
 
-  element.innerHTML = /* html */ `<rect x="0" y="0" width="100%" height="100%"></rect>
-    <rect x="0" y="0" width="100%" height="100%" fill="#e8f0f6" filter="url(#splotch)"></rect>`;
+  const { width, height } = options.map.graph; // cover the graph, not the viewport
+  element.innerHTML = /* html */ `<rect x="0" y="0" width="${width}" height="${height}"></rect>
+    <rect x="0" y="0" width="${width}" height="${height}" fill="#e8f0f6" filter="url(#splotch)"></rect>`;
 
   const fogging = select(element);
   fogging.attr("opacity", 0).transition(fadeIn()).attr("opacity", styles.fogging.attrs.opacity);

--- a/src/services/versioning.ts
+++ b/src/services/versioning.ts
@@ -20,7 +20,7 @@ import { Pins } from "@/components/pins";
 import { tip } from "@/components/tooltips";
 import { isElectron } from "./platform";
 
-export const VERSION = "1.152.1";
+export const VERSION = "1.152.2";
 
 // new changes on top
 const latestPublicChanges = [


### PR DESCRIPTION
drawFogging created its rects lazily with width/height 100%, which resolve to the SVG viewport inside the zoomed viewbox. applyGraphSize only resizes rects that already exist on load, so on maps whose graph is larger than the window the fog covered a corner patch only.

# Description

<!-- Describe the problem, resulting behavior, and validation. Use "Fixes #123" only if this PR completes that issue; use "Refs #123" for partial work. Link the originating idea discussion when applicable. -->

<!-- Before closing a request: check its acceptance criteria, split remaining work into linked issues, and record implementation/release evidence. Merged does not mean released. See docs/board-completion.md. -->
