### PR TITLE
Remove vertex editing from the Lakes Editor

### DIFF
--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -12,7 +12,7 @@ Check out [Dev board](https://github.com/users/Azgaar/projects/3/views/1?sumFiel
 
 Current version of the Fantasy Map Generator is the latest `master` branch. You can download it here: https://github.com/Azgaar/Fantasy-Map-Generator/archive/refs/heads/master.zip. Also see [the wiki](https://github.com/Azgaar/Fantasy-Map-Generator/wiki/Q&A#can-i-use-the-generator-offline).
 
-- Wrap Tool: reshape cells with a brush [1.153.0]
+- Wrap Tool: reshape cells with a brush; it replaces per-vertex dragging in the Coastline and Lake editors [1.153.0]
 - Coastlines: local roughness instead of global [1.153.0]
 - Legend boxes for States, Cultures, Religions, Biomes and Zones can be shown at the same time by _[esullivan9](https://github.com/esullivan9)_
 - Diplomacy: click states on the map to select relation targets, repair invalid pairs in the editor or matrix, and record only actual changes in bulk edits

--- a/src/controllers/lakes-editor.ts
+++ b/src/controllers/lakes-editor.ts
@@ -1,15 +1,12 @@
-import { drag, mean, min, polygonLength, type Selection, select } from "d3";
+import { mean, min, polygonLength, type Selection, select } from "d3";
 import { closeDialogs, destroyDialog } from "@/components/dialog/dialog-helpers";
 import { Layers } from "@/components/layers";
 import { Notes } from "@/components/notes";
 import { tip } from "@/components/tooltips";
-import { applyDefaultViewboxEvents } from "@/components/viewbox-events";
 import { Controllers } from "@/controllers";
-import { Coastline } from "@/generators/coastline-generator";
 import type { Feature } from "@/generators/features";
-import { GraphOverride } from "@/generators/graph-override";
 import { getArea, getAreaUnit, speak } from "@/utils";
-import { ensureEl, findEl, rand, rn, si, unique } from "../utils";
+import { ensureEl, findEl, rand, si } from "../utils";
 import { getHeight } from "../utils/unitUtils";
 
 let selectedLake: Selection<SVGElement, unknown, HTMLElement, unknown>;
@@ -21,12 +18,9 @@ function open(element: SVGElement): void {
 
   renderDialog();
 
-  select("#debug").append("g").attr("id", "vertices");
   selectedLake = select<SVGElement, unknown>(element) as unknown as typeof selectedLake;
   updateLakeValues();
   selectLakeGroup();
-  drawLakeVertices();
-  select<SVGElement, unknown>("#viewbox").on("touchmove mousemove", null);
 
   $("#lakeEditor").dialog({
     title: "Edit Lake",
@@ -144,62 +138,6 @@ function updateLakeValues(): void {
   inletsInput.value = inlets ? String(inlets.length) : "no";
   inletsInput.title = inlets ? inlets.join(", ") : "";
   ensureEl<HTMLInputElement>("lakeOutlet").value = outlet ?? "no";
-}
-
-function drawLakeVertices(): void {
-  const vertices = getLake().vertices;
-
-  const neibCells: number[] = unique(vertices.flatMap(v => pack.vertices.c[v]));
-  select("#debug")
-    .select("#vertices")
-    .selectAll<SVGPolygonElement, number>("polygon")
-    .data(neibCells)
-    .enter()
-    .append("polygon")
-    .attr("points", (d: number) => String(Pack.getPolygon(d)))
-    .attr("data-c", (d: number) => d);
-
-  select<SVGGElement, unknown>("#debug")
-    .select("#vertices")
-    .selectAll<SVGCircleElement, number>("circle")
-    .data(vertices)
-    .enter()
-    .append("circle")
-    .attr("cx", (d: number) => pack.vertices.p[d][0])
-    .attr("cy", (d: number) => pack.vertices.p[d][1])
-    .attr("r", 0.4)
-    .attr("data-v", (d: number) => d)
-    .call(drag<SVGCircleElement, number>().on("drag", handleVertexDrag).on("end", handleVertexDragEnd))
-    .on("mousemove", () =>
-      tip("Drag to move the vertex. Please use for fine-tuning only! Edit heightmap to change actual cell heights")
-    );
-}
-
-function handleVertexDrag(this: SVGCircleElement, event: any, vertexId: number): void {
-  const x = rn(event.x, 2);
-  const y = rn(event.y, 2);
-  this.setAttribute("cx", String(x));
-  this.setAttribute("cy", String(y));
-
-  GraphOverride.movePackVertex(vertexId, [x, y]);
-
-  const feature = getLake();
-
-  // update lake path
-  select<SVGElement, unknown>("#deftemp")
-    .select(`#featurePaths > path#feature_${feature.i}`)
-    .attr("d", Coastline.getFeaturePath(feature));
-  ensureEl<HTMLInputElement>("lakeArea").value = `${si(getArea(feature.area))} ${getAreaUnit()}`;
-
-  // update cell
-  select("#debug")
-    .select("#vertices")
-    .selectAll<SVGPolygonElement, number>("polygon")
-    .attr("points", d => String(Pack.getPolygon(d)));
-}
-
-function handleVertexDragEnd(): void {
-  Layers.draw("states", "provinces", "borders", "biomes", "religions", "cultures");
 }
 
 function changeName(this: HTMLInputElement): void {
@@ -345,8 +283,6 @@ function editLakeLegend(): void {
 }
 
 function closeLakesEditor(): void {
-  select("#debug").select("#vertices").remove();
-  applyDefaultViewboxEvents();
   destroyDialog("lakeEditor");
   selectedLake = null!;
 }


### PR DESCRIPTION
## Summary
- Lake editor no longer draws draggable shore vertices or the cell-polygon overlay in `#debug`; lake shores are reshaped only with the Wrap tool (#1831)
- `open()`/`closeLakesEditor()` no longer touch viewbox `mousemove`/`touchmove` handlers, so `applyDefaultViewboxEvents()` is not needed
- Dropped the now-unused imports (`drag`, `Coastline`, `GraphOverride`, `rn`, `unique`)
- Changelog entry notes the Wrap Tool replaces per-vertex dragging in the Coastline and Lake editors

## Test plan
- [x] `tsc --noEmit`, `biome check` clean; `graph-override` unit tests pass
- [x] Dev server: click a lake → editor opens with all fields, `#debug` has no `#vertices` group / circles, closing removes the dialog, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)